### PR TITLE
Implement Channels and Agent Identity (Phase 5)

### DIFF
--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -179,6 +179,10 @@ test-suite pureclaw-test
     Gateway.AuthSpec
     Gateway.RoutesSpec
     Gateway.ServerSpec
+    Channels.ClassSpec
+    Channels.TelegramSpec
+    Channels.SignalSpec
+    Agent.IdentitySpec
   hs-source-dirs:   test
   build-depends:
     base,
@@ -191,6 +195,8 @@ test-suite pureclaw-test
     filepath,
     http-types,
     optparse-applicative,
+    stm,
+    temporary,
     text,
     wai,
     warp,

--- a/src/PureClaw/Agent/Identity.hs
+++ b/src/PureClaw/Agent/Identity.hs
@@ -1,1 +1,127 @@
-module PureClaw.Agent.Identity () where
+module PureClaw.Agent.Identity
+  ( -- * Identity types
+    AgentIdentity (..)
+  , defaultIdentity
+    -- * Loading
+  , loadIdentity
+  , loadIdentityFromText
+    -- * System prompt generation
+  , identitySystemPrompt
+  ) where
+
+import Data.Maybe
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import System.Directory
+
+-- | Agent identity loaded from a SOUL.md file or configured defaults.
+-- Controls the agent's system prompt, personality, and behavioral constraints.
+data AgentIdentity = AgentIdentity
+  { _ai_name         :: Text
+  , _ai_description  :: Text
+  , _ai_instructions :: Text
+  , _ai_constraints  :: [Text]
+  }
+  deriving stock (Show, Eq)
+
+-- | A minimal default identity for when no SOUL.md is provided.
+defaultIdentity :: AgentIdentity
+defaultIdentity = AgentIdentity
+  { _ai_name         = "PureClaw"
+  , _ai_description  = "A helpful AI assistant."
+  , _ai_instructions = ""
+  , _ai_constraints  = []
+  }
+
+-- | Load an identity from a SOUL.md file at the given path.
+-- Returns 'defaultIdentity' if the file does not exist.
+loadIdentity :: FilePath -> IO AgentIdentity
+loadIdentity path = do
+  exists <- doesFileExist path
+  if exists
+    then do
+      content <- TIO.readFile path
+      pure (loadIdentityFromText content)
+    else pure defaultIdentity
+
+-- | Parse identity from SOUL.md markdown content. Extracts sections
+-- by heading:
+--
+-- @
+-- # Name
+-- Agent name here
+--
+-- # Description
+-- What this agent does.
+--
+-- # Instructions
+-- How the agent should behave.
+--
+-- # Constraints
+-- - Do not do X
+-- - Always do Y
+-- @
+loadIdentityFromText :: Text -> AgentIdentity
+loadIdentityFromText content =
+  let sections = parseSections content
+      get key = fromMaybe "" (lookup key sections)
+      constraints = maybe [] parseConstraints (lookup "constraints" sections)
+  in AgentIdentity
+    { _ai_name         = T.strip (get "name")
+    , _ai_description  = T.strip (get "description")
+    , _ai_instructions = T.strip (get "instructions")
+    , _ai_constraints  = constraints
+    }
+
+-- | Generate a system prompt from an identity.
+identitySystemPrompt :: AgentIdentity -> Text
+identitySystemPrompt ident =
+  let parts = filter (not . T.null)
+        [ if T.null (_ai_name ident)
+            then ""
+            else "You are " <> _ai_name ident <> "."
+        , _ai_description ident
+        , _ai_instructions ident
+        , if null (_ai_constraints ident)
+            then ""
+            else "Constraints:\n" <> T.unlines (map ("- " <>) (_ai_constraints ident))
+        ]
+  in T.intercalate "\n\n" parts
+
+-- | Parse markdown into sections keyed by lowercase heading text.
+-- Lines before the first heading are ignored.
+parseSections :: Text -> [(Text, Text)]
+parseSections content =
+  let ls = T.lines content
+  in go Nothing [] ls []
+  where
+    go :: Maybe Text -> [Text] -> [Text] -> [(Text, Text)] -> [(Text, Text)]
+    go currentKey accLines [] result =
+      case currentKey of
+        Nothing -> result
+        Just k  -> result ++ [(k, T.unlines (reverse accLines))]
+    go currentKey accLines (l:rest) result
+      | Just heading <- parseHeading l =
+          let result' = case currentKey of
+                Nothing -> result
+                Just k  -> result ++ [(k, T.unlines (reverse accLines))]
+          in go (Just (T.toLower heading)) [] rest result'
+      | otherwise = go currentKey (l : accLines) rest result
+
+    parseHeading :: Text -> Maybe Text
+    parseHeading line =
+      let stripped = T.stripStart line
+      in if T.isPrefixOf "# " stripped
+         then Just (T.strip (T.drop 2 stripped))
+         else Nothing
+
+-- | Parse constraint lines from a markdown list.
+-- Each line starting with @-@ is a constraint.
+parseConstraints :: Text -> [Text]
+parseConstraints content =
+  [ T.strip (T.drop 1 line)
+  | line <- T.lines content
+  , let trimmed = T.stripStart line
+  , T.isPrefixOf "- " trimmed
+  ]

