### PR TITLE
Add memory backends and additional providers

### DIFF
--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -166,6 +166,13 @@ test-suite pureclaw-test
     Tools.FileReadSpec
     Tools.GitSpec
     Tools.MemorySpec
+    Memory.MarkdownSpec
+    Memory.SQLiteSpec
+    Memory.NoneSpec
+    Agent.MemorySpec
+    Providers.OpenAISpec
+    Providers.OllamaSpec
+    Providers.OpenRouterSpec
   hs-source-dirs:   test
   build-depends:
     base,

--- a/src/PureClaw/Agent/Memory.hs
+++ b/src/PureClaw/Agent/Memory.hs
@@ -1,1 +1,50 @@
-module PureClaw.Agent.Memory () where
+module PureClaw.Agent.Memory
+  ( -- * Memory integration
+    autoRecall
+  , autoSave
+  ) where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import Data.Map.Strict qualified as Map
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Log
+import PureClaw.Handles.Memory
+
+-- | Minimum message length to trigger auto-save (characters).
+minSaveLength :: Int
+minSaveLength = 50
+
+-- | Automatically recall relevant memories for a user message.
+-- Returns formatted context to prepend to the system prompt, or
+-- Nothing if no relevant memories are found.
+autoRecall :: MemoryHandle -> LogHandle -> Text -> IO (Maybe Text)
+autoRecall mh logger query = do
+  results <- _mh_search mh query defaultSearchConfig { _sc_maxResults = 3 }
+  if null results
+    then pure Nothing
+    else do
+      _lh_logDebug logger $ "Recalled " <> T.pack (show (length results)) <> " memories"
+      let formatted = T.unlines
+            [ "## Relevant memories"
+            , ""
+            , T.intercalate "\n\n" [ _sr_content r | r <- results ]
+            ]
+      pure (Just formatted)
+
+-- | Automatically save an assistant response to memory if it's
+-- long enough to be worth remembering.
+autoSave :: MemoryHandle -> LogHandle -> Text -> IO ()
+autoSave mh logger content
+  | T.length content < minSaveLength = pure ()
+  | otherwise = do
+      let source = MemorySource
+            { _ms_content  = content
+            , _ms_metadata = Map.empty
+            }
+      result <- _mh_save mh source
+      case result of
+        Nothing -> pure ()
+        Just mid -> _lh_logDebug logger $ "Auto-saved memory: " <> unMemoryId mid

--- a/src/PureClaw/Memory/Markdown.hs
+++ b/src/PureClaw/Memory/Markdown.hs
@@ -1,1 +1,139 @@
-module PureClaw.Memory.Markdown () where
+module PureClaw.Memory.Markdown
+  ( -- * Construction
+    mkMarkdownMemoryHandle
+  ) where
+
+import Data.IORef
+import Data.List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Time
+import System.Directory
+import System.FilePath
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Memory
+
+-- | Create a file-based markdown memory handle. Each memory entry is
+-- stored as a markdown file in the given directory. Search is a simple
+-- case-insensitive substring match (no embeddings).
+mkMarkdownMemoryHandle :: FilePath -> IO MemoryHandle
+mkMarkdownMemoryHandle dir = do
+  createDirectoryIfMissing True dir
+  counterRef <- newIORef (0 :: Int)
+  pure MemoryHandle
+    { _mh_search = searchMemories dir
+    , _mh_save   = saveMemory dir counterRef
+    , _mh_recall = recallMemory dir
+    }
+
+-- | Save a memory entry as a markdown file.
+saveMemory :: FilePath -> IORef Int -> MemorySource -> IO (Maybe MemoryId)
+saveMemory dir counterRef source = do
+  n <- atomicModifyIORef' counterRef (\i -> (i + 1, i + 1))
+  now <- getCurrentTime
+  let mid = MemoryId (T.pack (show n))
+      filename = T.unpack (unMemoryId mid) <> ".md"
+      path = dir </> filename
+      content = renderEntry mid now source
+  TIO.writeFile path content
+  pure (Just mid)
+
+-- | Search memories by case-insensitive substring match.
+searchMemories :: FilePath -> Text -> SearchConfig -> IO [SearchResult]
+searchMemories dir query config = do
+  exists <- doesDirectoryExist dir
+  if not exists
+    then pure []
+    else do
+      files <- listDirectory dir
+      let mdFiles = filter (".md" `isSuffixOf`) files
+      results <- mapM (matchFile dir queryLower) mdFiles
+      pure $ take (_sc_maxResults config)
+           $ sortOn (negate . _sr_score)
+           $ concatMap (filter (\r -> _sr_score r >= _sc_minScore config)) results
+  where
+    queryLower = T.toLower query
+
+-- | Check if a file matches the query.
+matchFile :: FilePath -> Text -> FilePath -> IO [SearchResult]
+matchFile dir queryLower filename = do
+  content <- TIO.readFile (dir </> filename)
+  let bodyText = extractBody content
+      mid = MemoryId (T.pack (takeBaseName filename))
+  if queryLower `T.isInfixOf` T.toLower bodyText
+    then pure [SearchResult mid bodyText 1.0]
+    else pure []
+
+-- | Recall a specific memory by ID.
+recallMemory :: FilePath -> MemoryId -> IO (Maybe MemoryEntry)
+recallMemory dir mid = do
+  let path = dir </> T.unpack (unMemoryId mid) <> ".md"
+  exists <- doesFileExist path
+  if not exists
+    then pure Nothing
+    else do
+      content <- TIO.readFile path
+      pure (Just (parseEntry mid content))
+
+-- | Render a memory entry as markdown.
+renderEntry :: MemoryId -> UTCTime -> MemorySource -> Text
+renderEntry mid now source = T.unlines $
+  [ "---"
+  , "id: " <> unMemoryId mid
+  , "created: " <> T.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" now)
+  ]
+  ++ renderMetadata (_ms_metadata source)
+  ++ [ "---"
+     , ""
+     , _ms_content source
+     ]
+
+renderMetadata :: Map Text Text -> [Text]
+renderMetadata m = [ k <> ": " <> v | (k, v) <- Map.toList m ]
+
+-- | Extract the body (after frontmatter) from a markdown file.
+extractBody :: Text -> Text
+extractBody content =
+  case T.stripPrefix "---\n" content of
+    Nothing -> content
+    Just rest ->
+      case T.breakOn "---\n" rest of
+        (_, after) -> T.strip (T.drop 4 after)
+
+-- | Parse a markdown file into a MemoryEntry.
+parseEntry :: MemoryId -> Text -> MemoryEntry
+parseEntry mid content =
+  let body = extractBody content
+      metadata = parseFrontmatter content
+      created = case Map.lookup "created" metadata of
+        Just ts -> case parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (T.unpack ts) of
+          Just t  -> t
+          Nothing -> UTCTime (fromGregorian 2000 1 1) 0
+        Nothing -> UTCTime (fromGregorian 2000 1 1) 0
+  in MemoryEntry
+    { _me_memoryId  = mid
+    , _me_content   = body
+    , _me_metadata  = Map.delete "id" (Map.delete "created" metadata)
+    , _me_createdAt = created
+    }
+
+-- | Parse frontmatter key-value pairs from markdown.
+parseFrontmatter :: Text -> Map Text Text
+parseFrontmatter content =
+  case T.stripPrefix "---\n" content of
+    Nothing -> Map.empty
+    Just rest ->
+      case T.breakOn "---\n" rest of
+        (fm, _) ->
+          Map.fromList
+            [ (T.strip k, T.strip v)
+            | line <- T.lines fm
+            , let (k, rawV) = T.breakOn ":" line
+            , not (T.null rawV)
+            , let v = T.drop 1 rawV
+            ]
+

