### PR TITLE
Feat/mcp client

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,12 @@
 packages: .
 
+-- MCP client (not yet on Hackage)
+source-repository-package
+  type: git
+  location: https://github.com/pureclaw/mcp-client.git
+  tag: 9dc716b2e108efeada7a1cbaac0beec4947c920e
+  --sha256: 14gl58xyc6jh74qsh28f4j1caazg0fjn7la9as8x636j7rsgyiv0
+
 -- Strict build: warnings are errors in CI
 package pureclaw
   ghc-options: -Werror

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -125,6 +125,8 @@ library
     PureClaw.Transcript.Combinator
     PureClaw.Transcript.Provider
     PureClaw.Transcript.Types
+    -- MCP
+    PureClaw.MCP
     -- CLI
     PureClaw.CLI.Config
     PureClaw.CLI.Import
@@ -145,9 +147,12 @@ library
     http-client,
     http-client-tls,
     http-types,
+    mcp-client,
+    mcp-types,
     memory,
     mtl,
     optparse-applicative,
+    process,
     sqlite-simple,
     stm,
     temporary,

--- a/src/PureClaw/Agent/Env.hs
+++ b/src/PureClaw/Agent/Env.hs
@@ -17,6 +17,7 @@ import PureClaw.Handles.Channel
 import PureClaw.Handles.Harness
 import PureClaw.Handles.Log
 import PureClaw.Handles.Transcript (TranscriptHandle)
+import PureClaw.MCP (McpServer)
 import PureClaw.Providers.Class
 import PureClaw.Security.Policy
 import PureClaw.Security.Vault
@@ -72,6 +73,11 @@ data AgentEnv = AgentEnv
     -- 'StreamDone' does not re-fire it. In production this is
     -- populated with @'markBootstrapConsumed' session@ so the agent
     -- marks its bootstrap as consumed exactly once per process start.
+  , _env_mcpServers :: IORef (Map Text McpServer)
+    -- ^ Connected MCP servers, keyed by user-assigned name.
+    -- Mutable so @\/mcp connect@ and @\/mcp disconnect@ can add\/remove
+    -- servers at runtime. Tools from these servers are merged into the
+    -- effective registry on each completion request.
   }
 
 -- | Read the active session's transcript handle.

--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -25,6 +25,7 @@ import PureClaw.Core.Errors
 import PureClaw.Handles.Channel
 import PureClaw.Handles.Harness
 import PureClaw.Handles.Log
+import PureClaw.MCP (mcpRegistry)
 import PureClaw.Providers.Class
 import PureClaw.Tools.Registry
 import PureClaw.Transcript.Provider
@@ -57,8 +58,16 @@ runAgentLoopWith env initialMessages = do
   where
     channel  = _env_channel env
     logger   = _env_logger env
-    registry = _env_registry env
-    tools    = registryDefinitions registry
+    baseRegistry = _env_registry env
+
+    -- | Build the effective registry by merging built-in tools with
+    -- any connected MCP server tools.
+    effectiveRegistry :: IO ToolRegistry
+    effectiveRegistry = do
+      servers <- readIORef (_env_mcpServers env)
+      if Map.null servers
+        then pure baseRegistry
+        else pure $ mergeRegistries baseRegistry (mcpRegistry (Map.elems servers))
 
     go ctx = do
       receiveResult <- try @IOException (_ch_receive channel)
@@ -125,7 +134,9 @@ runAgentLoopWith env initialMessages = do
 
     handleCompletion provider ctx = do
       mModel <- readIORef (_env_model env)