--- a/src/PureClaw/Channels/Class.hs
+++ b/src/PureClaw/Channels/Class.hs
@@ -1,1 +1,26 @@
-module PureClaw.Channels.Class () where
+module PureClaw.Channels.Class
+  ( -- * Channel typeclass
+    Channel (..)
+    -- * Existential wrapper
+  , SomeChannel (..)
+  , someChannelHandle
+  ) where
+
+import PureClaw.Handles.Channel
+
+-- | Typeclass for channel implementations. Each channel knows how to
+-- receive messages from users and send responses back. The 'toHandle'
+-- method converts any channel into the uniform 'ChannelHandle' used
+-- by the agent loop.
+class Channel c where
+  -- | Convert this channel into a 'ChannelHandle'.
+  toHandle :: c -> ChannelHandle
+
+-- | Existential wrapper for runtime channel selection (e.g. from config).
+-- Use 'someChannelHandle' to extract the 'ChannelHandle'.
+data SomeChannel where
+  MkChannel :: Channel c => c -> SomeChannel
+
+-- | Extract a 'ChannelHandle' from a 'SomeChannel'.
+someChannelHandle :: SomeChannel -> ChannelHandle
+someChannelHandle (MkChannel c) = toHandle c

--- a/src/PureClaw/Channels/Signal.hs
+++ b/src/PureClaw/Channels/Signal.hs
@@ -1,1 +1,103 @@
-module PureClaw.Channels.Signal () where
+module PureClaw.Channels.Signal
+  ( -- * Signal channel
+    SignalChannel (..)
+  , SignalConfig (..)
+  , mkSignalChannel
+    -- * Message parsing
+  , parseSignalEnvelope
+  , SignalEnvelope (..)
+  , SignalDataMessage (..)
+  ) where
+
+import Control.Concurrent.STM
+import Data.Aeson
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import PureClaw.Channels.Class
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+import PureClaw.Handles.Log
+
+-- | Configuration for Signal channel.
+newtype SignalConfig = SignalConfig
+  { _sc_account :: Text
+  }
+  deriving stock (Show, Eq)
+
+-- | A Signal channel backed by a message queue. Messages from signal-cli
+-- are pushed into the queue and the agent loop pulls them out via 'receive'.
+data SignalChannel = SignalChannel
+  { _sch_config :: SignalConfig
+  , _sch_inbox  :: TQueue SignalEnvelope
+  , _sch_log    :: LogHandle
+  }
+
+-- | Create a Signal channel with an empty inbox.
+mkSignalChannel :: SignalConfig -> LogHandle -> IO SignalChannel
+mkSignalChannel config lh = do
+  inbox <- newTQueueIO
+  pure SignalChannel
+    { _sch_config = config
+    , _sch_inbox  = inbox
+    , _sch_log    = lh
+    }
+
+instance Channel SignalChannel where
+  toHandle sc = ChannelHandle
+    { _ch_receive   = receiveEnvelope sc
+    , _ch_send      = sendSignalMessage sc
+    , _ch_sendError = sendSignalError sc
+    }
+
+-- | Block until a Signal envelope arrives in the queue.
+receiveEnvelope :: SignalChannel -> IO IncomingMessage
+receiveEnvelope sc = do
+  envelope <- atomically $ readTQueue (_sch_inbox sc)
+  let sender = _se_source envelope
+      content = maybe "" _sdm_message (_se_dataMessage envelope)
+  pure IncomingMessage
+    { _im_userId  = UserId sender
+    , _im_content = content
+    }
+
+-- | Send a message via Signal. In a full implementation this would
+-- invoke signal-cli. For now, logs the outgoing message.
+sendSignalMessage :: SignalChannel -> OutgoingMessage -> IO ()
+sendSignalMessage sc msg =
+  _lh_logInfo (_sch_log sc) $ "Signal send: " <> _om_content msg
+
+-- | Send an error via Signal.
+sendSignalError :: SignalChannel -> PublicError -> IO ()
+sendSignalError sc err =
+  _lh_logWarn (_sch_log sc) $ "Signal error: " <> T.pack (show err)
+
+-- | A Signal envelope (simplified JSON-RPC format from signal-cli).
+data SignalEnvelope = SignalEnvelope
+  { _se_source      :: Text
+  , _se_timestamp   :: Int
+  , _se_dataMessage :: Maybe SignalDataMessage
+  }
+  deriving stock (Show, Eq)
+
+-- | A Signal data message.
+data SignalDataMessage = SignalDataMessage
+  { _sdm_message   :: Text
+  , _sdm_timestamp :: Int
+  }
+  deriving stock (Show, Eq)
+
+instance FromJSON SignalEnvelope where
+  parseJSON = withObject "SignalEnvelope" $ \o ->
+    SignalEnvelope <$> o .: "source" <*> o .: "timestamp" <*> o .:? "dataMessage"
+
+instance FromJSON SignalDataMessage where
+  parseJSON = withObject "SignalDataMessage" $ \o ->
+    SignalDataMessage <$> o .: "message" <*> o .: "timestamp"
+
+-- | Parse a JSON value as a Signal envelope.
+parseSignalEnvelope :: Value -> Either String SignalEnvelope
+parseSignalEnvelope v = case fromJSON v of
+  Error err -> Left err
+  Success e -> Right e