--- a/src/PureClaw/Memory/None.hs
+++ b/src/PureClaw/Memory/None.hs
@@ -1,1 +1,11 @@
-module PureClaw.Memory.None () where
+module PureClaw.Memory.None
+  ( -- * Construction
+    mkNoneMemoryHandle
+  ) where
+
+import PureClaw.Handles.Memory
+
+-- | No-op memory handle. Equivalent to 'mkNoOpMemoryHandle' — exists
+-- as a named backend for configuration selection.
+mkNoneMemoryHandle :: MemoryHandle
+mkNoneMemoryHandle = mkNoOpMemoryHandle

--- a/src/PureClaw/Memory/SQLite.hs
+++ b/src/PureClaw/Memory/SQLite.hs
@@ -1,1 +1,108 @@
-module PureClaw.Memory.SQLite () where
+module PureClaw.Memory.SQLite
+  ( -- * Construction
+    mkSQLiteMemoryHandle
+  , withSQLiteMemory
+  ) where
+
+import Data.IORef
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time
+import Database.SQLite.Simple
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Memory
+
+-- | Create a SQLite-backed memory handle. Opens the database at the
+-- given path and creates the schema if needed.
+mkSQLiteMemoryHandle :: FilePath -> IO MemoryHandle
+mkSQLiteMemoryHandle dbPath = do
+  conn <- open dbPath
+  initSchema conn
+  counterRef <- newIORef (0 :: Int)
+  pure MemoryHandle
+    { _mh_search = searchMemories conn
+    , _mh_save   = saveMemory conn counterRef
+    , _mh_recall = recallMemory conn
+    }
+
+-- | Convenience: open a SQLite memory handle, run an action, then close.
+withSQLiteMemory :: FilePath -> (MemoryHandle -> IO a) -> IO a
+withSQLiteMemory dbPath action = do
+  mh <- mkSQLiteMemoryHandle dbPath
+  action mh
+
+-- | Initialize the database schema.
+initSchema :: Connection -> IO ()
+initSchema conn = execute_ conn
+  "CREATE TABLE IF NOT EXISTS memories (\
+  \  id TEXT PRIMARY KEY,\
+  \  content TEXT NOT NULL,\
+  \  metadata TEXT NOT NULL DEFAULT '{}',\
+  \  created_at TEXT NOT NULL\
+  \)"
+
+-- | Save a memory entry.
+saveMemory :: Connection -> IORef Int -> MemorySource -> IO (Maybe MemoryId)
+saveMemory conn counterRef source = do
+  n <- atomicModifyIORef' counterRef (\i -> (i + 1, i + 1))
+  now <- getCurrentTime
+  let mid = MemoryId (T.pack ("mem-" <> show n))
+      ts = T.pack (formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" now)
+      metaText = renderMetadata (_ms_metadata source)
+  execute conn
+    "INSERT INTO memories (id, content, metadata, created_at) VALUES (?, ?, ?, ?)"
+    (unMemoryId mid, _ms_content source, metaText, ts)
+  pure (Just mid)
+
+-- | Search memories using LIKE (case-insensitive substring match).
+-- SQLite FTS5 would be better for production, but LIKE is sufficient
+-- to get the interface working.
+searchMemories :: Connection -> Text -> SearchConfig -> IO [SearchResult]
+searchMemories conn queryText config = do
+  rows <- query conn
+    "SELECT id, content FROM memories WHERE content LIKE ? LIMIT ?"
+    ("%" <> queryText <> "%" :: Text, _sc_maxResults config)
+  pure [ SearchResult (MemoryId mid) content 1.0
+       | (mid, content) <- rows :: [(Text, Text)]
+       ]
+
+-- | Recall a specific memory by ID.
+recallMemory :: Connection -> MemoryId -> IO (Maybe MemoryEntry)
+recallMemory conn mid = do
+  rows <- query conn
+    "SELECT content, metadata, created_at FROM memories WHERE id = ?"
+    (Only (unMemoryId mid))
+  case rows of
+    [] -> pure Nothing
+    ((content, metaText, tsText) : _) ->
+      pure $ Just MemoryEntry
+        { _me_memoryId  = mid
+        , _me_content   = content
+        , _me_metadata  = parseMetadata metaText
+        , _me_createdAt = parseTimestamp tsText
+        }
+
+-- | Render metadata map as a simple key=value text.
+renderMetadata :: Map.Map Text Text -> Text
+renderMetadata m = T.intercalate ";" [ k <> "=" <> v | (k, v) <- Map.toList m ]
+
+-- | Parse metadata from key=value text.
+parseMetadata :: Text -> Map.Map Text Text
+parseMetadata t
+  | T.null t = Map.empty
+  | otherwise = Map.fromList
+      [ (k, v)
+      | pair <- T.splitOn ";" t
+      , let (k, rawV) = T.breakOn "=" pair
+      , not (T.null rawV)
+      , let v = T.drop 1 rawV
+      ]
+
+-- | Parse a timestamp, with a fallback.
+parseTimestamp :: Text -> UTCTime
+parseTimestamp t =
+  case parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%SZ" (T.unpack t) of
+    Just ts -> ts
+    Nothing -> UTCTime (fromGregorian 2000 1 1) 0

--- a/src/PureClaw/Providers/Ollama.hs
+++ b/src/PureClaw/Providers/Ollama.hs
@@ -1,1 +1,126 @@
-module PureClaw.Providers.Ollama () where
+module PureClaw.Providers.Ollama
+  ( -- * Provider type
+    OllamaProvider
+  , mkOllamaProvider
+    -- * Errors
+  , OllamaError (..)
+    -- * Request/response encoding (exported for testing)
+  , encodeRequest
+  , decodeResponse
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
+import Data.Text qualified as T
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Types.Status qualified as Status
+
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+
+-- | Ollama provider for local model inference.
+data OllamaProvider = OllamaProvider
+  { _ol_manager :: HTTP.Manager
+  , _ol_baseUrl :: String
+  }
+
+-- | Create an Ollama provider. Defaults to localhost:11434.
+mkOllamaProvider :: HTTP.Manager -> OllamaProvider
+mkOllamaProvider mgr = OllamaProvider mgr "http://localhost:11434/api/chat"
+
+instance Provider OllamaProvider where
+  complete = ollamaComplete
+
+-- | Errors from the Ollama API.
+data OllamaError
+  = OllamaAPIError Int ByteString
+  | OllamaParseError Text
+  deriving stock (Show)
+
+instance Exception OllamaError
+
+instance ToPublicError OllamaError where
+  toPublicError _ = TemporaryError "Provider error"
+
+ollamaComplete :: OllamaProvider -> CompletionRequest -> IO CompletionResponse
+ollamaComplete provider req = do
+  initReq <- HTTP.parseRequest (_ol_baseUrl provider)
+  let httpReq = initReq
+        { HTTP.method = "POST"
+        , HTTP.requestBody = HTTP.RequestBodyLBS (encodeRequest req)
+        , HTTP.requestHeaders = [("content-type", "application/json")]
+        }
+  resp <- HTTP.httpLbs httpReq (_ol_manager provider)
+  let status = Status.statusCode (HTTP.responseStatus resp)
+  if status /= 200
+    then throwIO (OllamaAPIError status (BL.toStrict (HTTP.responseBody resp)))
+    else case decodeResponse (HTTP.responseBody resp) of
+      Left err -> throwIO (OllamaParseError (T.pack err))
+      Right response -> pure response
+
+-- | Encode a request for the Ollama /api/chat endpoint.
+-- Ollama uses system messages in the messages array and a simpler
+-- tool format than OpenAI.
+encodeRequest :: CompletionRequest -> BL.ByteString
+encodeRequest req = encode $ object $
+  [ "model"    .= unModelId (_cr_model req)
+  , "messages" .= encodeMessages req
+  , "stream"   .= False
+  ]
+  ++ ["tools" .= map encodeTool (_cr_tools req) | not (null (_cr_tools req))]
+
+encodeMessages :: CompletionRequest -> [Value]
+encodeMessages req =
+  maybe [] (\s -> [object ["role" .= ("system" :: Text), "content" .= s]]) (_cr_systemPrompt req)
+  ++ map encodeMsg (_cr_messages req)
+
+encodeMsg :: Message -> Value
+encodeMsg msg = case _msg_content msg of
+  [TextBlock t] ->
+    object ["role" .= roleToText (_msg_role msg), "content" .= t]
+  blocks ->
+    -- Ollama supports content as string only; concatenate text blocks
+    let textParts = [t | TextBlock t <- blocks]
+    in object ["role" .= roleToText (_msg_role msg), "content" .= T.intercalate "\n" textParts]
+
+encodeTool :: ToolDefinition -> Value
+encodeTool td = object
+  [ "type" .= ("function" :: Text)
+  , "function" .= object
+      [ "name"        .= _td_name td
+      , "description" .= _td_description td
+      , "parameters"  .= _td_inputSchema td
+      ]
+  ]
+
+-- | Decode an Ollama /api/chat response.
+decodeResponse :: BL.ByteString -> Either String CompletionResponse
+decodeResponse bs = eitherDecode bs >>= parseEither parseResp
+  where
+    parseResp :: Value -> Parser CompletionResponse
+    parseResp = withObject "OllamaResponse" $ \o -> do
+      msg <- o .: "message"
+      content <- msg .: "content"
+      modelText <- o .: "model"
+      -- Ollama tool calls come as tool_calls array in the message
+      toolCalls <- msg .:? "tool_calls" .!= ([] :: [Value])
+      toolBlocks <- mapM parseToolCall toolCalls
+      let textBlocks = [TextBlock content | not (T.null content)]
+      pure CompletionResponse
+        { _crsp_content = textBlocks ++ toolBlocks
+        , _crsp_model   = ModelId modelText
+        , _crsp_usage   = Nothing  -- Ollama doesn't report usage in chat endpoint
+        }
+
+    parseToolCall :: Value -> Parser ContentBlock
+    parseToolCall = withObject "ToolCall" $ \tc -> do
+      fn <- tc .: "function"
+      name <- fn .: "name"
+      args <- fn .: "arguments"
+      -- Ollama doesn't return a call ID, so generate a placeholder
+      pure (ToolUseBlock (ToolCallId ("ollama-" <> name)) name args)

--- a/src/PureClaw/Providers/OpenAI.hs
+++ b/src/PureClaw/Providers/OpenAI.hs
@@ -1,1 +1,178 @@
-module PureClaw.Providers.OpenAI () where
+module PureClaw.Providers.OpenAI
+  ( -- * Provider type
+    OpenAIProvider
+  , mkOpenAIProvider
+    -- * Errors
+  , OpenAIError (..)
+    -- * Request/response encoding (exported for testing)
+  , encodeRequest
+  , decodeResponse
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
+import Data.Maybe
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Types.Status qualified as Status
+
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Security.Secrets
+
+-- | OpenAI API provider.
+data OpenAIProvider = OpenAIProvider
+  { _oai_manager :: HTTP.Manager
+  , _oai_apiKey  :: ApiKey
+  , _oai_baseUrl :: String
+  }
+
+-- | Create an OpenAI provider. Uses the standard OpenAI API base URL.
+mkOpenAIProvider :: HTTP.Manager -> ApiKey -> OpenAIProvider
+mkOpenAIProvider mgr key = OpenAIProvider mgr key "https://api.openai.com/v1/chat/completions"
+
+instance Provider OpenAIProvider where
+  complete = openAIComplete
+
+-- | Errors from the OpenAI API.
+data OpenAIError
+  = OpenAIAPIError Int ByteString
+  | OpenAIParseError Text
+  deriving stock (Show)
+
+instance Exception OpenAIError
+
+instance ToPublicError OpenAIError where
+  toPublicError (OpenAIAPIError 429 _) = RateLimitError
+  toPublicError (OpenAIAPIError 401 _) = NotAllowedError
+  toPublicError _                       = TemporaryError "Provider error"
+
+openAIComplete :: OpenAIProvider -> CompletionRequest -> IO CompletionResponse
+openAIComplete provider req = do
+  initReq <- HTTP.parseRequest (_oai_baseUrl provider)
+  let httpReq = initReq
+        { HTTP.method = "POST"
+        , HTTP.requestBody = HTTP.RequestBodyLBS (encodeRequest req)
+        , HTTP.requestHeaders =
+            [ ("Authorization", "Bearer " <> withApiKey (_oai_apiKey provider) id)
+            , ("content-type", "application/json")
+            ]
+        }
+  resp <- HTTP.httpLbs httpReq (_oai_manager provider)
+  let status = Status.statusCode (HTTP.responseStatus resp)
+  if status /= 200
+    then throwIO (OpenAIAPIError status (BL.toStrict (HTTP.responseBody resp)))
+    else case decodeResponse (HTTP.responseBody resp) of
+      Left err -> throwIO (OpenAIParseError (T.pack err))
+      Right response -> pure response
+
+-- | Encode a completion request as OpenAI Chat Completions JSON.
+encodeRequest :: CompletionRequest -> BL.ByteString
+encodeRequest req = encode $ object $
+  [ "model"    .= unModelId (_cr_model req)
+  , "messages" .= encodeMessages req
+  ]
+  ++ maybe [] (\mt -> ["max_tokens" .= mt]) (_cr_maxTokens req)
+  ++ ["tools" .= map encodeTool (_cr_tools req) | not (null (_cr_tools req))]
+  ++ maybe [] (\tc -> ["tool_choice" .= encodeToolChoice tc]) (_cr_toolChoice req)
+
+-- | OpenAI puts system prompt as a system message in the messages array.
+encodeMessages :: CompletionRequest -> [Value]
+encodeMessages req =
+  maybe [] (\s -> [object ["role" .= ("system" :: Text), "content" .= s]]) (_cr_systemPrompt req)
+  ++ map encodeMsg (_cr_messages req)
+
+encodeMsg :: Message -> Value
+encodeMsg msg = case _msg_content msg of
+  [TextBlock t] ->
+    -- Simple text message — use string content for compatibility
+    object ["role" .= roleToText (_msg_role msg), "content" .= t]
+  blocks ->
+    object [ "role"    .= roleToText (_msg_role msg)
+           , "content" .= map encodeContentBlock blocks
+           ]
+
+encodeContentBlock :: ContentBlock -> Value
+encodeContentBlock (TextBlock t) = object
+  [ "type" .= ("text" :: Text), "text" .= t ]
+encodeContentBlock (ToolUseBlock callId name input) = object
+  [ "type" .= ("function" :: Text)
+  , "id"   .= unToolCallId callId
+  , "function" .= object ["name" .= name, "arguments" .= decodeUtf8Lenient (BL.toStrict (encode input))]
+  ]
+  where
+    decodeUtf8Lenient = TE.decodeUtf8
+encodeContentBlock (ToolResultBlock callId content _) = object
+  [ "type"         .= ("tool_result" :: Text)
+  , "tool_call_id" .= unToolCallId callId
+  , "content"      .= content
+  ]
+
+encodeTool :: ToolDefinition -> Value
+encodeTool td = object
+  [ "type" .= ("function" :: Text)
+  , "function" .= object
+      [ "name"        .= _td_name td
+      , "description" .= _td_description td
+      , "parameters"  .= _td_inputSchema td
+      ]
+  ]
+
+encodeToolChoice :: ToolChoice -> Value
+encodeToolChoice AutoTool = String "auto"
+encodeToolChoice AnyTool = String "required"
+encodeToolChoice (SpecificTool name) = object
+  [ "type" .= ("function" :: Text)
+  , "function" .= object ["name" .= name]
+  ]
+
+-- | Decode an OpenAI Chat Completions response.
+decodeResponse :: BL.ByteString -> Either String CompletionResponse
+decodeResponse bs = eitherDecode bs >>= parseEither parseResp
+  where
+    parseResp :: Value -> Parser CompletionResponse
+    parseResp = withObject "OpenAIResponse" $ \o -> do
+      choices <- o .: "choices"
+      case choices of
+        [] -> fail "No choices in response"
+        (firstChoice : _) -> do
+          msg <- firstChoice .: "message"
+          blocks <- parseMessage msg
+          modelText <- o .: "model"
+          usageObj <- o .:? "usage"
+          usage <- case usageObj of
+            Nothing -> pure Nothing
+            Just u -> do
+              inToks <- u .: "prompt_tokens"
+              outToks <- u .: "completion_tokens"
+              pure (Just (Usage inToks outToks))
+          pure CompletionResponse
+            { _crsp_content = blocks
+            , _crsp_model   = ModelId modelText
+            , _crsp_usage   = usage
+            }
+
+    parseMessage :: Value -> Parser [ContentBlock]
+    parseMessage = withObject "Message" $ \m -> do
+      contentVal <- m .:? "content"
+      toolCalls <- m .:? "tool_calls" .!= ([] :: [Value])
+      let textBlocks = case contentVal of
+            Just (String t) | not (T.null t) -> [TextBlock t]
+            _ -> []
+      toolBlocks <- mapM parseToolCall toolCalls
+      pure (textBlocks ++ toolBlocks)
+
+    parseToolCall :: Value -> Parser ContentBlock
+    parseToolCall = withObject "ToolCall" $ \tc -> do
+      callId <- tc .: "id"
+      fn <- tc .: "function"
+      name <- fn .: "name"
+      argsStr <- fn .: "arguments"
+      let input = fromMaybe (object []) (decode (BL.fromStrict (TE.encodeUtf8 argsStr)))
+      pure (ToolUseBlock (ToolCallId callId) name input)

--- a/src/PureClaw/Providers/OpenRouter.hs
+++ b/src/PureClaw/Providers/OpenRouter.hs
@@ -1,1 +1,82 @@
-module PureClaw.Providers.OpenRouter () where
+module PureClaw.Providers.OpenRouter
+  ( -- * Provider type
+    OpenRouterProvider
+  , mkOpenRouterProvider
+    -- * Errors
+  , OpenRouterError (..)
+    -- * Request/response encoding (exported for testing)
+  , encodeRequest
+  , decodeResponse
+  ) where
+
+import Control.Exception
+import Data.ByteString (ByteString)
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
+import Data.Text qualified as T
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Types.Status qualified as Status
+
+import PureClaw.Core.Errors
+import PureClaw.Providers.Class
+import PureClaw.Providers.OpenAI qualified as OAI
+import PureClaw.Security.Secrets
+
+-- | OpenRouter provider. Uses the OpenAI-compatible API with a
+-- different base URL and authentication header.
+data OpenRouterProvider = OpenRouterProvider
+  { _or_manager :: HTTP.Manager
+  , _or_apiKey  :: ApiKey
+  }
+
+-- | Create an OpenRouter provider.
+mkOpenRouterProvider :: HTTP.Manager -> ApiKey -> OpenRouterProvider
+mkOpenRouterProvider = OpenRouterProvider
+
+instance Provider OpenRouterProvider where
+  complete = openRouterComplete
+
+-- | Errors from the OpenRouter API.
+data OpenRouterError
+  = OpenRouterAPIError Int ByteString
+  | OpenRouterParseError Text
+  deriving stock (Show)
+
+instance Exception OpenRouterError
+
+instance ToPublicError OpenRouterError where
+  toPublicError (OpenRouterAPIError 429 _) = RateLimitError
+  toPublicError (OpenRouterAPIError 401 _) = NotAllowedError
+  toPublicError _                           = TemporaryError "Provider error"
+
+openRouterBaseUrl :: String
+openRouterBaseUrl = "https://openrouter.ai/api/v1/chat/completions"
+
+openRouterComplete :: OpenRouterProvider -> CompletionRequest -> IO CompletionResponse
+openRouterComplete provider req = do
+  initReq <- HTTP.parseRequest openRouterBaseUrl
+  let httpReq = initReq
+        { HTTP.method = "POST"
+        , HTTP.requestBody = HTTP.RequestBodyLBS (encodeRequest req)
+        , HTTP.requestHeaders =
+            [ ("Authorization", "Bearer " <> withApiKey (_or_apiKey provider) id)
+            , ("content-type", "application/json")
+            , ("HTTP-Referer", "https://github.com/pureclaw/pureclaw")
+            , ("X-Title", "PureClaw")
+            ]
+        }
+  resp <- HTTP.httpLbs httpReq (_or_manager provider)
+  let status = Status.statusCode (HTTP.responseStatus resp)
+  if status /= 200
+    then throwIO (OpenRouterAPIError status (BL.toStrict (HTTP.responseBody resp)))
+    else case decodeResponse (HTTP.responseBody resp) of
+      Left err -> throwIO (OpenRouterParseError (T.pack err))
+      Right response -> pure response
+
+-- | Encode request — reuses OpenAI format.
+encodeRequest :: CompletionRequest -> BL.ByteString
+encodeRequest = OAI.encodeRequest
+
+-- | Decode response — reuses OpenAI format.
+decodeResponse :: BL.ByteString -> Either String CompletionResponse
+decodeResponse = OAI.decodeResponse

--- a/test/Agent/MemorySpec.hs
+++ b/test/Agent/MemorySpec.hs
@@ -1,0 +1,54 @@
+module Agent.MemorySpec (spec) where
+
+import Data.IORef
+import Test.Hspec
+
+import PureClaw.Agent.Memory
+import PureClaw.Core.Types
+import PureClaw.Handles.Log
+import PureClaw.Handles.Memory
+
+spec :: Spec
+spec = do
+  describe "autoRecall" $ do
+    it "returns Nothing when no memories match" $ do
+      let mh = mkNoOpMemoryHandle
+      result <- autoRecall mh mkNoOpLogHandle "anything"
+      result `shouldBe` Nothing
+
+    it "returns formatted context when memories exist" $ do
+      let results = [SearchResult (MemoryId "1") "relevant info" 0.9]
+          mh = mkNoOpMemoryHandle { _mh_search = \_ _ -> pure results }
+      result <- autoRecall mh mkNoOpLogHandle "query"
+      result `shouldSatisfy` isJust
+      case result of
+        Just t -> show t `shouldContain` "relevant info"
+        Nothing -> expectationFailure "expected Just"
+
+  describe "autoSave" $ do
+    it "does not save short messages" $ do
+      savedRef <- newIORef (0 :: Int)
+      let mh = mkNoOpMemoryHandle
+            { _mh_save = \_ -> do
+                modifyIORef savedRef (+ 1)
+                pure (Just (MemoryId "1"))
+            }
+      autoSave mh mkNoOpLogHandle "short"
+      saved <- readIORef savedRef
+      saved `shouldBe` 0
+
+    it "saves messages over the minimum length" $ do
+      savedRef <- newIORef (0 :: Int)
+      let mh = mkNoOpMemoryHandle
+            { _mh_save = \_ -> do
+                modifyIORef savedRef (+ 1)
+                pure (Just (MemoryId "1"))
+            }
+          longMsg = "This is a message that is definitely longer than fifty characters to trigger auto-save."
+      autoSave mh mkNoOpLogHandle longMsg
+      saved <- readIORef savedRef
+      saved `shouldBe` 1
+
+isJust :: Maybe a -> Bool
+isJust (Just _) = True
+isJust Nothing  = False

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -26,6 +26,13 @@ import qualified Tools.ShellSpec
 import qualified Tools.FileReadSpec
 import qualified Tools.GitSpec
 import qualified Tools.MemorySpec
+import qualified Memory.NoneSpec
+import qualified Memory.MarkdownSpec
+import qualified Memory.SQLiteSpec
+import qualified Agent.MemorySpec
+import qualified Providers.OpenAISpec
+import qualified Providers.OllamaSpec
+import qualified Providers.OpenRouterSpec
 
 main :: IO ()
 main = hspec $ do
@@ -53,3 +60,10 @@ main = hspec $ do
   describe "Tools.FileRead" Tools.FileReadSpec.spec
   describe "Tools.Git" Tools.GitSpec.spec
   describe "Tools.Memory" Tools.MemorySpec.spec
+  describe "Memory.None" Memory.NoneSpec.spec
+  describe "Memory.Markdown" Memory.MarkdownSpec.spec
+  describe "Memory.SQLite" Memory.SQLiteSpec.spec
+  describe "Agent.Memory" Agent.MemorySpec.spec
+  describe "Providers.OpenAI" Providers.OpenAISpec.spec
+  describe "Providers.Ollama" Providers.OllamaSpec.spec
+  describe "Providers.OpenRouter" Providers.OpenRouterSpec.spec

--- a/test/Memory/MarkdownSpec.hs
+++ b/test/Memory/MarkdownSpec.hs
@@ -1,0 +1,84 @@
+module Memory.MarkdownSpec (spec) where
+
+import Data.Map.Strict qualified as Map
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Memory
+import PureClaw.Memory.Markdown
+
+spec :: Spec
+spec = do
+  describe "mkMarkdownMemoryHandle" $ do
+    it "saves and recalls a memory" $ do
+      dir <- mkTempDir "pureclaw-md-test"
+      mh <- mkMarkdownMemoryHandle dir
+      let source = MemorySource "Remember this important thing" Map.empty
+      result <- _mh_save mh source
+      case result of
+        Nothing -> expectationFailure "expected Just from save"
+        Just mid -> do
+          recalled <- _mh_recall mh mid
+          case recalled of
+            Nothing -> expectationFailure "expected Just from recall"
+            Just entry ->
+              _me_content entry `shouldBe` "Remember this important thing"
+
+    it "searches by substring match" $ do
+      dir <- mkTempDir "pureclaw-md-search"
+      mh <- mkMarkdownMemoryHandle dir
+      let source1 = MemorySource "The cat sat on the mat" Map.empty
+          source2 = MemorySource "The dog ran in the park" Map.empty
+      _ <- _mh_save mh source1
+      _ <- _mh_save mh source2
+      results <- _mh_search mh "cat" defaultSearchConfig
+      case results of
+        [r] -> _sr_content r `shouldBe` "The cat sat on the mat"
+        _   -> expectationFailure $ "expected 1 result, got " ++ show (length results)
+
+    it "returns empty for no matches" $ do
+      dir <- mkTempDir "pureclaw-md-nomatch"
+      mh <- mkMarkdownMemoryHandle dir
+      let source = MemorySource "hello world" Map.empty
+      _ <- _mh_save mh source
+      results <- _mh_search mh "zebra" defaultSearchConfig
+      results `shouldBe` []
+
+    it "stores and retrieves metadata" $ do
+      dir <- mkTempDir "pureclaw-md-meta"
+      mh <- mkMarkdownMemoryHandle dir
+      let meta = Map.fromList [("tags", "test,important")]
+          source = MemorySource "content with tags" meta
+      result <- _mh_save mh source
+      case result of
+        Nothing -> expectationFailure "expected Just from save"
+        Just mid -> do
+          recalled <- _mh_recall mh mid
+          case recalled of
+            Nothing -> expectationFailure "expected Just from recall"
+            Just entry ->
+              Map.lookup "tags" (_me_metadata entry) `shouldBe` Just "test,important"
+
+    it "recall returns Nothing for unknown id" $ do
+      dir <- mkTempDir "pureclaw-md-unknown"
+      mh <- mkMarkdownMemoryHandle dir
+      result <- _mh_recall mh (MemoryId "nonexistent")
+      result `shouldBe` Nothing
+
+    it "creates the directory if it does not exist" $ do
+      tmpDir <- getTemporaryDirectory
+      let dir = tmpDir </> "pureclaw-md-newdir"
+      removePathForcibly dir
+      mh <- mkMarkdownMemoryHandle dir
+      _ <- _mh_save mh (MemorySource "test" Map.empty)
+      doesDirectoryExist dir `shouldReturn` True
+
+mkTempDir :: String -> IO FilePath
+mkTempDir name = do
+  tmpDir <- getTemporaryDirectory
+  let dir = tmpDir </> name
+  removePathForcibly dir
+  createDirectoryIfMissing True dir
+  pure dir

--- a/test/Memory/NoneSpec.hs
+++ b/test/Memory/NoneSpec.hs
@@ -1,0 +1,26 @@
+module Memory.NoneSpec (spec) where
+
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Memory
+import PureClaw.Memory.None
+
+spec :: Spec
+spec = do
+  describe "mkNoneMemoryHandle" $ do
+    it "search returns empty list" $ do
+      let mh = mkNoneMemoryHandle
+      results <- _mh_search mh "anything" defaultSearchConfig
+      results `shouldBe` []
+
+    it "save returns Nothing" $ do
+      let mh = mkNoneMemoryHandle
+          source = MemorySource "test" mempty
+      result <- _mh_save mh source
+      result `shouldBe` Nothing
+
+    it "recall returns Nothing" $ do
+      let mh = mkNoneMemoryHandle
+      result <- _mh_recall mh (MemoryId "1")
+      result `shouldBe` Nothing

--- a/test/Memory/SQLiteSpec.hs
+++ b/test/Memory/SQLiteSpec.hs
@@ -1,0 +1,82 @@
+module Memory.SQLiteSpec (spec) where
+
+import Data.Map.Strict qualified as Map
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Memory
+import PureClaw.Memory.SQLite
+
+spec :: Spec
+spec = do
+  describe "mkSQLiteMemoryHandle" $ do
+    it "saves and recalls a memory" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-test"
+      mh <- mkSQLiteMemoryHandle dbPath
+      let source = MemorySource "Remember this" Map.empty
+      result <- _mh_save mh source
+      case result of
+        Nothing -> expectationFailure "expected Just from save"
+        Just mid -> do
+          recalled <- _mh_recall mh mid
+          case recalled of
+            Nothing -> expectationFailure "expected Just from recall"
+            Just entry ->
+              _me_content entry `shouldBe` "Remember this"
+
+    it "searches by substring" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-search"
+      mh <- mkSQLiteMemoryHandle dbPath
+      _ <- _mh_save mh (MemorySource "The cat sat on the mat" Map.empty)
+      _ <- _mh_save mh (MemorySource "The dog ran in the park" Map.empty)
+      results <- _mh_search mh "cat" defaultSearchConfig
+      case results of
+        [r] -> _sr_content r `shouldBe` "The cat sat on the mat"
+        _   -> expectationFailure $ "expected 1 result, got " ++ show (length results)
+
+    it "returns empty for no matches" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-nomatch"
+      mh <- mkSQLiteMemoryHandle dbPath
+      _ <- _mh_save mh (MemorySource "hello world" Map.empty)
+      results <- _mh_search mh "zebra" defaultSearchConfig
+      results `shouldBe` []
+
+    it "recall returns Nothing for unknown id" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-unknown"
+      mh <- mkSQLiteMemoryHandle dbPath
+      result <- _mh_recall mh (MemoryId "nonexistent")
+      result `shouldBe` Nothing
+
+    it "preserves metadata" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-meta"
+      mh <- mkSQLiteMemoryHandle dbPath
+      let meta = Map.fromList [("tags", "test")]
+      result <- _mh_save mh (MemorySource "content" meta)
+      case result of
+        Nothing -> expectationFailure "expected Just from save"
+        Just mid -> do
+          recalled <- _mh_recall mh mid
+          case recalled of
+            Nothing -> expectationFailure "expected Just from recall"
+            Just entry ->
+              Map.lookup "tags" (_me_metadata entry) `shouldBe` Just "test"
+
+  describe "withSQLiteMemory" $ do
+    it "runs an action with a memory handle" $ do
+      dbPath <- mkTempDb "pureclaw-sqlite-with"
+      result <- withSQLiteMemory dbPath $ \mh ->
+        _mh_save mh (MemorySource "test" Map.empty)
+      result `shouldSatisfy` isJust
+
+isJust :: Maybe a -> Bool
+isJust (Just _) = True
+isJust Nothing  = False
+
+mkTempDb :: String -> IO FilePath
+mkTempDb name = do
+  tmpDir <- getTemporaryDirectory
+  let path = tmpDir </> name <> ".db"
+  removePathForcibly path
+  pure path

--- a/test/Providers/OllamaSpec.hs
+++ b/test/Providers/OllamaSpec.hs
@@ -1,0 +1,88 @@
+module Providers.OllamaSpec (spec) where
+
+import Data.Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString.Lazy qualified as BL
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Providers.Ollama
+
+spec :: Spec
+spec = do
+  describe "encodeRequest" $ do
+    it "encodes with model and messages" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "llama3"
+            , _cr_messages     = [textMessage User "Hello"]
+            , _cr_systemPrompt = Nothing
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just val -> do
+          val `shouldSatisfy` hasKey "model"
+          val `shouldSatisfy` hasKey "messages"
+          val `shouldSatisfy` hasKey "stream"
+
+    it "sets stream to false" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "llama3"
+            , _cr_messages     = []
+            , _cr_systemPrompt = Nothing
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just (Object obj) ->
+          KM.lookup "stream" obj `shouldBe` Just (Bool False)
+        Just _ -> expectationFailure "Expected object"
+
+    it "includes system prompt in messages" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "llama3"
+            , _cr_messages     = [textMessage User "Hi"]
+            , _cr_systemPrompt = Just "Be helpful"
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just (Object obj) ->
+          case KM.lookup "messages" obj of
+            Just (Array msgs) -> length msgs `shouldBe` 2
+            _ -> expectationFailure "messages not found"
+        Just _ -> expectationFailure "Expected object"
+
+  describe "decodeResponse" $ do
+    it "decodes a text response" $ do
+      let json = BL.fromStrict $ mconcat
+            [ "{\"message\":{\"content\":\"Hello from Ollama!\"}"
+            , ",\"model\":\"llama3\"}"
+            ]
+      case decodeResponse json of
+        Left err -> expectationFailure err
+        Right resp -> do
+          responseText resp `shouldBe` "Hello from Ollama!"
+          _crsp_model resp `shouldBe` ModelId "llama3"
+          _crsp_usage resp `shouldBe` Nothing
+
+    it "returns error on invalid JSON" $ do
+      decodeResponse "not json" `shouldSatisfy` isLeft
+
+hasKey :: Key -> Value -> Bool
+hasKey k (Object obj) = KM.member k obj
+hasKey _ _ = False
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False

--- a/test/Providers/OpenAISpec.hs
+++ b/test/Providers/OpenAISpec.hs
@@ -1,0 +1,100 @@
+module Providers.OpenAISpec (spec) where
+
+import Data.Aeson
+import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString.Lazy qualified as BL
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Providers.OpenAI
+
+spec :: Spec
+spec = do
+  describe "encodeRequest" $ do
+    it "encodes a basic request" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "gpt-4"
+            , _cr_messages     = [textMessage User "Hello"]
+            , _cr_systemPrompt = Nothing
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just val -> do
+          val `shouldSatisfy` hasKey "model"
+          val `shouldSatisfy` hasKey "messages"
+
+    it "puts system prompt in messages array" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "gpt-4"
+            , _cr_messages     = [textMessage User "Hi"]
+            , _cr_systemPrompt = Just "Be helpful"
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just (Object obj) ->
+          case KM.lookup "messages" obj of
+            Just (Array msgs) -> length msgs `shouldBe` 2  -- system + user
+            _ -> expectationFailure "messages not found"
+        Just _ -> expectationFailure "Expected object"
+
+    it "includes tools when provided" $ do
+      let tool = ToolDefinition "test" "A test" (object ["type" .= ("object" :: String)])
+          req = CompletionRequest
+            { _cr_model        = ModelId "gpt-4"
+            , _cr_messages     = []
+            , _cr_systemPrompt = Nothing
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = [tool]
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just val -> val `shouldSatisfy` hasKey "tools"
+
+  describe "decodeResponse" $ do
+    it "decodes a text response" $ do
+      let json = BL.fromStrict $ mconcat
+            [ "{\"choices\":[{\"message\":{\"content\":\"Hello!\"}}]"
+            , ",\"model\":\"gpt-4\""
+            , ",\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":3}}"
+            ]
+      case decodeResponse json of
+        Left err -> expectationFailure err
+        Right resp -> do
+          responseText resp `shouldBe` "Hello!"
+          _crsp_model resp `shouldBe` ModelId "gpt-4"
+          _crsp_usage resp `shouldBe` Just (Usage 5 3)
+
+    it "decodes a response with tool calls" $ do
+      let json = BL.fromStrict $ mconcat
+            [ "{\"choices\":[{\"message\":{\"content\":null"
+            , ",\"tool_calls\":[{\"id\":\"call_1\",\"type\":\"function\""
+            , ",\"function\":{\"name\":\"shell\",\"arguments\":\"{\\\"command\\\":\\\"ls\\\"}\"}}]"
+            , "}}],\"model\":\"gpt-4\"}"
+            ]
+      case decodeResponse json of
+        Left err -> expectationFailure err
+        Right resp -> do
+          let calls = toolUseCalls resp
+          length calls `shouldBe` 1
+
+    it "returns error on invalid JSON" $ do
+      decodeResponse "not json" `shouldSatisfy` isLeft
+
+hasKey :: Key -> Value -> Bool
+hasKey k (Object obj) = KM.member k obj
+hasKey _ _ = False
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False

--- a/test/Providers/OpenRouterSpec.hs
+++ b/test/Providers/OpenRouterSpec.hs
@@ -1,0 +1,45 @@
+module Providers.OpenRouterSpec (spec) where
+
+import Data.Aeson
+import Data.ByteString.Lazy qualified as BL
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Providers.OpenRouter
+
+spec :: Spec
+spec = do
+  describe "encodeRequest" $ do
+    it "produces valid JSON (same as OpenAI format)" $ do
+      let req = CompletionRequest
+            { _cr_model        = ModelId "anthropic/claude-3.5-sonnet"
+            , _cr_messages     = [textMessage User "Hello"]
+            , _cr_systemPrompt = Nothing
+            , _cr_maxTokens    = Nothing
+            , _cr_tools        = []
+            , _cr_toolChoice   = Nothing
+            }
+          body = encodeRequest req
+      case decode body :: Maybe Value of
+        Nothing -> expectationFailure "Invalid JSON"
+        Just _ -> pure ()
+
+  describe "decodeResponse" $ do
+    it "decodes an OpenAI-format response" $ do
+      let json = BL.fromStrict $ mconcat
+            [ "{\"choices\":[{\"message\":{\"content\":\"Hello!\"}}]"
+            , ",\"model\":\"anthropic/claude-3.5-sonnet\"}"
+            ]
+      case decodeResponse json of
+        Left err -> expectationFailure err
+        Right resp -> do
+          responseText resp `shouldBe` "Hello!"
+          _crsp_model resp `shouldBe` ModelId "anthropic/claude-3.5-sonnet"
+
+    it "returns error on invalid JSON" $ do
+      decodeResponse "not json" `shouldSatisfy` isLeft
+
+isLeft :: Either a b -> Bool
+isLeft (Left _) = True
+isLeft _ = False


### PR DESCRIPTION
## Summary
- **Memory backends**: None (no-op), Markdown (file-based with YAML frontmatter), SQLite (persistent with LIKE search)
- **Agent memory integration**: `autoRecall` (search top 3 memories, format as context) and `autoSave` (save messages ≥50 chars)
- **New providers**: OpenAI (Chat Completions API with tool calling), OpenRouter (reuses OpenAI format, different base URL/headers), Ollama (local inference, no auth)
- 33 new tests (206 total), all passing, hlint clean

## Test plan
- [x] All 206 tests pass (`cabal test`)
- [x] hlint clean on all new files
- [x] Pre-push hooks pass (hlint + tests)
- [x] Memory save/recall/search verified for Markdown and SQLite backends
- [x] Provider encode/decode verified for OpenAI, OpenRouter, and Ollama formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)