-      let model = fromMaybe (ModelId "") mModel
+      registry <- effectiveRegistry
+      let tools = registryDefinitions registry
+          model = fromMaybe (ModelId "") mModel
           modelName = unModelId model
           req = CompletionRequest
             { _cr_model        = model
@@ -192,6 +203,7 @@ runAgentLoopWith env initialMessages = do
 
     executeCall (callId, name, input) = do
       _lh_logInfo logger $ "Tool call: " <> name
+      registry <- effectiveRegistry
       result <- executeTool registry name input
       case result of
         Nothing -> do

--- a/src/PureClaw/Agent/SlashCommands.hs
+++ b/src/PureClaw/Agent/SlashCommands.hs
@@ -8,6 +8,7 @@ module PureClaw.Agent.SlashCommands
   , HarnessSubCommand (..)
   , AgentSubCommand (..)
   , SessionSubCommand (..)
+  , McpSubCommand (..)
     -- * Known harnesses
   , knownHarnesses
     -- * Agent name tab completion helper
@@ -48,10 +49,12 @@ import System.FilePath ((</>))
 import Data.ByteString.Lazy qualified as BL
 import System.Exit
 import System.IO (Handle, hGetLine)
+import System.Process (proc)
 import System.Process.Typed qualified as P
 
 import Data.Aeson qualified as Aeson
 import PureClaw.Agent.AgentDef qualified as AgentDef
+import PureClaw.MCP qualified as MCP
 import PureClaw.Agent.Compaction
 import PureClaw.Agent.Context
 import PureClaw.Agent.Env
@@ -91,6 +94,7 @@ data CommandGroup
   | GroupTranscript  -- ^ Transcript / permanent log
   | GroupHarness    -- ^ Harness management (tmux-based AI CLI tools)
   | GroupAgent      -- ^ Agent management (bootstrap file collections)
+  | GroupMcp        -- ^ MCP server management
   deriving stock (Show, Eq, Ord, Enum, Bounded)
 
 -- | Human-readable section heading for '/help' output.
@@ -102,6 +106,7 @@ groupHeading GroupVault      = "Vault"
 groupHeading GroupTranscript = "Transcript"
 groupHeading GroupHarness    = "Harness"
 groupHeading GroupAgent      = "Agent"
+groupHeading GroupMcp        = "MCP"
 
 -- | Specification for a single slash command.
 -- 'allCommandSpecs' is the single source of truth: 'parseSlashCommand'
@@ -181,6 +186,14 @@ data AgentSubCommand
   | AgentUnknown Text          -- ^ Unrecognised subcommand
   deriving stock (Show, Eq)
 
+-- | Subcommands of the '/mcp' family.
+data McpSubCommand
+  = McpConnect Text [Text]    -- ^ Connect to server: (name, command + args)
+  | McpDisconnect Text        -- ^ Disconnect a named server
+  | McpList                   -- ^ List connected servers and their tools
+  | McpUnknown Text           -- ^ Unrecognised subcommand
+  deriving stock (Show, Eq)
+
 -- ---------------------------------------------------------------------------
 -- Top-level commands
 -- ---------------------------------------------------------------------------
@@ -202,6 +215,7 @@ data SlashCommand
   | CmdAgent AgentSubCommand          -- ^ Agent management commands
   | CmdSession SessionSubCommand      -- ^ Session management commands
   | CmdMsg Text Text                  -- ^ Send a message to a specific target (name, message)
+  | CmdMcp McpSubCommand              -- ^ MCP server management commands
   deriving stock (Show, Eq)
 
 -- ---------------------------------------------------------------------------
@@ -214,7 +228,7 @@ data SlashCommand
 -- To add a command, add a 'CommandSpec' here — parsing and help update
 -- automatically.
 allCommandSpecs :: [CommandSpec]
-allCommandSpecs = sessionCommandSpecs ++ sessionFamilyCommandSpecs ++ providerCommandSpecs ++ channelCommandSpecs ++ vaultCommandSpecs ++ transcriptCommandSpecs ++ harnessCommandSpecs ++ agentCommandSpecs ++ msgCommandSpecs
+allCommandSpecs = sessionCommandSpecs ++ sessionFamilyCommandSpecs ++ providerCommandSpecs ++ channelCommandSpecs ++ vaultCommandSpecs ++ transcriptCommandSpecs ++ harnessCommandSpecs ++ agentCommandSpecs ++ mcpCommandSpecs ++ msgCommandSpecs
 
 sessionCommandSpecs :: [CommandSpec]
 sessionCommandSpecs =
@@ -404,6 +418,42 @@ agentUnknownFallback t =
      then let rest = T.strip (T.drop (T.length "/agent") lower)
               sub  = fst (T.break (== ' ') rest)
           in Just (CmdAgent (AgentUnknown sub))
+     else Nothing
+
+mcpCommandSpecs :: [CommandSpec]
+mcpCommandSpecs =
+  [ CommandSpec "/mcp connect <name> <command...>"
+      "Connect to an MCP server" GroupMcp mcpConnectP
+  , CommandSpec "/mcp disconnect <name>"
+      "Disconnect from an MCP server" GroupMcp mcpDisconnectP
+  , CommandSpec "/mcp list"
+      "List connected MCP servers and their tools" GroupMcp mcpListP
+  ]
+
+mcpConnectP :: Text -> Maybe SlashCommand
+mcpConnectP t =
+  let lower = T.toLower t
+  in if "/mcp connect " `T.isPrefixOf` lower
+     then let rest = T.strip (T.drop (T.length "/mcp connect") t)
+              (name, cmdPart) = T.break (== ' ') rest
+          in if T.null name || T.null (T.strip cmdPart)
+               then Nothing
+               else Just (CmdMcp (McpConnect name (T.words (T.strip cmdPart))))
+     else Nothing
+
+mcpDisconnectP :: Text -> Maybe SlashCommand
+mcpDisconnectP t =
+  let lower = T.toLower t
+  in if "/mcp disconnect " `T.isPrefixOf` lower
+     then let name = T.strip (T.drop (T.length "/mcp disconnect") t)
+          in if T.null name then Nothing else Just (CmdMcp (McpDisconnect name))
+     else Nothing
+
+mcpListP :: Text -> Maybe SlashCommand
+mcpListP t =
+  let lower = T.toLower (T.strip t)
+  in if lower == "/mcp list" || lower == "/mcp"
+     then Just (CmdMcp McpList)
      else Nothing
 
 msgCommandSpecs :: [CommandSpec]
@@ -877,6 +927,9 @@ executeSlashCommand env (CmdAgent sub) ctx = do
 executeSlashCommand env (CmdSession sub) ctx = do
   executeSessionCommand env sub ctx
 
+executeSlashCommand env (CmdMcp sub) ctx = do
+  executeMcpCommand env sub ctx
+
 executeSlashCommand env (CmdVault sub) ctx = do
   vaultOpt <- readIORef (_env_vault env)
   case sub of
@@ -902,6 +955,85 @@ supportedProviders =
   , ("openrouter", "OpenRouter (multi-model gateway)")
   , ("ollama",     "Ollama (local models)")
   ]