--- a/src/PureClaw/Channels/Telegram.hs
+++ b/src/PureClaw/Channels/Telegram.hs
@@ -1,1 +1,136 @@
-module PureClaw.Channels.Telegram () where
+module PureClaw.Channels.Telegram
+  ( -- * Telegram channel
+    TelegramChannel (..)
+  , TelegramConfig (..)
+  , mkTelegramChannel
+    -- * Message parsing
+  , parseTelegramUpdate
+  , TelegramUpdate (..)
+  , TelegramMessage (..)
+  , TelegramChat (..)
+  , TelegramUser (..)
+  ) where
+
+import Control.Concurrent.STM
+import Data.Aeson
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import PureClaw.Channels.Class
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+import PureClaw.Handles.Log
+import PureClaw.Handles.Network
+
+-- | Configuration for Telegram channel.
+data TelegramConfig = TelegramConfig
+  { _tc_botToken :: Text
+  , _tc_apiBase  :: Text
+  }
+  deriving stock (Show, Eq)
+
+-- | A Telegram channel backed by a message queue. Updates are pushed
+-- into the queue (e.g. from a webhook endpoint) and the agent loop
+-- pulls them out via 'receive'. Responses are sent via the Telegram
+-- Bot API using the provided 'NetworkHandle'.
+data TelegramChannel = TelegramChannel
+  { _tch_config  :: TelegramConfig
+  , _tch_inbox   :: TQueue TelegramUpdate
+  , _tch_network :: NetworkHandle
+  , _tch_log     :: LogHandle
+  }
+
+-- | Create a Telegram channel with an empty inbox.
+mkTelegramChannel :: TelegramConfig -> NetworkHandle -> LogHandle -> IO TelegramChannel
+mkTelegramChannel config nh lh = do
+  inbox <- newTQueueIO
+  pure TelegramChannel
+    { _tch_config  = config
+    , _tch_inbox   = inbox
+    , _tch_network = nh
+    , _tch_log     = lh
+    }
+
+instance Channel TelegramChannel where
+  toHandle tc = ChannelHandle
+    { _ch_receive   = receiveUpdate tc
+    , _ch_send      = sendMessage tc
+    , _ch_sendError = sendTelegramError tc
+    }
+
+-- | Block until a Telegram update arrives in the queue.
+receiveUpdate :: TelegramChannel -> IO IncomingMessage
+receiveUpdate tc = do
+  update <- atomically $ readTQueue (_tch_inbox tc)
+  let msg = _tu_message update
+      userId = T.pack (show (_tu_id (_tm_from msg)))
+      content = _tm_text msg
+  pure IncomingMessage
+    { _im_userId  = UserId userId
+    , _im_content = content
+    }
+
+-- | Send a message to the chat that the last update came from.
+-- In a full implementation this would POST to the Telegram sendMessage API.
+-- For now, logs the outgoing message.
+sendMessage :: TelegramChannel -> OutgoingMessage -> IO ()
+sendMessage tc msg =
+  _lh_logInfo (_tch_log tc) $ "Telegram send: " <> _om_content msg
+
+-- | Send an error to the Telegram chat.
+sendTelegramError :: TelegramChannel -> PublicError -> IO ()
+sendTelegramError tc err =
+  _lh_logWarn (_tch_log tc) $ "Telegram error: " <> T.pack (show err)
+
+-- | A Telegram Update object (simplified).
+data TelegramUpdate = TelegramUpdate
+  { _tu_updateId :: Int
+  , _tu_message  :: TelegramMessage
+  }
+  deriving stock (Show, Eq)
+
+-- | A Telegram Message object (simplified).
+data TelegramMessage = TelegramMessage
+  { _tm_messageId :: Int
+  , _tm_from      :: TelegramUser
+  , _tm_chat      :: TelegramChat
+  , _tm_text      :: Text
+  }
+  deriving stock (Show, Eq)
+
+-- | A Telegram Chat object (simplified).
+data TelegramChat = TelegramChat
+  { _tcht_id   :: Int
+  , _tcht_type :: Text
+  }
+  deriving stock (Show, Eq)
+
+-- | A Telegram User object (simplified).
+data TelegramUser = TelegramUser
+  { _tu_id        :: Int
+  , _tu_firstName :: Text
+  }
+  deriving stock (Show, Eq)
+
+instance FromJSON TelegramUpdate where
+  parseJSON = withObject "TelegramUpdate" $ \o ->
+    TelegramUpdate <$> o .: "update_id" <*> o .: "message"
+
+instance FromJSON TelegramMessage where
+  parseJSON = withObject "TelegramMessage" $ \o ->
+    TelegramMessage <$> o .: "message_id" <*> o .: "from" <*> o .: "chat" <*> o .: "text"
+
+instance FromJSON TelegramChat where
+  parseJSON = withObject "TelegramChat" $ \o ->
+    TelegramChat <$> o .: "id" <*> o .: "type"
+
+instance FromJSON TelegramUser where
+  parseJSON = withObject "TelegramUser" $ \o ->
+    TelegramUser <$> o .: "id" <*> o .: "first_name"
+
+-- | Parse a JSON value as a Telegram update.
+parseTelegramUpdate :: Value -> Either String TelegramUpdate
+parseTelegramUpdate v = case fromJSON v of
+  Error err   -> Left err
+  Success upd -> Right upd

