### PR TITLE
[BUGFIX] Anthropic streaming tool calls

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,9 @@
               shell.buildInputs = with final; [
                 age
                 age-plugin-yubikey
+                git
                 signal-cli
                 tmux
-                git
               ];
             };
           })

--- a/flake.nix
+++ b/flake.nix
@@ -3,30 +3,37 @@
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils, haskellNix }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] (system:
-    let
-      lib = nixpkgs.lib;
-      overlays = [ haskellNix.overlay
-        (final: prev: {
-          # This overlay adds our project to pkgs
-          pureclaw-project =
-            final.haskell-nix.cabalProject' {
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      haskellNix,
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-darwin" ] (
+      system:
+      let
+        lib = nixpkgs.lib;
+        overlays = [
+          haskellNix.overlay
+          (final: prev: {
+            # This overlay adds our project to pkgs
+            pureclaw-project = final.haskell-nix.cabalProject' {
               src = ./.;
               compiler-nix-name = "ghc9123";
               modules = [
-                  {
-                      enableProfiling = true;
-                      enableLibraryProfiling = true;
-                  }
+                {
+                  enableProfiling = true;
+                  enableLibraryProfiling = true;
+                }
               ];
 
               # This is used by `nix develop .` to open a shell for use with
               # `cabal`, `hlint` and `haskell-language-server`
               shell.tools = {
-                cabal = {};
-                ghcid = {};
-                hlint = {};
+                cabal = { };
+                ghcid = { };
+                hlint = { };
                 # haskell-language-server = {};
               };
               shell.buildInputs = with final; [
@@ -34,20 +41,27 @@
                 age-plugin-yubikey
                 signal-cli
                 tmux
+                git
               ];
             };
-        })
-      ];
-      pkgs = import nixpkgs { inherit system overlays; inherit (haskellNix) config; };
-      flake = pkgs.pureclaw-project.flake {
-        # This adds support for `nix build .#js-unknown-ghcjs:hello:exe:hello`
-        # crossPlatforms = p: [p.ghcjs];
-      };
-    in flake // {
-      # Built by `nix build .`
-      packages.default = flake.packages."pureclaw:exe:pureclaw";
-      inherit pkgs;
-    });
+          })
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          inherit (haskellNix) config;
+        };
+        flake = pkgs.pureclaw-project.flake {
+          # This adds support for `nix build .#js-unknown-ghcjs:hello:exe:hello`
+          # crossPlatforms = p: [p.ghcjs];
+        };
+      in
+      flake
+      // {
+        # Built by `nix build .`
+        packages.default = flake.packages."pureclaw:exe:pureclaw";
+        inherit pkgs;
+      }
+    );
   nixConfig = {
     extra-substituters = [
       # IOG binary cache — covers haskell.nix + most Haskell packages

--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -150,6 +150,7 @@ runAgentLoopWith env initialMessages = do
             mAction <- atomicModifyIORef' (_env_onFirstStreamDone env)
                          (Nothing,)
             for_ mAction id
+          StreamWarning w -> _lh_logWarn logger w
           _ -> pure ()
       case providerResult of
         Left e -> do

--- a/src/PureClaw/Providers/Anthropic.hs
+++ b/src/PureClaw/Providers/Anthropic.hs
@@ -12,14 +12,17 @@ module PureClaw.Providers.Anthropic
   , decodeResponse
     -- * SSE parsing (exported for testing)
   , parseSSELine
+  , splitSSELines
     -- * Stream accumulation (exported for testing)
   , StreamState
-  , newStreamState
+  , initialStreamState
+  , runStreamLine
   , processStreamLine
-  , finalizeStream
+  , finalizeStreamState
   ) where
 
 import Control.Exception
+import Control.Monad (foldM)
 import Data.Aeson
 import Data.Aeson.Types
 import Data.ByteString (ByteString)
@@ -130,11 +133,16 @@ anthropicComplete provider req = do
 
 -- | Encode a completion request as JSON for the Anthropic API.
 encodeRequest :: CompletionRequest -> BL.ByteString
-encodeRequest req = encode $ object $
+encodeRequest = encodeRequestWith False
+
+-- | Internal: shared encoder for streaming and non-streaming requests.
+encodeRequestWith :: Bool -> CompletionRequest -> BL.ByteString
+encodeRequestWith stream req = encode $ object $
   [ "model"      .= unModelId (_cr_model req)
   , "max_tokens" .= fromMaybe 4096 (_cr_maxTokens req)
   , "messages"   .= map encodeMsg (_cr_messages req)
   ]
+  ++ ["stream" .= True | stream]
   ++ maybe [] (\s -> ["system" .= s]) (_cr_systemPrompt req)
   ++ if null (_cr_tools req)
      then maybe [] (\tc -> ["tool_choice" .= encodeToolChoice tc]) (_cr_toolChoice req)
@@ -232,17 +240,7 @@ decodeResponse bs = eitherDecode bs >>= parseEither parseResp
 
 -- | Encode a streaming completion request (adds "stream": true).
 encodeStreamRequest :: CompletionRequest -> BL.ByteString
-encodeStreamRequest req = encode $ object $
-  [ "model"      .= unModelId (_cr_model req)
-  , "max_tokens" .= fromMaybe 4096 (_cr_maxTokens req)
-  , "messages"   .= map encodeMsg (_cr_messages req)
-  , "stream"     .= True
-  ]
-  ++ maybe [] (\s -> ["system" .= s]) (_cr_systemPrompt req)
-  ++ if null (_cr_tools req)
-     then maybe [] (\tc -> ["tool_choice" .= encodeToolChoice tc]) (_cr_toolChoice req)
-     else ("tools" .= map encodeTool (_cr_tools req))
-        : maybe [] (\tc -> ["tool_choice" .= encodeToolChoice tc]) (_cr_toolChoice req)
+encodeStreamRequest = encodeRequestWith True
 
 -- | Stream a completion from the Anthropic API.
 -- Processes SSE events and emits StreamEvent callbacks. Accumulates
@@ -262,42 +260,47 @@ anthropicCompleteStream provider req callback = do
       then do
         body <- BL.toStrict <$> HTTP.brReadSome (HTTP.responseBody resp) (1024 * 1024)
         throwIO (AnthropicAPIError status body)
-      else do
-        st <- newStreamState
-        bufRef <- newIORef BS.empty
-        let readChunks = do
-              chunk <- HTTP.brRead (HTTP.responseBody resp)
+      else
+        let body = HTTP.responseBody resp
+            go st buf = do
+              chunk <- HTTP.brRead body
               if BS.null chunk
-                then do
-                  finalResp <- finalizeStream st
-                  callback (StreamDone finalResp)
+                then callback (StreamDone (finalizeStreamState st))
                 else do
-                  buf <- readIORef bufRef
-                  let fullBuf = buf <> chunk
-                      (lines', remaining) = splitSSELines fullBuf
-                  writeIORef bufRef remaining
-                  mapM_ (processStreamLine st callback) lines'
-                  readChunks
-        readChunks
+                  let (lines', remaining) = splitSSELines (buf <> chunk)
+                  st' <- foldM (processStreamLine callback) st lines'
+                  go st' remaining
+        in go initialStreamState BS.empty
 
 -- | Split a buffer into complete SSE lines and remaining partial data.
+-- Strips a trailing CR from each complete line so CRLF-delimited
+-- streams parse identically to LF-delimited ones.
+--
+-- The last element of 'BS.split' is everything after the final newline
+-- (possibly empty) — that becomes the carry-forward partial line. The
+-- preceding elements are complete lines.
 splitSSELines :: ByteString -> ([ByteString], ByteString)
-splitSSELines bs =
-  let parts = BS.splitWith (== 0x0a) bs  -- split on newline
-  in case parts of
-    [] -> ([], BS.empty)
-    _ -> (init parts, last parts)
+splitSSELines bs = go [] (BS.split 0x0a bs)
+  where
+    go acc []     = (reverse acc, BS.empty)
+    go acc [tl]   = (reverse acc, tl)
+    go acc (l:ls) = go (stripCR l : acc) ls
+    stripCR b = case BS.unsnoc b of
+      Just (rest, 0x0d) -> rest
+      _                 -> b
 
--- | Mutable accumulator for streaming SSE responses. Tracks the
--- evolving list of content blocks, the model id, usage stats, and any
--- tool_use block currently being assembled (whose JSON input arrives
--- across multiple deltas).
+-- | Pure accumulator for streaming SSE responses. Tracks the evolving
+-- list of content blocks, the model id, token counts (which arrive in
+-- separate events), and any tool_use block currently being assembled
+-- (whose JSON input arrives across multiple deltas).
 data StreamState = StreamState
-  { _ss_blocksRef :: IORef [ContentBlock]   -- ^ Reversed: head is most-recent block
-  , _ss_modelRef  :: IORef ModelId
-  , _ss_usageRef  :: IORef (Maybe Usage)
-  , _ss_toolRef   :: IORef (Maybe ToolBuilder)
+  { _ss_blocks       :: [ContentBlock]    -- ^ Reversed: head is most-recent block
+  , _ss_model        :: ModelId
+  , _ss_inputTokens  :: Maybe Int         -- ^ From @message_start@
+  , _ss_outputTokens :: Maybe Int         -- ^ From @message_delta@
+  , _ss_tool         :: Maybe ToolBuilder
   }
+  deriving stock (Show, Eq)
 
 -- | A tool_use block being assembled mid-stream. Inputs arrive as
 -- a sequence of @input_json_delta@ fragments which must be concatenated
@@ -307,86 +310,97 @@ data ToolBuilder = ToolBuilder
   , _tb_name  :: Text
   , _tb_input :: ByteString
   }
+  deriving stock (Show, Eq)
 
-newStreamState :: IO StreamState
-newStreamState = StreamState
-  <$> newIORef []
-  <*> newIORef (ModelId "")
-  <*> newIORef Nothing
-  <*> newIORef Nothing
+-- | Initial state at the start of a stream.
+initialStreamState :: StreamState
+initialStreamState = StreamState [] (ModelId "") Nothing Nothing Nothing
 
--- | Process a single SSE 'data:' line, updating state and emitting
--- 'StreamEvent' callbacks. Non-data lines, unparseable JSON, and
--- unknown event types are silently ignored.
-processStreamLine :: StreamState -> (StreamEvent -> IO ()) -> ByteString -> IO ()
-processStreamLine st callback line =
-  case parseSSELine line of
-    Nothing -> pure ()
-    Just json -> case parseEither parseStreamEvent json of
-      Left _ -> pure ()
-      Right evt -> case evt of
-        SSEContentText t -> do
-          callback (StreamText t)
-          -- Accumulate streamed text into a single TextBlock rather than
-          -- creating one per chunk (which would insert spurious newlines
-          -- when responseText joins them with "\n").
-          modifyIORef (_ss_blocksRef st) $ \blocks -> case blocks of
-            (TextBlock prev : rest) -> TextBlock (prev <> t) : rest
-            _                       -> TextBlock t : blocks
-        SSEToolStart callId name -> do
-          -- Defensive: close any tool that didn't get an explicit stop.
-          finalizeCurrentTool st
-          writeIORef (_ss_toolRef st)
-            (Just (ToolBuilder callId name BS.empty))
-          callback (StreamToolUse callId name)
-        SSEToolDelta t -> do
-          modifyIORef (_ss_toolRef st) $ fmap $ \tb ->
-            tb { _tb_input = _tb_input tb <> TE.encodeUtf8 t }
-          callback (StreamToolInput t)
-        SSEContentBlockStop -> finalizeCurrentTool st
-        SSEMessageStart model -> writeIORef (_ss_modelRef st) model
-        SSEUsage usage -> writeIORef (_ss_usageRef st) (Just usage)
-        SSEMessageStop -> pure ()
+-- | Pure step: apply one parsed SSE event to the state and return any
+-- 'StreamEvent's that should be emitted to the caller's callback.
+stepStreamState :: SSEEvent -> StreamState -> (StreamState, [StreamEvent])
+stepStreamState evt st = case evt of
+  SSEContentText t ->
+    -- Accumulate streamed text into a single TextBlock rather than
+    -- creating one per chunk (which would insert spurious newlines
+    -- when 'responseText' joins them with "\n").
+    let blocks' = case _ss_blocks st of
+          (TextBlock prev : rest) -> TextBlock (prev <> t) : rest
+          _                       -> TextBlock t : _ss_blocks st
+    in (st { _ss_blocks = blocks' }, [StreamText t])
+  SSEToolStart callId name ->
+    -- Defensive: close any tool that didn't get an explicit stop.
+    let st' = closeOpenTool st
+    in (st' { _ss_tool = Just (ToolBuilder callId name BS.empty) },
+        [StreamToolUse callId name])
+  SSEToolDelta t ->
+    let st' = st { _ss_tool = fmap (appendToolInput t) (_ss_tool st) }
+    in (st', [StreamToolInput t])
+  SSEContentBlockStop -> (closeOpenTool st, [])
+  SSEMessageStart model mInTokens ->
+    (st { _ss_model = model, _ss_inputTokens = mInTokens }, [])
+  SSEOutputUsage outToks ->
+    (st { _ss_outputTokens = Just outToks }, [])
+  SSEMessageStop -> (st, [])
 
--- | Close out any in-progress tool_use block: parse the accumulated
--- JSON input and push the completed 'ToolUseBlock' onto blocks.
--- A malformed or empty buffer falls back to an empty object so the
--- block isn't lost — downstream tool execution will surface any
+appendToolInput :: Text -> ToolBuilder -> ToolBuilder
+appendToolInput t tb = tb { _tb_input = _tb_input tb <> TE.encodeUtf8 t }
+
+-- | Close the in-progress tool block (if any), parsing its accumulated
+-- JSON input. A malformed or empty buffer falls back to 'object []' so
+-- the block isn't lost — downstream tool execution will surface any
 -- schema mismatch as a normal tool error.
-finalizeCurrentTool :: StreamState -> IO ()
-finalizeCurrentTool st = do
-  mTool <- readIORef (_ss_toolRef st)
-  case mTool of
-    Nothing -> pure ()
-    Just tb -> do
-      let input = case decode (BL.fromStrict (_tb_input tb)) of
-            Just v  -> v
-            Nothing -> object []
-      modifyIORef (_ss_blocksRef st)
-        (ToolUseBlock (_tb_id tb) (_tb_name tb) input :)
-      writeIORef (_ss_toolRef st) Nothing
+closeOpenTool :: StreamState -> StreamState
+closeOpenTool st = case _ss_tool st of
+  Nothing -> st
+  Just tb ->
+    let input = fromMaybe (object []) (decode (BL.fromStrict (_tb_input tb)))
+        block = ToolUseBlock (_tb_id tb) (_tb_name tb) input
+    in st { _ss_blocks = block : _ss_blocks st, _ss_tool = Nothing }
+
+-- | Pure: parse a single SSE line and step the state. Non-data lines,
+-- unparseable JSON, and unknown event types yield no state change and
+-- no events.
+runStreamLine :: ByteString -> StreamState -> (StreamState, [StreamEvent])
+runStreamLine line st = case parseSSELine line of
+  Nothing   -> (st, [])
+  Just json -> case parseEither parseStreamEvent json of
+    Left _    -> (st, [])
+    Right evt -> stepStreamState evt st
+
+-- | IO wrapper around 'runStreamLine': step the state, emit any
+-- resulting 'StreamEvent's via the callback.
+processStreamLine :: (StreamEvent -> IO ()) -> StreamState -> ByteString -> IO StreamState
+processStreamLine cb st line = do
+  let (st', evs) = runStreamLine line st
+  mapM_ cb evs
+  pure st'
 
 -- | Finalize the accumulator into a 'CompletionResponse'. Any
--- still-open tool block is closed defensively.
-finalizeStream :: StreamState -> IO CompletionResponse
-finalizeStream st = do
-  finalizeCurrentTool st
-  blocks <- readIORef (_ss_blocksRef st)
-  model  <- readIORef (_ss_modelRef st)
-  usage  <- readIORef (_ss_usageRef st)
-  pure CompletionResponse
-    { _crsp_content = reverse blocks
-    , _crsp_model   = model
-    , _crsp_usage   = usage
-    }
+-- still-open tool block is closed defensively. Usage is reported only
+-- if at least one of input/output tokens was observed.
+finalizeStreamState :: StreamState -> CompletionResponse
+finalizeStreamState st0 =
+  let st = closeOpenTool st0
+      mUsage = case (_ss_inputTokens st, _ss_outputTokens st) of
+        (Nothing, Nothing) -> Nothing
+        (mi, mo)           -> Just (Usage (fromMaybe 0 mi) (fromMaybe 0 mo))
+  in CompletionResponse
+       { _crsp_content = reverse (_ss_blocks st)
+       , _crsp_model   = _ss_model st
+       , _crsp_usage   = mUsage
+       }
 
--- | Parse an SSE "data: ..." line into a JSON value.
+-- | Parse an SSE "data: ..." line into a JSON value. Tolerates a
+-- trailing CR for callers that didn't pre-strip CRLF.
 parseSSELine :: ByteString -> Maybe Value
-parseSSELine bs
-  | BS.isPrefixOf "data: " bs =
-      let jsonBs = BS.drop 6 bs
-      in decode (BL.fromStrict jsonBs)
-  | otherwise = Nothing
+parseSSELine bs0
+  | BS.isPrefixOf "data: " bs = decode (BL.fromStrict (BS.drop 6 bs))
+  | otherwise                 = Nothing
+  where
+    bs = case BS.unsnoc bs0 of
+      Just (rest, 0x0d) -> rest
+      _                 -> bs0
 
 -- | Internal SSE event types.
 data SSEEvent
@@ -394,9 +408,10 @@ data SSEEvent
   | SSEToolStart ToolCallId Text
   | SSEToolDelta Text
   | SSEContentBlockStop
-  | SSEMessageStart ModelId
-  | SSEUsage Usage
+  | SSEMessageStart ModelId (Maybe Int)  -- ^ model, input_tokens (if present)
+  | SSEOutputUsage Int                   -- ^ output_tokens from @message_delta@
   | SSEMessageStop
+  deriving stock (Show, Eq)
 
 -- | Parse a JSON SSE event.
 parseStreamEvent :: Value -> Parser SSEEvent
@@ -404,9 +419,13 @@ parseStreamEvent = withObject "SSEEvent" $ \o -> do
   eventType <- o .: "type"
   case (eventType :: Text) of
     "message_start" -> do
-      msg <- o .: "message"
-      model <- msg .: "model"
-      pure (SSEMessageStart (ModelId model))
+      msg     <- o .: "message"
+      model   <- msg .: "model"
+      mUsage  <- msg .:? "usage"
+      mInToks <- case mUsage of
+        Nothing -> pure Nothing
+        Just u  -> u .:? "input_tokens"
+      pure (SSEMessageStart (ModelId model) mInToks)
     "content_block_delta" -> do
       delta <- o .: "delta"
       deltaType <- delta .: "type"
@@ -427,9 +446,7 @@ parseStreamEvent = withObject "SSEEvent" $ \o -> do
     "message_delta" -> do
       usage <- o .:? "usage"
       case usage of
-        Just u -> do
-          outToks <- u .: "output_tokens"
-          pure (SSEUsage (Usage 0 outToks))
+        Just u  -> SSEOutputUsage <$> u .: "output_tokens"
         Nothing -> pure SSEMessageStop
     "message_stop" -> pure SSEMessageStop
     _ -> fail $ "Unknown event type: " <> T.unpack eventType

--- a/src/PureClaw/Providers/Anthropic.hs
+++ b/src/PureClaw/Providers/Anthropic.hs
@@ -265,7 +265,10 @@ anthropicCompleteStream provider req callback = do
             go st buf = do
               chunk <- HTTP.brRead body
               if BS.null chunk
-                then callback (StreamDone (finalizeStreamState st))
+                then do
+                  let (final, finalEvs) = finalizeStreamState st
+                  mapM_ callback finalEvs
+                  callback (StreamDone final)
                 else do
                   let (lines', remaining) = splitSSELines (buf <> chunk)
                   st' <- foldM (processStreamLine callback) st lines'
@@ -330,18 +333,27 @@ stepStreamState evt st = case evt of
     in (st { _ss_blocks = blocks' }, [StreamText t])
   SSEToolStart callId name ->
     -- Defensive: close any tool that didn't get an explicit stop.
-    let st' = closeOpenTool st
+    let (st', mWarn) = closeOpenTool st
     in (st' { _ss_tool = Just (ToolBuilder callId name BS.empty) },
-        [StreamToolUse callId name])
+        warningEvents mWarn ++ [StreamToolUse callId name])
   SSEToolDelta t ->
     let st' = st { _ss_tool = fmap (appendToolInput t) (_ss_tool st) }
     in (st', [StreamToolInput t])
-  SSEContentBlockStop -> (closeOpenTool st, [])
+  SSEContentBlockStop ->
+    let (st', mWarn) = closeOpenTool st
+    in (st', warningEvents mWarn)
   SSEMessageStart model mInTokens ->
+    -- 'message_start' carries an initial @output_tokens: 1@ that we
+    -- intentionally drop: the authoritative output_tokens count arrives
+    -- in 'message_delta' at end-of-stream, and overwriting it here would
+    -- only confuse the accumulator.
     (st { _ss_model = model, _ss_inputTokens = mInTokens }, [])
   SSEOutputUsage outToks ->
     (st { _ss_outputTokens = Just outToks }, [])
   SSEMessageStop -> (st, [])
+
+warningEvents :: Maybe Text -> [StreamEvent]
+warningEvents = maybe [] (\t -> [StreamWarning t])
 
 appendToolInput :: Text -> ToolBuilder -> ToolBuilder
 appendToolInput t tb = tb { _tb_input = _tb_input tb <> TE.encodeUtf8 t }
@@ -349,14 +361,25 @@ appendToolInput t tb = tb { _tb_input = _tb_input tb <> TE.encodeUtf8 t }
 -- | Close the in-progress tool block (if any), parsing its accumulated
 -- JSON input. A malformed or empty buffer falls back to 'object []' so
 -- the block isn't lost — downstream tool execution will surface any
--- schema mismatch as a normal tool error.
-closeOpenTool :: StreamState -> StreamState
+-- schema mismatch as a normal tool error. The second component is a
+-- diagnostic warning carrying the tool name and id so callers can log
+-- it; otherwise a broken stream looks like a valid call with no args.
+closeOpenTool :: StreamState -> (StreamState, Maybe Text)
 closeOpenTool st = case _ss_tool st of
-  Nothing -> st
+  Nothing -> (st, Nothing)
   Just tb ->
-    let input = fromMaybe (object []) (decode (BL.fromStrict (_tb_input tb)))
-        block = ToolUseBlock (_tb_id tb) (_tb_name tb) input
-    in st { _ss_blocks = block : _ss_blocks st, _ss_tool = Nothing }
+    let mParsed = decode (BL.fromStrict (_tb_input tb))
+        input   = fromMaybe (object []) mParsed
+        block   = ToolUseBlock (_tb_id tb) (_tb_name tb) input
+        st'     = st { _ss_blocks = block : _ss_blocks st, _ss_tool = Nothing }
+        mWarn   = case mParsed of
+          Just _  -> Nothing
+          Nothing -> Just $
+            "Anthropic stream: malformed tool input JSON for tool "
+              <> _tb_name tb
+              <> " (id=" <> unToolCallId (_tb_id tb)
+              <> "); falling back to empty object"
+    in (st', mWarn)
 
 -- | Pure: parse a single SSE line and step the state. Non-data lines,
 -- unparseable JSON, and unknown event types yield no state change and
@@ -377,19 +400,21 @@ processStreamLine cb st line = do
   pure st'
 
 -- | Finalize the accumulator into a 'CompletionResponse'. Any
--- still-open tool block is closed defensively. Usage is reported only
+-- still-open tool block is closed defensively (yielding an optional
+-- warning to be emitted before 'StreamDone'). Usage is reported only
 -- if at least one of input/output tokens was observed.
-finalizeStreamState :: StreamState -> CompletionResponse
+finalizeStreamState :: StreamState -> (CompletionResponse, [StreamEvent])
 finalizeStreamState st0 =
-  let st = closeOpenTool st0
+  let (st, mWarn) = closeOpenTool st0
       mUsage = case (_ss_inputTokens st, _ss_outputTokens st) of
         (Nothing, Nothing) -> Nothing
         (mi, mo)           -> Just (Usage (fromMaybe 0 mi) (fromMaybe 0 mo))
-  in CompletionResponse
-       { _crsp_content = reverse (_ss_blocks st)
-       , _crsp_model   = _ss_model st
-       , _crsp_usage   = mUsage
-       }
+      resp = CompletionResponse
+        { _crsp_content = reverse (_ss_blocks st)
+        , _crsp_model   = _ss_model st
+        , _crsp_usage   = mUsage
+        }
+  in (resp, warningEvents mWarn)
 
 -- | Parse an SSE "data: ..." line into a JSON value. Tolerates a
 -- trailing CR for callers that didn't pre-strip CRLF.

--- a/src/PureClaw/Providers/Anthropic.hs
+++ b/src/PureClaw/Providers/Anthropic.hs
@@ -12,6 +12,11 @@ module PureClaw.Providers.Anthropic
   , decodeResponse
     -- * SSE parsing (exported for testing)
   , parseSSELine
+    -- * Stream accumulation (exported for testing)
+  , StreamState
+  , newStreamState
+  , processStreamLine
+  , finalizeStream
   ) where
 
 import Control.Exception
@@ -258,30 +263,20 @@ anthropicCompleteStream provider req callback = do
         body <- BL.toStrict <$> HTTP.brReadSome (HTTP.responseBody resp) (1024 * 1024)
         throwIO (AnthropicAPIError status body)
       else do
-        -- Accumulate content blocks and usage as events arrive
-        blocksRef <- newIORef ([] :: [ContentBlock])
-        modelRef <- newIORef (ModelId "")
-        usageRef <- newIORef (Nothing :: Maybe Usage)
+        st <- newStreamState
         bufRef <- newIORef BS.empty
         let readChunks = do
               chunk <- HTTP.brRead (HTTP.responseBody resp)
               if BS.null chunk
                 then do
-                  -- Stream ended — emit final response
-                  blocks <- readIORef blocksRef
-                  model <- readIORef modelRef
-                  usage <- readIORef usageRef
-                  callback $ StreamDone CompletionResponse
-                    { _crsp_content = reverse blocks
-                    , _crsp_model   = model
-                    , _crsp_usage   = usage
-                    }
+                  finalResp <- finalizeStream st
+                  callback (StreamDone finalResp)
                 else do
                   buf <- readIORef bufRef
                   let fullBuf = buf <> chunk
                       (lines', remaining) = splitSSELines fullBuf
                   writeIORef bufRef remaining
-                  mapM_ (processSSELine blocksRef modelRef usageRef callback) lines'
+                  mapM_ (processStreamLine st callback) lines'
                   readChunks
         readChunks
 
@@ -293,9 +288,38 @@ splitSSELines bs =
     [] -> ([], BS.empty)
     _ -> (init parts, last parts)
 
--- | Process a single SSE line.
-processSSELine :: IORef [ContentBlock] -> IORef ModelId -> IORef (Maybe Usage) -> (StreamEvent -> IO ()) -> ByteString -> IO ()
-processSSELine blocksRef modelRef usageRef callback line =
+-- | Mutable accumulator for streaming SSE responses. Tracks the
+-- evolving list of content blocks, the model id, usage stats, and any
+-- tool_use block currently being assembled (whose JSON input arrives
+-- across multiple deltas).
+data StreamState = StreamState
+  { _ss_blocksRef :: IORef [ContentBlock]   -- ^ Reversed: head is most-recent block
+  , _ss_modelRef  :: IORef ModelId
+  , _ss_usageRef  :: IORef (Maybe Usage)
+  , _ss_toolRef   :: IORef (Maybe ToolBuilder)
+  }
+
+-- | A tool_use block being assembled mid-stream. Inputs arrive as
+-- a sequence of @input_json_delta@ fragments which must be concatenated
+-- and parsed once @content_block_stop@ closes the block.
+data ToolBuilder = ToolBuilder
+  { _tb_id    :: ToolCallId
+  , _tb_name  :: Text
+  , _tb_input :: ByteString
+  }
+
+newStreamState :: IO StreamState
+newStreamState = StreamState
+  <$> newIORef []
+  <*> newIORef (ModelId "")
+  <*> newIORef Nothing
+  <*> newIORef Nothing
+
+-- | Process a single SSE 'data:' line, updating state and emitting
+-- 'StreamEvent' callbacks. Non-data lines, unparseable JSON, and
+-- unknown event types are silently ignored.
+processStreamLine :: StreamState -> (StreamEvent -> IO ()) -> ByteString -> IO ()
+processStreamLine st callback line =
   case parseSSELine line of
     Nothing -> pure ()
     Just json -> case parseEither parseStreamEvent json of
@@ -306,16 +330,55 @@ processSSELine blocksRef modelRef usageRef callback line =
           -- Accumulate streamed text into a single TextBlock rather than
           -- creating one per chunk (which would insert spurious newlines
           -- when responseText joins them with "\n").
-          modifyIORef blocksRef $ \blocks -> case blocks of
+          modifyIORef (_ss_blocksRef st) $ \blocks -> case blocks of
             (TextBlock prev : rest) -> TextBlock (prev <> t) : rest
             _                       -> TextBlock t : blocks
-        SSEToolStart callId name ->
+        SSEToolStart callId name -> do
+          -- Defensive: close any tool that didn't get an explicit stop.
+          finalizeCurrentTool st
+          writeIORef (_ss_toolRef st)
+            (Just (ToolBuilder callId name BS.empty))
           callback (StreamToolUse callId name)
-        SSEToolDelta t ->
+        SSEToolDelta t -> do
+          modifyIORef (_ss_toolRef st) $ fmap $ \tb ->
+            tb { _tb_input = _tb_input tb <> TE.encodeUtf8 t }
           callback (StreamToolInput t)
-        SSEMessageStart model -> writeIORef modelRef model
-        SSEUsage usage -> writeIORef usageRef (Just usage)
+        SSEContentBlockStop -> finalizeCurrentTool st
+        SSEMessageStart model -> writeIORef (_ss_modelRef st) model
+        SSEUsage usage -> writeIORef (_ss_usageRef st) (Just usage)
         SSEMessageStop -> pure ()
+
+-- | Close out any in-progress tool_use block: parse the accumulated
+-- JSON input and push the completed 'ToolUseBlock' onto blocks.
+-- A malformed or empty buffer falls back to an empty object so the
+-- block isn't lost — downstream tool execution will surface any
+-- schema mismatch as a normal tool error.
+finalizeCurrentTool :: StreamState -> IO ()
+finalizeCurrentTool st = do
+  mTool <- readIORef (_ss_toolRef st)
+  case mTool of
+    Nothing -> pure ()
+    Just tb -> do
+      let input = case decode (BL.fromStrict (_tb_input tb)) of
+            Just v  -> v
+            Nothing -> object []
+      modifyIORef (_ss_blocksRef st)
+        (ToolUseBlock (_tb_id tb) (_tb_name tb) input :)
+      writeIORef (_ss_toolRef st) Nothing
+
+-- | Finalize the accumulator into a 'CompletionResponse'. Any
+-- still-open tool block is closed defensively.
+finalizeStream :: StreamState -> IO CompletionResponse
+finalizeStream st = do
+  finalizeCurrentTool st
+  blocks <- readIORef (_ss_blocksRef st)
+  model  <- readIORef (_ss_modelRef st)
+  usage  <- readIORef (_ss_usageRef st)
+  pure CompletionResponse
+    { _crsp_content = reverse blocks
+    , _crsp_model   = model
+    , _crsp_usage   = usage
+    }
 
 -- | Parse an SSE "data: ..." line into a JSON value.
 parseSSELine :: ByteString -> Maybe Value
@@ -330,6 +393,7 @@ data SSEEvent
   = SSEContentText Text
   | SSEToolStart ToolCallId Text
   | SSEToolDelta Text
+  | SSEContentBlockStop
   | SSEMessageStart ModelId
   | SSEUsage Usage
   | SSEMessageStop
@@ -359,6 +423,7 @@ parseStreamEvent = withObject "SSEEvent" $ \o -> do
           name <- block .: "name"
           pure (SSEToolStart (ToolCallId callId) name)
         _ -> fail "Ignored block start"
+    "content_block_stop" -> pure SSEContentBlockStop
     "message_delta" -> do
       usage <- o .:? "usage"
       case usage of

--- a/src/PureClaw/Providers/Class.hs
+++ b/src/PureClaw/Providers/Class.hs
@@ -155,6 +155,7 @@ data StreamEvent
   = StreamText Text                -- ^ Partial text content
   | StreamToolUse ToolCallId Text  -- ^ Tool call started (id, name)
   | StreamToolInput Text           -- ^ Partial tool input JSON
+  | StreamWarning Text             -- ^ Non-fatal provider-side anomaly (e.g. malformed tool input recovered via fallback). Surfaced so callers can log it.
   | StreamDone CompletionResponse  -- ^ Stream finished with full response
   deriving stock (Show, Eq)
 
@@ -310,6 +311,8 @@ instance ToJSON StreamEvent where
     [ "type" .= ("tool_use" :: Text), "id" .= unToolCallId cid, "name" .= name ]
   toJSON (StreamToolInput t)     = Aeson.object
     [ "type" .= ("tool_input" :: Text), "input" .= t ]
+  toJSON (StreamWarning t)       = Aeson.object
+    [ "type" .= ("warning" :: Text), "message" .= t ]
   toJSON (StreamDone resp)       = Aeson.object
     [ "type" .= ("done" :: Text), "response" .= resp ]
 
@@ -320,6 +323,7 @@ instance FromJSON StreamEvent where
       "text"       -> StreamText <$> o .: "text"
       "tool_use"   -> (StreamToolUse . ToolCallId <$> (o .: "id")) <*> o .: "name"
       "tool_input" -> StreamToolInput <$> o .: "input"
+      "warning"    -> StreamWarning <$> o .: "message"
       "done"       -> StreamDone <$> o .: "response"
       _            -> fail ("unknown StreamEvent type: " <> T.unpack tag)
 

--- a/test/Providers/AnthropicSpec.hs
+++ b/test/Providers/AnthropicSpec.hs
@@ -1,8 +1,10 @@
 module Providers.AnthropicSpec (spec) where
 
+import Control.Monad (foldM_)
 import Data.Aeson
 import Data.Aeson.KeyMap qualified as KM
 import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Either (isLeft)
 import Data.IORef
@@ -208,10 +210,8 @@ spec = do
 
   describe "stream accumulation" $ do
     it "accumulates a tool_use block from streamed events" $ do
-      st <- newStreamState
-      mapM_ (processStreamLine st (\_ -> pure ())) toolOnlyStream
-      resp <- finalizeStream st
-      let calls = toolUseCalls resp
+      let resp = runStream toolOnlyStream
+          calls = toolUseCalls resp
       length calls `shouldBe` 1
       case calls of
         [(_, name, input)] -> do
@@ -223,32 +223,55 @@ spec = do
         _ -> expectationFailure "expected exactly one tool call"
 
     it "preserves text and tool blocks in stream order" $ do
-      st <- newStreamState
-      mapM_ (processStreamLine st (\_ -> pure ())) mixedStream
-      resp <- finalizeStream st
+      let resp = runStream mixedStream
       responseText resp `shouldBe` "Let me create the file."
       length (toolUseCalls resp) `shouldBe` 1
 
     it "accumulates multiple sequential tool blocks" $ do
-      st <- newStreamState
-      mapM_ (processStreamLine st (\_ -> pure ())) twoToolsStream
-      resp <- finalizeStream st
-      length (toolUseCalls resp) `shouldBe` 2
+      length (toolUseCalls (runStream twoToolsStream)) `shouldBe` 2
 
     it "emits StreamToolUse and StreamToolInput callbacks" $ do
-      st <- newStreamState
       eventsRef <- newIORef ([] :: [StreamEvent])
       let cb e = modifyIORef eventsRef (e :)
-      mapM_ (processStreamLine st cb) toolOnlyStream
+      foldM_ (processStreamLine cb) initialStreamState toolOnlyStream
       events <- reverse <$> readIORef eventsRef
       events `shouldSatisfy` any isToolUseEvent
       events `shouldSatisfy` any isToolInputEvent
 
-    it "captures the final usage record" $ do
-      st <- newStreamState
-      mapM_ (processStreamLine st (\_ -> pure ())) toolOnlyStream
-      resp <- finalizeStream st
-      _crsp_usage resp `shouldBe` Just (Usage 0 7)
+    it "captures both input and output token counts" $ do
+      -- Regression: streaming used to hard-code input_tokens=0 because
+      -- the parser only looked at message_delta.usage.output_tokens
+      -- and ignored message_start.message.usage.input_tokens.
+      _crsp_usage (runStream toolOnlyStream) `shouldBe` Just (Usage 12 7)
+
+    it "reports Nothing for usage when no token events arrive" $ do
+      _crsp_usage (runStream noUsageStream) `shouldBe` Nothing
+
+    it "tolerates CRLF line endings" $
+      let crlf = map (<> "\r") toolOnlyStream
+      in length (toolUseCalls (runStream crlf)) `shouldBe` 1
+
+    it "reassembles SSE events split across network chunks" $ do
+      -- Concat the canned stream into one buffer (with newlines) and
+      -- feed it through splitSSELines two bytes at a time, simulating
+      -- a server that fragments mid-line. Output must equal the
+      -- whole-stream parse.
+      let joined  = BS.intercalate "\n" toolOnlyStream <> "\n"
+          chunks  = chunkBy 2 joined
+          drive (st, buf) chunk =
+            let (ls, rest) = splitSSELines (buf <> chunk)
+            in (foldl (\s l -> fst (runStreamLine l s)) st ls, rest)
+          (final, _) = foldl drive (initialStreamState, BS.empty) chunks
+          resp = finalizeStreamState final
+      length (toolUseCalls resp) `shouldBe` 1
+      _crsp_usage resp `shouldBe` Just (Usage 12 7)
+
+    it "falls back to empty object on malformed tool input JSON" $ do
+      -- Documents the silent-fallback behavior so a future change has
+      -- to break this test deliberately.
+      case toolUseCalls (runStream malformedToolStream) of
+        [(_, _, input)] -> input `shouldBe` object []
+        _               -> expectationFailure "expected one tool call"
 
   describe "buildAuthHeaders (API key)" $ do
     it "uses x-api-key header for ApiKey auth" $ do
@@ -344,16 +367,51 @@ isToolInputEvent :: StreamEvent -> Bool
 isToolInputEvent (StreamToolInput _) = True
 isToolInputEvent _                   = False
 
+-- | Run a sequence of canned SSE lines through the pure stream pipeline
+-- and return the finalized completion response. No IO, no IORefs.
+runStream :: [ByteString] -> CompletionResponse
+runStream =
+  finalizeStreamState
+    . foldl' (\s line -> fst (runStreamLine line s)) initialStreamState
+
+-- | Split a ByteString into fixed-size chunks (last chunk may be smaller).
+chunkBy :: Int -> ByteString -> [ByteString]
+chunkBy n bs
+  | BS.null bs = []
+  | otherwise  = let (h, t) = BS.splitAt n bs in h : chunkBy n t
+
 -- | Realistic Anthropic SSE stream containing a single tool_use block
 -- whose JSON input is split across two partial_json deltas.
 toolOnlyStream :: [ByteString]
 toolOnlyStream =
-  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"content\":[]}}"
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"content\":[],\"usage\":{\"input_tokens\":12,\"output_tokens\":1}}}"
   , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"file_write\"}}"
   , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\"}}"
   , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"/tmp/test.txt\\\",\\\"content\\\":\\\"Hello\\\"}\"}}"
   , "data: {\"type\":\"content_block_stop\",\"index\":0}"
   , "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":7}}"
+  , "data: {\"type\":\"message_stop\"}"
+  ]
+
+-- | A stream with no message_start usage and no message_delta usage —
+-- exercises the @Nothing@ branch of finalize.
+noUsageStream :: [ByteString]
+noUsageStream =
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"m\",\"content\":[]}}"
+  , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":0}"
+  , "data: {\"type\":\"message_stop\"}"
+  ]
+
+-- | A stream where the tool_use input JSON is malformed — exercises
+-- the documented empty-object fallback.
+malformedToolStream :: [ByteString]
+malformedToolStream =
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"m\",\"content\":[]}}"
+  , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"file_write\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{not valid json\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":0}"
   , "data: {\"type\":\"message_stop\"}"
   ]
 

--- a/test/Providers/AnthropicSpec.hs
+++ b/test/Providers/AnthropicSpec.hs
@@ -9,6 +9,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Either (isLeft)
 import Data.IORef
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime (..), addUTCTime)
 import Network.HTTP.Client.TLS qualified as TLS
@@ -262,7 +263,7 @@ spec = do
             let (ls, rest) = splitSSELines (buf <> chunk)
             in (foldl (\s l -> fst (runStreamLine l s)) st ls, rest)
           (final, _) = foldl drive (initialStreamState, BS.empty) chunks
-          resp = finalizeStreamState final
+          (resp, _) = finalizeStreamState final
       length (toolUseCalls resp) `shouldBe` 1
       _crsp_usage resp `shouldBe` Just (Usage 12 7)
 
@@ -272,6 +273,23 @@ spec = do
       case toolUseCalls (runStream malformedToolStream) of
         [(_, _, input)] -> input `shouldBe` object []
         _               -> expectationFailure "expected one tool call"
+
+    it "emits a StreamWarning when tool input JSON is malformed" $ do
+      -- A silent fallback to empty input would let the agent loop run a
+      -- tool call with bogus arguments and produce a confusing schema
+      -- error. The warning carries the tool name and id so operators can
+      -- correlate the failure with the request.
+      eventsRef <- newIORef ([] :: [StreamEvent])
+      let cb e = modifyIORef eventsRef (e :)
+      foldM_ (processStreamLine cb) initialStreamState malformedToolStream
+      events <- reverse <$> readIORef eventsRef
+      let warnings = [t | StreamWarning t <- events]
+      length warnings `shouldBe` 1
+      case warnings of
+        [w] -> do
+          w `shouldSatisfy` (\t -> "toolu_01" `T.isInfixOf` t)
+          w `shouldSatisfy` (\t -> "file_write" `T.isInfixOf` t)
+        _   -> expectationFailure "expected exactly one warning"
 
   describe "buildAuthHeaders (API key)" $ do
     it "uses x-api-key header for ApiKey auth" $ do
@@ -371,7 +389,8 @@ isToolInputEvent _                   = False
 -- and return the finalized completion response. No IO, no IORefs.
 runStream :: [ByteString] -> CompletionResponse
 runStream =
-  finalizeStreamState
+  fst
+    . finalizeStreamState
     . foldl' (\s line -> fst (runStreamLine line s)) initialStreamState
 
 -- | Split a ByteString into fixed-size chunks (last chunk may be smaller).

--- a/test/Providers/AnthropicSpec.hs
+++ b/test/Providers/AnthropicSpec.hs
@@ -2,9 +2,11 @@ module Providers.AnthropicSpec (spec) where
 
 import Data.Aeson
 import Data.Aeson.KeyMap qualified as KM
+import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.Either (isLeft)
 import Data.IORef
+import Data.Text (Text)
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime (..), addUTCTime)
 import Network.HTTP.Client.TLS qualified as TLS
@@ -204,6 +206,50 @@ spec = do
       let line = "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"content\":[]}}"
       parseSSELine line `shouldSatisfy` isJust
 
+  describe "stream accumulation" $ do
+    it "accumulates a tool_use block from streamed events" $ do
+      st <- newStreamState
+      mapM_ (processStreamLine st (\_ -> pure ())) toolOnlyStream
+      resp <- finalizeStream st
+      let calls = toolUseCalls resp
+      length calls `shouldBe` 1
+      case calls of
+        [(_, name, input)] -> do
+          name `shouldBe` "file_write"
+          input `shouldBe` object
+            [ "path"    .= ("/tmp/test.txt" :: Text)
+            , "content" .= ("Hello" :: Text)
+            ]
+        _ -> expectationFailure "expected exactly one tool call"
+
+    it "preserves text and tool blocks in stream order" $ do
+      st <- newStreamState
+      mapM_ (processStreamLine st (\_ -> pure ())) mixedStream
+      resp <- finalizeStream st
+      responseText resp `shouldBe` "Let me create the file."
+      length (toolUseCalls resp) `shouldBe` 1
+
+    it "accumulates multiple sequential tool blocks" $ do
+      st <- newStreamState
+      mapM_ (processStreamLine st (\_ -> pure ())) twoToolsStream
+      resp <- finalizeStream st
+      length (toolUseCalls resp) `shouldBe` 2
+
+    it "emits StreamToolUse and StreamToolInput callbacks" $ do
+      st <- newStreamState
+      eventsRef <- newIORef ([] :: [StreamEvent])
+      let cb e = modifyIORef eventsRef (e :)
+      mapM_ (processStreamLine st cb) toolOnlyStream
+      events <- reverse <$> readIORef eventsRef
+      events `shouldSatisfy` any isToolUseEvent
+      events `shouldSatisfy` any isToolInputEvent
+
+    it "captures the final usage record" $ do
+      st <- newStreamState
+      mapM_ (processStreamLine st (\_ -> pure ())) toolOnlyStream
+      resp <- finalizeStream st
+      _crsp_usage resp `shouldBe` Just (Usage 0 7)
+
   describe "buildAuthHeaders (API key)" $ do
     it "uses x-api-key header for ApiKey auth" $ do
       manager <- TLS.newTlsManager
@@ -289,4 +335,53 @@ hasKey _ _ = False
 isJust :: Maybe a -> Bool
 isJust (Just _) = True
 isJust Nothing = False
+
+isToolUseEvent :: StreamEvent -> Bool
+isToolUseEvent (StreamToolUse _ _) = True
+isToolUseEvent _                   = False
+
+isToolInputEvent :: StreamEvent -> Bool
+isToolInputEvent (StreamToolInput _) = True
+isToolInputEvent _                   = False
+
+-- | Realistic Anthropic SSE stream containing a single tool_use block
+-- whose JSON input is split across two partial_json deltas.
+toolOnlyStream :: [ByteString]
+toolOnlyStream =
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"content\":[]}}"
+  , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"file_write\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"/tmp/test.txt\\\",\\\"content\\\":\\\"Hello\\\"}\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":0}"
+  , "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":7}}"
+  , "data: {\"type\":\"message_stop\"}"
+  ]
+
+-- | Stream containing a text block followed by a tool_use block —
+-- the most common shape when the model narrates before acting.
+mixedStream :: [ByteString]
+mixedStream =
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"m\",\"content\":[]}}"
+  , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Let me create the file.\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":0}"
+  , "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"file_write\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"/tmp/test.txt\\\"}\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":1}"
+  , "data: {\"type\":\"message_stop\"}"
+  ]
+
+-- | Stream containing two sequential tool_use blocks — exercises the
+-- builder being reset cleanly between blocks.
+twoToolsStream :: [ByteString]
+twoToolsStream =
+  [ "data: {\"type\":\"message_start\",\"message\":{\"model\":\"m\",\"content\":[]}}"
+  , "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"first\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"a\\\":1}\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":0}"
+  , "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_02\",\"name\":\"second\"}}"
+  , "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"b\\\":2}\"}}"
+  , "data: {\"type\":\"content_block_stop\",\"index\":1}"
+  , "data: {\"type\":\"message_stop\"}"
+  ]
 


### PR DESCRIPTION
Before: When using the Anthropic provider, steaming responses containing tool calls silently drop the tool calls.
After: Tool calls are parsed and executed according to the security rules.

```
[2026-05-04T19:21:54] [INFO] Agent loop started
> Hi! Can you ls this directory?
[2026-05-04T19:22:02] [DEBUG] Sending 1 messages
claude-sonnet-4-20250514> I'll list the contents of the current directory for you.
[2026-05-04T19:22:04] [INFO] Tool call: shell
[2026-05-04T19:22:04] [INFO] Executing: ls
[2026-05-04T19:22:04] [DEBUG] Executed 1 tool calls, continuing
claude-sonnet-4-20250514> Here are the contents of the current directory! I can see this appears to be a Haskell project with:

- Documentation files (README.md, AGENTS.md, CLAUDE.md, etc.)
- Build files (Makefile, cabal.project, pureclaw.cabal, flake.nix)
- Source directories (src, test, app)
- Build artifacts (dist-newstyle)
- Additional directories (bin, docs, scripts, tools)

Would you like me to explore any specific directory or file in more detail?
>
```