+
+-- ---------------------------------------------------------------------------
+-- MCP commands
+-- ---------------------------------------------------------------------------
+
+executeMcpCommand :: AgentEnv -> McpSubCommand -> Context -> IO Context
+executeMcpCommand env (McpConnect name cmdArgs) ctx = do
+  let channel = _env_channel env
+      logger  = _env_logger env
+  servers <- readIORef (_env_mcpServers env)
+  if Map.member name servers
+    then do
+      _ch_send channel (OutgoingMessage $
+        "MCP server \"" <> name <> "\" is already connected. Disconnect it first with /mcp disconnect " <> name)
+      pure ctx
+    else do
+      case cmdArgs of
+        [] -> do
+          _ch_send channel (OutgoingMessage
+            "Usage: /mcp connect <name> <command> [args...]")
+          pure ctx
+        (cmdText : argTexts) -> do
+          let cmd  = T.unpack cmdText
+              args = map T.unpack argTexts
+          result <- try @SomeException $
+            MCP.connectServer logger name cmdArgs (proc cmd args)
+          case result of
+            Left e -> do
+              _ch_send channel (OutgoingMessage $
+                "Failed to connect to MCP server \"" <> name <> "\": " <> T.pack (show e))
+              pure ctx
+            Right server -> do
+              atomicModifyIORef' (_env_mcpServers env) $ \m ->
+                (Map.insert name server m, ())
+              let toolNames = MCP.mcpToolNames server
+                  toolList = T.intercalate ", " toolNames
+              _ch_send channel (OutgoingMessage $
+                "Connected to MCP server \"" <> name <> "\" ("
+                <> T.pack (show (length toolNames)) <> " tools: " <> toolList <> ")")
+              pure ctx
+
+executeMcpCommand env (McpDisconnect name) ctx = do
+  let channel = _env_channel env
+      logger  = _env_logger env
+  servers <- readIORef (_env_mcpServers env)
+  case Map.lookup name servers of
+    Nothing -> do
+      _ch_send channel (OutgoingMessage $
+        "No MCP server named \"" <> name <> "\" is connected.")
+      pure ctx
+    Just server -> do
+      MCP.disconnectServer logger server
+      atomicModifyIORef' (_env_mcpServers env) $ \m ->
+        (Map.delete name m, ())
+      _ch_send channel (OutgoingMessage $
+        "Disconnected MCP server \"" <> name <> "\".")
+      pure ctx
+
+executeMcpCommand env McpList ctx = do
+  let channel = _env_channel env
+  servers <- readIORef (_env_mcpServers env)
+  if Map.null servers
+    then _ch_send channel (OutgoingMessage
+           "No MCP servers connected. Use /mcp connect <name> <command...> to connect one.")
+    else do
+      let lines' = flip map (Map.toList servers) $ \(sName, server) ->
+            let nTools = length (MCP.mcpToolNames server)
+                cmd = T.intercalate " " (MCP._ms_command server)
+            in "  " <> sName <> " (" <> T.pack (show nTools)
+               <> " tools) \x2014 " <> cmd
+          msg = "Connected MCP servers:\n" <> T.intercalate "\n" lines'
+      _ch_send channel (OutgoingMessage msg)
+  pure ctx
+
+executeMcpCommand env (McpUnknown sub) ctx = do
+  _ch_send (_env_channel env) (OutgoingMessage $
+    "Unknown /mcp subcommand: " <> sub
+    <> "\nAvailable: connect, disconnect, list")
+  pure ctx
 
 executeProviderCommand :: AgentEnv -> VaultHandle -> ProviderSubCommand -> Context -> IO Context
 executeProviderCommand env _vault ProviderList ctx = do

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -591,6 +591,7 @@ runChat opts = do
         -- BOOTSTRAP.md and its consumed flag is currently False.
         onFirstStreamDoneRef <- newIORef
           =<< resolveBootstrapCallback logger mAgentDef sessionHandle