--- a/test/Agent/IdentitySpec.hs
+++ b/test/Agent/IdentitySpec.hs
@@ -1,0 +1,110 @@
+module Agent.IdentitySpec (spec) where
+
+import Data.Text qualified as T
+import System.FilePath
+import System.IO.Temp
+import Test.Hspec
+
+import PureClaw.Agent.Identity
+
+spec :: Spec
+spec = do
+  describe "defaultIdentity" $ do
+    it "has a name" $
+      _ai_name defaultIdentity `shouldBe` "PureClaw"
+
+    it "has a description" $
+      _ai_description defaultIdentity `shouldSatisfy` (not . T.null)
+
+    it "has empty instructions" $
+      _ai_instructions defaultIdentity `shouldBe` ""
+
+    it "has no constraints" $
+      _ai_constraints defaultIdentity `shouldBe` []
+
+    it "has Show and Eq instances" $ do
+      show defaultIdentity `shouldContain` "AgentIdentity"
+      defaultIdentity `shouldBe` defaultIdentity
+
+  describe "loadIdentityFromText" $ do
+    it "parses a full SOUL.md" $ do
+      let soul = T.unlines
+            [ "# Name"
+            , "TestBot"
+            , ""
+            , "# Description"
+            , "A test bot for unit tests."
+            , ""
+            , "# Instructions"
+            , "Be helpful and concise."
+            , ""
+            , "# Constraints"
+            , "- Do not share secrets"
+            , "- Always be polite"
+            ]
+          ident = loadIdentityFromText soul
+      _ai_name ident `shouldBe` "TestBot"
+      _ai_description ident `shouldBe` "A test bot for unit tests."
+      _ai_instructions ident `shouldBe` "Be helpful and concise."
+      _ai_constraints ident `shouldBe` ["Do not share secrets", "Always be polite"]
+
+    it "handles missing sections gracefully" $ do
+      let soul = T.unlines
+            [ "# Name"
+            , "MinimalBot"
+            ]
+          ident = loadIdentityFromText soul
+      _ai_name ident `shouldBe` "MinimalBot"
+      _ai_description ident `shouldBe` ""
+      _ai_instructions ident `shouldBe` ""
+      _ai_constraints ident `shouldBe` []
+
+    it "handles empty content" $ do
+      let ident = loadIdentityFromText ""
+      _ai_name ident `shouldBe` ""
+      _ai_description ident `shouldBe` ""
+
+    it "ignores content before first heading" $ do
+      let soul = T.unlines
+            [ "This is preamble text"
+            , "that should be ignored."
+            , ""
+            , "# Name"
+            , "MyBot"
+            ]
+          ident = loadIdentityFromText soul
+      _ai_name ident `shouldBe` "MyBot"
+
+  describe "loadIdentity" $ do
+    it "loads from a file" $ do
+      withSystemTempDirectory "pureclaw-test" $ \dir -> do
+        let path = dir </> "SOUL.md"
+        writeFile path "# Name\nFileBot\n\n# Description\nLoaded from disk."
+        ident <- loadIdentity path
+        _ai_name ident `shouldBe` "FileBot"
+        _ai_description ident `shouldBe` "Loaded from disk."
+
+    it "returns defaultIdentity for missing file" $ do
+      ident <- loadIdentity "/nonexistent/SOUL.md"
+      ident `shouldBe` defaultIdentity
+
+  describe "identitySystemPrompt" $ do
+    it "generates a system prompt from identity" $ do
+      let ident = AgentIdentity "Bot" "A helpful bot." "Be concise." ["No secrets"]
+          prompt = identitySystemPrompt ident
+      prompt `shouldSatisfy` T.isInfixOf "You are Bot."
+      prompt `shouldSatisfy` T.isInfixOf "A helpful bot."
+      prompt `shouldSatisfy` T.isInfixOf "Be concise."
+      prompt `shouldSatisfy` T.isInfixOf "No secrets"
+
+    it "omits empty sections" $ do
+      let ident = AgentIdentity "Bot" "" "" []
+          prompt = identitySystemPrompt ident
+      prompt `shouldBe` "You are Bot."
+
+    it "includes constraints header" $ do
+      let ident = AgentIdentity "" "" "" ["Rule 1", "Rule 2"]
+          prompt = identitySystemPrompt ident
+      prompt `shouldSatisfy` T.isInfixOf "Constraints:"
+      prompt `shouldSatisfy` T.isInfixOf "- Rule 1"
+      prompt `shouldSatisfy` T.isInfixOf "- Rule 2"

--- a/test/Channels/ClassSpec.hs
+++ b/test/Channels/ClassSpec.hs
@@ -1,0 +1,35 @@
+module Channels.ClassSpec (spec) where
+
+import Test.Hspec
+
+import PureClaw.Channels.Class
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+
+-- A trivial channel for testing the typeclass machinery.
+newtype TestChannel = TestChannel IncomingMessage
+
+instance Channel TestChannel where
+  toHandle (TestChannel msg) = ChannelHandle
+    { _ch_receive   = pure msg
+    , _ch_send      = \_ -> pure ()
+    , _ch_sendError = \_ -> pure ()
+    }
+
+spec :: Spec
+spec = do
+  describe "Channel typeclass" $ do
+    it "toHandle produces a working ChannelHandle" $ do
+      let msg = IncomingMessage (UserId "u1") "hello"
+          ch  = TestChannel msg
+          h   = toHandle ch
+      received <- _ch_receive h
+      received `shouldBe` msg
+
+  describe "SomeChannel" $ do
+    it "wraps a Channel and extracts a handle" $ do
+      let msg  = IncomingMessage (UserId "u2") "world"
+          some = MkChannel (TestChannel msg)
+          h    = someChannelHandle some
+      received <- _ch_receive h
+      received `shouldBe` msg