+        mcpRef <- newIORef Map.empty
         let env = AgentEnv
               { _env_provider     = providerRef
               , _env_model        = modelRef
@@ -607,6 +608,7 @@ runChat opts = do
               , _env_agentDef     = mAgentDef
               , _env_session      = sessionRef
               , _env_onFirstStreamDone = onFirstStreamDoneRef
+              , _env_mcpServers   = mcpRef
               }
         -- Fill the envRef so the tab completer can access the live env
         writeIORef envRef (Just env)

--- a/src/PureClaw/MCP.hs
+++ b/src/PureClaw/MCP.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+module PureClaw.MCP
+  ( -- * Server state
+    McpServer (..)
+    -- * Lifecycle
+  , connectServer
+  , disconnectServer
+    -- * Tool queries
+  , mcpToolNames
+    -- * Registry integration
+  , mcpRegistry
+  ) where
+
+import Control.Concurrent (forkIO, killThread)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception (SomeException, catch, throwIO, try)
+import Data.Aeson (Value (..))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KM
+import Data.IORef
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import System.IO (Handle, hClose, hFlush, hIsEOF, hSetBuffering, BufferMode (..))
+import System.Process
+  ( CreateProcess (..)
+  , ProcessHandle
+  , StdStream (..)
+  , cleanupProcess
+  , createProcess
+  , waitForProcess
+  )
+import System.Timeout (timeout)
+
+import Data.ByteString.Char8 qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+
+import MCP.Client.API qualified as MCP
+import MCP.Client.Config (ClientConfig (..), defaultClientConfig)
+import MCP.Client.Error (MCPClientError)
+import MCP.Client.Session (ClientSession, withClientSession, initialize)
+import MCP.Client.Transport (Transport (..))
+import MCP.Protocol (CallToolResult (..), InitializeResult (..), ListToolsResult (..))
+import MCP.Types
+  ( ContentBlock (..)
+  , ImageContent (..)
+  , Implementation
+  , TextContent (..)
+  , Tool (..)
+  )
+
+import PureClaw.Handles.Log
+import PureClaw.Providers.Class (ToolDefinition (..), ToolResultPart (..))
+import PureClaw.Tools.Registry
+
+-- | An active MCP server connection.
+data McpServer = McpServer
+  { _ms_name       :: Text
+    -- ^ User-assigned name for this server (e.g. "filesystem", "time")
+  , _ms_command    :: [Text]
+    -- ^ The command + args used to spawn the server (for display)
+  , _ms_session    :: ClientSession
+    -- ^ Active MCP client session
+  , _ms_tools      :: [Tool]
+    -- ^ Tools discovered during initialization
+  , _ms_serverInfo :: Maybe Implementation
+    -- ^ Server identity from initialization
+  , _ms_cleanup    :: IO ()
+    -- ^ Shuts down the process and background threads
+  }
+
+-- | Connect to an MCP server by spawning it as a child process.
+--
+-- The server process communicates over stdio (JSON-RPC). On success,
+-- returns the connected server with its discovered tools. On failure,
+-- throws 'MCPClientError' or 'IOException'.
+connectServer :: LogHandle -> Text -> [Text] -> CreateProcess -> IO McpServer
+connectServer logger serverName cmdArgs cp = do
+  _lh_logInfo logger $ "MCP: connecting to " <> serverName <> "..."
+
+  -- Spawn the child process
+  let cp' = cp { std_in = CreatePipe, std_out = CreatePipe, std_err = Inherit }
+  (Just hIn, Just hOut, _hErr, ph) <- createProcess cp'
+  hSetBuffering hIn LineBuffering
+  hSetBuffering hOut LineBuffering
+
+  let transport = mkStdioTransport hIn hOut ph
+
+  -- Start a client session (spawns background receive thread).
+  -- We manage the session manually rather than using withClientSession's
+  -- bracket because the connection persists across slash commands.
+  sessionMVar <- newEmptyMVar
+  tidRef <- newIORef Nothing
+  tid <- forkIO $
+    withClientSession transport
+      defaultClientConfig { config_request_timeout_us = 30_000_000 }
+      (\session -> do
+        putMVar sessionMVar (Right session)
+        -- Block forever until the thread is killed
+        newEmptyMVar >>= takeMVar :: IO ()
+      )
+    `catch` \(e :: SomeException) ->
+      putMVar sessionMVar (Left e)
+  writeIORef tidRef (Just tid)
+
+  result <- takeMVar sessionMVar
+  session <- case result of
+    Left e  -> do
+      stopProcess hIn hOut ph
+      throwIO e
+    Right s -> pure s
+
+  -- Initialize the MCP protocol
+  initResult <- initialize session
+    `catch` \(e :: MCPClientError) -> do
+      readIORef tidRef >>= mapM_ killThread
+      stopProcess hIn hOut ph
+      throwIO e
+
+  let sInfo = Just (serverInfo initResult)
+
+  -- Discover available tools
+  ListToolsResult { tools = mcpTools } <- MCP.listTools session Nothing
+
+  _lh_logInfo logger $ "MCP: " <> serverName <> " connected ("
+    <> T.pack (show (length mcpTools)) <> " tools)"
+
+  let cleanup = do
+        readIORef tidRef >>= mapM_ killThread
+        stopProcess hIn hOut ph
+
+  pure McpServer
+    { _ms_name       = serverName
+    , _ms_command    = cmdArgs
+    , _ms_session    = session
+    , _ms_tools      = mcpTools
+    , _ms_serverInfo = sInfo
+    , _ms_cleanup    = cleanup
+    }
+
+-- | Disconnect from an MCP server, cleaning up the child process.
+disconnectServer :: LogHandle -> McpServer -> IO ()
+disconnectServer logger server = do
+  _lh_logInfo logger $ "MCP: disconnecting " <> _ms_name server
+  _ms_cleanup server
+    `catch` \(_ :: SomeException) -> pure ()
+
+-- | Get the names of all tools provided by an MCP server.
+mcpToolNames :: McpServer -> [Text]
+mcpToolNames = map toolName . _ms_tools
+
+-- | Build a 'ToolRegistry' from a list of connected MCP servers.
+--
+-- Each MCP tool is registered with its original name. If multiple
+-- servers expose tools with the same name, the last server wins.
+mcpRegistry :: [McpServer] -> ToolRegistry
+mcpRegistry = foldl addServer emptyRegistry
+  where
+    addServer :: ToolRegistry -> McpServer -> ToolRegistry
+    addServer reg server =
+      foldl (addTool server) reg (_ms_tools server)
+
+    addTool :: McpServer -> ToolRegistry -> Tool -> ToolRegistry
+    addTool server reg tool =
+      let toolN = toolName tool
+          def = ToolDefinition
+            { _td_name        = toolN
+            , _td_description = toolDesc tool
+            , _td_inputSchema = Aeson.toJSON (inputSchema tool)
+            }
+          handler input = mcpExecuteTool (_ms_session server) toolN input
+      in registerRichTool def handler reg
+
+-- ---------------------------------------------------------------------------
+-- Tool accessors (avoid DuplicateRecordFields ambiguity)
+-- ---------------------------------------------------------------------------
+
+toolName :: Tool -> Text
+toolName (Tool { name = n }) = n
+
+toolDesc :: Tool -> Text
+toolDesc (Tool { description = d }) = maybe "" id d
+
+-- ---------------------------------------------------------------------------
+-- Tool execution
+-- ---------------------------------------------------------------------------
+
+-- | Execute an MCP tool call, returning PureClaw-compatible results.
+mcpExecuteTool :: ClientSession -> Text -> Value -> IO ([ToolResultPart], Bool)
+mcpExecuteTool session tName input = do
+  let argsMap = keyMapToMap input
+  result <- try @MCPClientError $ MCP.callTool session tName argsMap
+  case result of
+    Left e -> pure ([TRPText (T.pack (show e))], True)
+    Right (CallToolResult { content = blocks, isError = mErr }) ->
+      let isErr = maybe False id mErr
+          parts = map convertContent blocks
+      in pure (if null parts then [TRPText ""] else parts, isErr)
+
+convertContent :: ContentBlock -> ToolResultPart
+convertContent (TextBlock (TextContent { text = t })) = TRPText t
+convertContent (ImageBlock (ImageContent { data' = d, mimeType = m })) =
+  TRPImage m (BS.pack (T.unpack d))
+convertContent _ = TRPText "[unsupported content type]"
+
+-- | Convert a JSON object to @Maybe (Map Text Value)@ for callTool.
+keyMapToMap :: Value -> Maybe (Map.Map Text Value)
+keyMapToMap (Object km) = Just $ Map.fromList
+  [(Key.toText k, v) | (k, v) <- KM.toList km]
+keyMapToMap _ = Nothing
+
+-- ---------------------------------------------------------------------------
+-- Internal: stdio transport (manual lifecycle, not bracket-based)
+-- ---------------------------------------------------------------------------
+
+mkStdioTransport :: Handle -> Handle -> ProcessHandle -> Transport
+mkStdioTransport hIn hOut ph = Transport
+  { transport_send = \msg -> do
+      BSL.hPut hIn (Aeson.encode msg)
+      BSL.hPut hIn "\n"
+      hFlush hIn
+  , transport_receive = do
+      eof <- hIsEOF hOut
+      if eof
+        then pure Nothing
+        else do
+          line <- BS.hGetLine hOut
+          case Aeson.eitherDecodeStrict' line of
+            Right msg -> pure (Just msg)
+            Left _    -> transport_receive (mkStdioTransport hIn hOut ph)
+  , transport_close = stopProcess hIn hOut ph
+  }
+
+stopProcess :: Handle -> Handle -> ProcessHandle -> IO ()
+stopProcess hIn hOut ph = do
+  hClose hIn `catch` \(_ :: SomeException) -> pure ()
+  exited <- timeout 2_000_000 (waitForProcess ph)
+  case exited of
+    Just _  -> hClose hOut `catch` \(_ :: SomeException) -> pure ()
+    Nothing -> cleanupProcess (Nothing, Just hOut, Nothing, ph)

--- a/src/PureClaw/MCP.hs
+++ b/src/PureClaw/MCP.hs
@@ -18,6 +18,7 @@ import Data.Aeson (Value (..))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KM
+import Data.Maybe (fromMaybe)
 import Data.IORef
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
@@ -169,7 +170,7 @@ mcpRegistry = foldl addServer emptyRegistry
             , _td_description = toolDesc tool
             , _td_inputSchema = Aeson.toJSON (inputSchema tool)
             }
-          handler input = mcpExecuteTool (_ms_session server) toolN input
+          handler = mcpExecuteTool (_ms_session server) toolN
       in registerRichTool def handler reg
 
 -- ---------------------------------------------------------------------------
@@ -180,7 +181,7 @@ toolName :: Tool -> Text
 toolName (Tool { name = n }) = n
 
 toolDesc :: Tool -> Text
-toolDesc (Tool { description = d }) = maybe "" id d
+toolDesc (Tool { description = d }) = fromMaybe "" d
 
 -- ---------------------------------------------------------------------------
 -- Tool execution
@@ -194,7 +195,7 @@ mcpExecuteTool session tName input = do
   case result of
     Left e -> pure ([TRPText (T.pack (show e))], True)
     Right (CallToolResult { content = blocks, isError = mErr }) ->
-      let isErr = maybe False id mErr
+      let isErr = fromMaybe False mErr
           parts = map convertContent blocks
       in pure (if null parts then [TRPText ""] else parts, isErr)
 

--- a/src/PureClaw/Tools/Registry.hs
+++ b/src/PureClaw/Tools/Registry.hs
@@ -8,6 +8,7 @@ module PureClaw.Tools.Registry
   , registerRichTool
   , registryDefinitions
   , executeTool
+  , mergeRegistries
   ) where
 
 import Data.Aeson (Value)
@@ -55,3 +56,9 @@ executeTool reg name input =
   case Map.lookup name (_tr_tools reg) of
     Nothing -> pure Nothing
     Just (_, handler) -> Just <$> handler input
+
+-- | Merge two registries. Tools from the second registry override
+-- tools with the same name in the first.
+mergeRegistries :: ToolRegistry -> ToolRegistry -> ToolRegistry
+mergeRegistries (ToolRegistry a) (ToolRegistry b) =
+  ToolRegistry (Map.union b a)

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -103,6 +103,7 @@ mkTestEnv p ch = do
   targetRef     <- newIORef TargetProvider
   windowIdxRef  <- newIORef 0
   sessionRef <- newIORef =<< mkNoOpSessionHandle
+  mcpRef     <- newIORef Map.empty
   pure AgentEnv
     { _env_provider     = providerRef
     , _env_model        = modelRef
@@ -119,6 +120,7 @@ mkTestEnv p ch = do
     , _env_agentDef      = Nothing
     , _env_session       = sessionRef
     , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+    , _env_mcpServers   = mcpRef
     }
 
 spec :: Spec

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -257,6 +257,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -274,6 +275,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/new clears messages but keeps system prompt" $ do
@@ -349,6 +351,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -366,6 +369,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdProvider ProviderList) ctx
@@ -388,6 +392,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -405,6 +410,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdProvider ProviderList) ctx
@@ -424,6 +430,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -440,6 +447,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdProvider (ProviderConfigure "badname")) ctx
@@ -459,6 +467,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -475,6 +484,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdProvider (ProviderConfigure "ollama")) ctx
@@ -506,6 +516,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -522,6 +533,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdProvider (ProviderConfigure "ollama")) ctx
@@ -544,6 +556,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -560,6 +573,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTarget Nothing) ctx
@@ -578,6 +592,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -594,6 +609,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTarget (Just "llama3")) ctx
@@ -623,6 +639,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -639,6 +656,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTarget (Just "claude-code")) ctx
@@ -669,6 +687,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 1
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -686,6 +705,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdMsg "claude-code-0" "list TODOs") ctx
@@ -707,6 +727,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -724,6 +745,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdMsg "nonexistent" "hello") ctx
@@ -745,6 +767,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 1
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -762,6 +785,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdMsg "cc-0" "test") ctx
@@ -778,6 +802,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -795,6 +820,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/vault list with no vault → helpful message" $ do
@@ -827,6 +853,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -843,6 +870,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -871,6 +899,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -887,6 +916,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -907,6 +937,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -924,6 +955,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/vault setup presents menu with passphrase option" $ withTempHome $ do
@@ -936,6 +968,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -952,6 +985,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -970,6 +1004,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let yubikey = AgePlugin
             { _ap_name   = "yubikey"
             , _ap_binary = "age-plugin-yubikey"
@@ -991,6 +1026,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -1020,6 +1056,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1036,6 +1073,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -1067,6 +1105,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1083,6 +1122,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -1101,6 +1141,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let ch = mkMockChannelAll allSentRef msgsRef
           env = AgentEnv
             { _env_provider     = providerRef
@@ -1119,6 +1160,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault VaultSetup) ctx
@@ -1205,6 +1247,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1221,6 +1264,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault (VaultDelete "todelete")) ctx
@@ -1244,6 +1288,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1260,6 +1305,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault (VaultDelete "keep")) ctx
@@ -1281,6 +1327,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1300,6 +1347,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdVault (VaultAdd "mykey")) ctx
@@ -1359,6 +1407,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1376,6 +1425,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env CmdHelp ctx
@@ -1395,6 +1445,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1412,6 +1463,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env CmdHelp ctx
@@ -1432,6 +1484,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1449,6 +1502,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = addMessage (textMessage User "hello") (emptyContext Nothing)
       ctx' <- executeSlashCommand env CmdHelp ctx