--- a/test/Channels/SignalSpec.hs
+++ b/test/Channels/SignalSpec.hs
@@ -1,0 +1,109 @@
+module Channels.SignalSpec (spec) where
+
+import Control.Concurrent.STM
+import Data.Aeson
+import Data.Either (isLeft)
+import Data.Text (Text)
+import Test.Hspec
+
+import PureClaw.Channels.Class
+import PureClaw.Channels.Signal
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+import PureClaw.Handles.Log
+
+spec :: Spec
+spec = do
+  describe "SignalConfig" $ do
+    it "has Show and Eq instances" $ do
+      let cfg = SignalConfig "+1234567890"
+      show cfg `shouldContain` "SignalConfig"
+      cfg `shouldBe` cfg
+
+  describe "mkSignalChannel" $ do
+    it "creates a channel that can receive pushed envelopes" $ do
+      sc <- mkTestSignalChannel
+      let env = mkTestEnvelope "+1234567890" 1000 "Hello from Signal"
+      atomically $ writeTQueue (_sch_inbox sc) env
+      let h = toHandle sc
+      msg <- _ch_receive h
+      _im_content msg `shouldBe` "Hello from Signal"
+
+    it "extracts sender as userId" $ do
+      sc <- mkTestSignalChannel
+      let env = mkTestEnvelope "+9876543210" 2000 "Hi"
+      atomically $ writeTQueue (_sch_inbox sc) env
+      msg <- _ch_receive (toHandle sc)
+      _im_userId msg `shouldBe` UserId "+9876543210"
+
+    it "handles envelope with no dataMessage" $ do
+      sc <- mkTestSignalChannel
+      let env = SignalEnvelope "+1111111111" 3000 Nothing
+      atomically $ writeTQueue (_sch_inbox sc) env
+      msg <- _ch_receive (toHandle sc)
+      _im_content msg `shouldBe` ""
+
+  describe "parseSignalEnvelope" $ do
+    it "parses a valid envelope JSON" $ do
+      let json = object
+            [ "source" .= ("+1234567890" :: String)
+            , "timestamp" .= (1000 :: Int)
+            , "dataMessage" .= object
+                [ "message" .= ("hello" :: String)
+                , "timestamp" .= (1000 :: Int)
+                ]
+            ]
+      case parseSignalEnvelope json of
+        Left err -> expectationFailure err
+        Right env -> do
+          _se_source env `shouldBe` "+1234567890"
+          _se_timestamp env `shouldBe` 1000
+          case _se_dataMessage env of
+            Nothing -> expectationFailure "expected dataMessage"
+            Just dm -> _sdm_message dm `shouldBe` "hello"
+
+    it "parses envelope without dataMessage" $ do
+      let json = object
+            [ "source" .= ("+1234567890" :: String)
+            , "timestamp" .= (2000 :: Int)
+            ]
+      case parseSignalEnvelope json of
+        Left err -> expectationFailure err
+        Right env -> _se_dataMessage env `shouldBe` Nothing
+
+    it "rejects invalid JSON" $ do
+      let json = object ["wrong" .= ("field" :: String)]
+      parseSignalEnvelope json `shouldSatisfy` isLeft
+
+  describe "SignalEnvelope" $ do
+    it "has Show and Eq instances" $ do
+      let env = mkTestEnvelope "+1234567890" 1000 "hi"
+      show env `shouldContain` "SignalEnvelope"
+      env `shouldBe` env
+
+  describe "SignalDataMessage" $ do
+    it "has Show and Eq instances" $ do
+      let dm = SignalDataMessage "hello" 1000
+      show dm `shouldContain` "SignalDataMessage"
+      dm `shouldBe` dm
+
+  describe "send and sendError" $ do
+    it "send completes without error" $ do
+      sc <- mkTestSignalChannel
+      let h = toHandle sc
+      _ch_send h (OutgoingMessage "test") `shouldReturn` ()
+
+    it "sendError completes without error" $ do
+      sc <- mkTestSignalChannel
+      let h = toHandle sc
+      _ch_sendError h (TemporaryError "oops") `shouldReturn` ()
+
+-- Helpers
+
+mkTestSignalChannel :: IO SignalChannel
+mkTestSignalChannel = mkSignalChannel (SignalConfig "+0000000000") mkNoOpLogHandle
+
+mkTestEnvelope :: Text -> Int -> Text -> SignalEnvelope
+mkTestEnvelope source ts msg =
+  SignalEnvelope source ts (Just (SignalDataMessage msg ts))

--- a/test/Channels/TelegramSpec.hs
+++ b/test/Channels/TelegramSpec.hs
@@ -1,0 +1,94 @@
+module Channels.TelegramSpec (spec) where
+
+import Control.Concurrent.STM
+import Data.Aeson
+import Data.Either (isLeft)
+import Data.Text (Text)
+import Test.Hspec
+
+import PureClaw.Channels.Class
+import PureClaw.Channels.Telegram
+import PureClaw.Core.Errors
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+import PureClaw.Handles.Log
+import PureClaw.Handles.Network
+
+spec :: Spec
+spec = do
+  describe "TelegramConfig" $ do
+    it "has Show and Eq instances" $ do
+      let cfg = TelegramConfig "tok" "https://api.telegram.org"
+      show cfg `shouldContain` "TelegramConfig"
+      cfg `shouldBe` cfg
+
+  describe "mkTelegramChannel" $ do
+    it "creates a channel that can receive pushed updates" $ do
+      tc <- mkTestTelegramChannel
+      let update = mkTestUpdate 1 42 "Alice" 100 "private" "Hello"
+      atomically $ writeTQueue (_tch_inbox tc) update
+      let h = toHandle tc
+      msg <- _ch_receive h
+      _im_content msg `shouldBe` "Hello"
+
+    it "extracts user id from the update" $ do
+      tc <- mkTestTelegramChannel
+      let update = mkTestUpdate 1 99 "Bob" 100 "private" "Hi"
+      atomically $ writeTQueue (_tch_inbox tc) update
+      msg <- _ch_receive (toHandle tc)
+      _im_userId msg `shouldBe` UserId "99"
+
+  describe "parseTelegramUpdate" $ do
+    it "parses a valid update JSON" $ do
+      let json = object
+            [ "update_id" .= (1 :: Int)
+            , "message" .= object
+                [ "message_id" .= (10 :: Int)
+                , "from" .= object ["id" .= (42 :: Int), "first_name" .= ("Alice" :: String)]
+                , "chat" .= object ["id" .= (100 :: Int), "type" .= ("private" :: String)]
+                , "text" .= ("Hello" :: String)
+                ]
+            ]
+      case parseTelegramUpdate json of
+        Left err -> expectationFailure err
+        Right upd -> do
+          _tu_updateId upd `shouldBe` 1
+          _tm_text (_tu_message upd) `shouldBe` "Hello"
+          _tu_id (_tm_from (_tu_message upd)) `shouldBe` 42
+
+    it "rejects invalid JSON" $ do
+      let json = object ["wrong" .= ("field" :: String)]
+      parseTelegramUpdate json `shouldSatisfy` isLeft
+
+  describe "TelegramUpdate" $ do
+    it "has Show and Eq instances" $ do
+      let upd = mkTestUpdate 1 42 "Alice" 100 "private" "hi"
+      show upd `shouldContain` "TelegramUpdate"
+      upd `shouldBe` upd
+
+  describe "TelegramMessage" $ do
+    it "has Show and Eq instances" $ do
+      let msg = TelegramMessage 1 (TelegramUser 42 "Alice") (TelegramChat 100 "private") "hi"
+      show msg `shouldContain` "TelegramMessage"
+      msg `shouldBe` msg
+
+  describe "send and sendError" $ do
+    it "send completes without error" $ do
+      tc <- mkTestTelegramChannel
+      let h = toHandle tc
+      _ch_send h (OutgoingMessage "test") `shouldReturn` ()
+
+    it "sendError completes without error" $ do
+      tc <- mkTestTelegramChannel
+      let h = toHandle tc
+      _ch_sendError h (TemporaryError "oops") `shouldReturn` ()
+
+-- Helpers
+
+mkTestTelegramChannel :: IO TelegramChannel
+mkTestTelegramChannel =
+  mkTelegramChannel (TelegramConfig "test-token" "https://api.telegram.org") mkNoOpNetworkHandle mkNoOpLogHandle
+
+mkTestUpdate :: Int -> Int -> Text -> Int -> Text -> Text -> TelegramUpdate
+mkTestUpdate updId userId firstName chatId chatType txt =
+  TelegramUpdate updId (TelegramMessage 1 (TelegramUser userId firstName) (TelegramChat chatId chatType) txt)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -38,6 +38,10 @@ import qualified Security.PairingSpec
 import qualified Gateway.AuthSpec
 import qualified Gateway.RoutesSpec
 import qualified Gateway.ServerSpec