@@ -1541,6 +1595,7 @@ spec = do
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1558,6 +1613,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptRecent Nothing)) ctx
@@ -1578,6 +1634,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1595,6 +1652,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript TranscriptPath) ctx
@@ -1627,6 +1685,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1644,6 +1703,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptRecent Nothing)) ctx
@@ -1667,6 +1727,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1684,6 +1745,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptRecent Nothing)) ctx
@@ -1729,6 +1791,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1746,6 +1809,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptSearch "ollama")) ctx
@@ -1768,6 +1832,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1785,6 +1850,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptUnknown "badcmd")) ctx
@@ -1804,6 +1870,7 @@ spec = do
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1821,6 +1888,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript TranscriptPath) ctx
@@ -1838,6 +1906,7 @@ spec = do
       targetRef     <- newIORef TargetProvider
       windowIdxRef  <- newIORef 0
       sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1855,6 +1924,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env CmdHelp ctx
@@ -1887,6 +1957,7 @@ spec = do
       vaultRef      <- newIORef Nothing
       providerRef   <- newIORef (Just (MkProvider (MockProvider "summary")))
       modelRef      <- newIORef (Just (ModelId "test"))
+      mcpRef        <- newIORef Map.empty
       let env = AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1904,6 +1975,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
           ctx = emptyContext Nothing
       _ <- executeSlashCommand env (CmdTranscript (TranscriptRecent Nothing)) ctx