+import qualified Channels.ClassSpec
+import qualified Channels.TelegramSpec
+import qualified Channels.SignalSpec
+import qualified Agent.IdentitySpec
 
 main :: IO ()
 main = hspec $ do
@@ -77,3 +81,7 @@ main = hspec $ do
   describe "Gateway.Auth" Gateway.AuthSpec.spec
   describe "Gateway.Routes" Gateway.RoutesSpec.spec
   describe "Gateway.Server" Gateway.ServerSpec.spec
+  describe "Channels.Class" Channels.ClassSpec.spec
+  describe "Channels.Telegram" Channels.TelegramSpec.spec
+  describe "Channels.Signal" Channels.SignalSpec.spec
+  describe "Agent.Identity" Agent.IdentitySpec.spec


### PR DESCRIPTION
## Summary
- Add `Channels.Class` with `Channel` typeclass and `SomeChannel` existential wrapper for runtime channel dispatch
- Implement `Channels.Telegram`: STM-backed message queue, Telegram Bot API JSON parsing (Update, Message, Chat, User types)
- Implement `Channels.Signal`: STM-backed message queue, signal-cli JSON envelope parsing (Envelope, DataMessage types)
- Implement `Agent.Identity`: SOUL.md markdown parser, identity loading from file, system prompt generation
- 36 new tests (305 total), all passing

## Test plan
- [x] All 305 tests pass
- [x] hlint clean
- [x] Library and tests build with `-Wall -Werror`
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)