@@ -1953,6 +2025,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -1970,6 +2043,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/agent list lists discovered agent names" $ withTempHome $ do
@@ -2006,6 +2080,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -2023,6 +2098,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/agent info <name> shows files and frontmatter" $ withTempHome $ do
@@ -2157,6 +2233,7 @@ spec = do
           targetRef     <- newIORef TargetProvider
           windowIdxRef  <- newIORef 0
           sessionRef <- newIORef =<< mkNoOpSessionHandle
+          mcpRef     <- newIORef Map.empty
           pure AgentEnv
             { _env_provider     = providerRef
             , _env_model        = modelRef
@@ -2174,6 +2251,7 @@ spec = do
             , _env_agentDef      = Nothing
             , _env_session       = sessionRef
             , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
             }
 
     it "/session new writes session.json on disk and returns a confirmation" $ withTempHome $ do

--- a/test/Integration/SignalFlowSpec.hs
+++ b/test/Integration/SignalFlowSpec.hs
@@ -50,6 +50,7 @@ mkTestEnv p ch = do
   targetRef     <- newIORef TargetProvider
   windowIdxRef  <- newIORef 0
   sessionRef <- newIORef =<< mkNoOpSessionHandle
+  mcpRef     <- newIORef Map.empty
   pure AgentEnv
     { _env_provider     = providerRef
     , _env_model        = modelRef
@@ -66,6 +67,7 @@ mkTestEnv p ch = do
     , _env_agentDef      = Nothing
     , _env_session       = sessionRef
     , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+    , _env_mcpServers   = mcpRef
     }
 
 spec :: Spec


### PR DESCRIPTION
  - Adds MCP (Model Context Protocol) client support so PureClaw can connect to any MCP server and use its tools
  - New PureClaw.MCP module handles server lifecycle, stdio transport, and tool conversion
  - Agent loop dynamically merges built-in tools with MCP server tools on each completion request
  - /mcp connect <name> <command...>, /mcp disconnect <name>, /mcp list slash commands

  Details

  Uses the pureclaw/mcp-client Haskell library (added as source-repository-package). MCP servers are spawned as child processes communicating via JSON-RPC over stdio.

  Key design decisions:
  - No registry IORef change — built-in _env_registry stays immutable; MCP tools are merged dynamically via mergeRegistries in the agent loop
  - _env_mcpServers :: IORef (Map Text McpServer) — new AgentEnv field for runtime server management
  - mcpToolNames/mcpRegistry — avoids DuplicateRecordFields ambiguity from mcp-types by using local pattern-match accessors

  Test plan

  - All 1207 existing tests pass
  - hlint clean
  - Smoke tested: connected to @modelcontextprotocol/server-everything (13 tools discovered and registered)
  - /mcp list shows connected servers
  - Graceful error on connection failure (timeout, missing package)