### PR TITLE
Feat/tool improvements

### DIFF
--- a/docs/tool-comparison-hermes.md
+++ b/docs/tool-comparison-hermes.md
@@ -6,8 +6,8 @@
 |---|---|---|
 | `file_read` | `read_file` | Hermes adds offset/limit pagination, ~100K char guard |
 | `file_write` | `write_file` | Hermes adds auto syntax checks (.py/.json/.yaml/.toml) |
-| `edit` | `patch` | **Big gap.** Hermes has 9 fuzzy-match strategies + V4A multi-file patch mode. PureClaw requires exact unique string match |
-| `shell` | `terminal` | **Big gap.** Hermes has 7 backends (local/Docker/SSH/Modal/Singularity/Daytona/Vercel), background mode, PTY, watch patterns. PureClaw is local-only with allowlist |
+| `edit` | `patch` | **Partial parity.** PureClaw now has fuzzy matching (whitespace-normalized, trimmed-lines, line-ending-normalized) and `replace_all` mode. Still missing: V4A multi-file patch mode, remaining ~6 fuzzy strategies |
+| `shell` | `terminal` | **Partial parity.** PureClaw now has timeout and working directory via `ExecOptions`. `ShellHandle` interface designed for future backends (Docker/SSH/etc). Still missing: PTY, watch patterns, remote backends |
 | `git` | _(via terminal)_ | PureClaw has a dedicated git tool; Hermes just uses terminal. PureClaw advantage here (structured subcommands) |
 | `http_request` | `web_extract` | Hermes is smarter -- markdown conversion, PDF support, LLM summarization for large pages. PureClaw is raw GET with domain allowlist |
 | `web_search` | `web_search` | Roughly equivalent. Hermes supports DuckDuckGo/Firecrawl/Exa backends and advanced operators |
@@ -16,17 +16,17 @@
 | `message` | `send_message` | **Big gap.** Hermes sends to 17 platforms with media attachments. PureClaw sends text to the active channel only |
 | `cron` | `cronjob` | Hermes adds repeat limits, custom model overrides, skill-aware, pause/resume/trigger. PureClaw is basic add/remove/list |
 | `image` | `vision_analyze` | Different scope. PureClaw reads local image files. Hermes analyzes URLs via vision LLM with custom prompts |
+| `search_files` | `search_files` | ✅ **Implemented.** Ripgrep-backed regex search with glob filters, output modes (content/files_only/count), context lines, limit, case-insensitive. Near parity — missing only offset pagination |
+| `clarify` | `clarify` | ✅ **Implemented.** Open-ended and multiple choice (up to 4 + "Other"). Returns JSON with question, choices_offered, user_response. Full parity |
 
 ## Tools Hermes Has That PureClaw Lacks Entirely
 
 | Hermes Tool | What It Does | Impact |
 |---|---|---|
 | **`patch`** (V4A mode) | Multi-file patches in a single tool call | High -- dramatically reduces round-trips for refactoring |
-| **`search_files`** | Ripgrep-backed regex search with glob filters, pagination, context lines | **High** -- PureClaw has no file content search tool at all |
 | **`browser_*`** (12 tools) | Full browser automation -- navigate, click, type, scroll, screenshot, JS console, CDP | High -- entire capability missing |
 | **`delegate_task`** | Spawn isolated subagents with restricted toolsets | High -- enables parallel task decomposition |
 | **`execute_code`** | Run Python that calls tools programmatically (collapses multi-step pipelines) | Medium-high -- reduces inference round-trips |
-| **`clarify`** | Ask user structured questions (multiple choice or open-ended) | **High** -- PureClaw agent can't ask clarifying questions |
 | **`todo`** | In-memory task list for decomposing complex work | Medium -- lightweight planning aid |
 | **`session_search`** | FTS5 search across past session transcripts with LLM summarization | Medium -- cross-session recall |
 | **`image_generate`** | Text-to-image via FAL.ai (FLUX, GPT-Image, etc.) | Low-medium -- niche but impressive |
@@ -44,18 +44,21 @@
 - **Backend:** Ripgrep
 - **Modes:** Content search (regex match with line numbers) or file search (glob match)
 - **Output:** Matches with line numbers, file paths only, or match counts
+- **PureClaw status:** ✅ Implemented. Missing only `offset` pagination.
 
 ### clarify
 
 - **Parameters:** question (string), choices (array of strings, max 4, optional)
 - **Modes:** Multiple choice (up to 4 choices + "Other" option) or open-ended (no choices)
 - **Returns:** JSON with question, choices_offered, user_response
+- **PureClaw status:** ✅ Implemented. Full parity.
 
 ### patch (V4A mode)
 
 - **Parameters:** mode ("replace" or "patch"), path, old_string, new_string, replace_all (default false), patch (V4A format)
 - **Replace mode:** 9 fuzzy-match strategies for targeted find-and-replace
 - **Patch mode:** V4A multi-file diff format in a single tool call
+- **PureClaw status:** ⚡ Partial. `edit` now has `replace_all` and 3 fuzzy strategies (whitespace-normalized, trimmed-lines, line-ending-normalized). Missing: V4A multi-file patch mode, ~6 remaining fuzzy strategies (indentation-normalized, block-anchor, line-range, similarity-threshold, AST-aware, context-anchored).
 
 ### delegate_task
 
@@ -114,14 +117,17 @@
 - **Parameters:** user_prompt, include_reasoning (default false)
 - **Behavior:** Queries multiple frontier models in parallel (reference layer), synthesizes with strongest model (aggregator)
 
-## Priority Ranking for Closing the Gap
+## Priority Ranking for Closing Remaining Gaps
 
 Ordered by bang-for-buck (impact vs implementation effort):
 
-1. **`search_files`** -- PureClaw has zero file content search. Table stakes. Simple to implement (shell out to grep/rg through ShellHandle).
-2. **`clarify`** -- Agent can't ask user questions. One-tool fix, dramatically improves UX for ambiguous requests.
-3. **`patch` fuzzy matching** -- PureClaw's `edit` requires exact unique string match, which fails often. Fuzzy matching is the #1 QoL improvement for code editing.
+1. ~~**`search_files`**~~ ✅ Done
+2. ~~**`clarify`**~~ ✅ Done
+3. ~~**`patch` fuzzy matching**~~ ✅ Done (3 strategies + replace_all)
 4. **`web_extract`** -- Upgrade `http_request` from raw GET to markdown extraction with size handling.
 5. **`delegate_task`** -- Subagent spawning. PureClaw has session infrastructure already; wire it into a tool.
 6. **`todo`** -- Simple in-memory task tracking. Tiny implementation, helps agent plan multi-step work.
-7. **Browser automation** -- Big effort, big payoff, but MCP can cover this in the interim.
+7. **`patch` V4A mode** -- Multi-file patches in one tool call. Significant implementation, big payoff for refactoring.
+8. **Shell backends** -- Docker/SSH execution. `ExecOptions` interface is ready; implement new `mkDockerShellHandle`/`mkSSHShellHandle`.
+9. **`message` platform expansion** -- Each platform is a separate integration. Low ROI without users on those platforms.
+10. **Browser automation** -- Big effort, big payoff, but MCP can cover this in the interim.

--- a/docs/tool-comparison-hermes.md
+++ b/docs/tool-comparison-hermes.md
@@ -6,10 +6,12 @@
 |---|---|---|
 | `file_read` | `read_file` | Hermes adds offset/limit pagination, ~100K char guard |
 | `file_write` | `write_file` | Hermes adds auto syntax checks (.py/.json/.yaml/.toml) |
-| `edit` | `patch` | **Partial parity.** PureClaw now has fuzzy matching (whitespace-normalized, trimmed-lines, line-ending-normalized) and `replace_all` mode. Still missing: V4A multi-file patch mode, remaining ~6 fuzzy strategies |
+| `edit` | `patch` | **Partial parity.** PureClaw now has fuzzy matching (whitespace-normalized, trimmed-lines, line-ending-normalized) and `replace_all` mode. Still missing: ~6 fuzzy strategies |
+| `patch` | `patch` (V4A) | ✅ **Implemented.** Multi-file unified diff patches in a single tool call. Context-aware hunk matching. |
 | `shell` | `terminal` | **Partial parity.** PureClaw now has timeout and working directory via `ExecOptions`. `ShellHandle` interface designed for future backends (Docker/SSH/etc). Still missing: PTY, watch patterns, remote backends |
 | `git` | _(via terminal)_ | PureClaw has a dedicated git tool; Hermes just uses terminal. PureClaw advantage here (structured subcommands) |
-| `http_request` | `web_extract` | Hermes is smarter -- markdown conversion, PDF support, LLM summarization for large pages. PureClaw is raw GET with domain allowlist |
+| `http_request` | `web_extract` | Legacy raw GET tool retained for backward compat |
+| `web_extract` | `web_extract` | ✅ **Implemented.** HTML→markdown conversion (headings, lists, emphasis, code, entities), script/style stripping, configurable truncation. Still missing: PDF support, LLM summarization |
 | `web_search` | `web_search` | Roughly equivalent. Hermes supports DuckDuckGo/Firecrawl/Exa backends and advanced operators |
 | `memory_store` / `memory_recall` | `memory` | Different model. PureClaw: vector/FTS search with similarity scores. Hermes: curated markdown (MEMORY.md/USER.md) injected into system prompt, 2200 char cap |
 | `process` | `process` | Similar (spawn/list/poll/kill/write_stdin). Hermes adds log pagination, wait, submit, close stdin |
@@ -18,14 +20,13 @@
 | `image` | `vision_analyze` | Different scope. PureClaw reads local image files. Hermes analyzes URLs via vision LLM with custom prompts |
 | `search_files` | `search_files` | ✅ **Implemented.** Ripgrep-backed regex search with glob filters, output modes (content/files_only/count), context lines, limit, case-insensitive. Near parity — missing only offset pagination |
 | `clarify` | `clarify` | ✅ **Implemented.** Open-ended and multiple choice (up to 4 + "Other"). Returns JSON with question, choices_offered, user_response. Full parity |
+| `delegate_task` | `delegate_task` | ✅ **Implemented.** Isolated sub-agents with restricted toolsets, bounded turns (max 30), own context. Recursive delegation prevented. Missing: max_concurrent (sequential only), orchestrator role |
 
 ## Tools Hermes Has That PureClaw Lacks Entirely
 
 | Hermes Tool | What It Does | Impact |
 |---|---|---|
-| **`patch`** (V4A mode) | Multi-file patches in a single tool call | High -- dramatically reduces round-trips for refactoring |
 | **`browser_*`** (12 tools) | Full browser automation -- navigate, click, type, scroll, screenshot, JS console, CDP | High -- entire capability missing |
-| **`delegate_task`** | Spawn isolated subagents with restricted toolsets | High -- enables parallel task decomposition |
 | **`execute_code`** | Run Python that calls tools programmatically (collapses multi-step pipelines) | Medium-high -- reduces inference round-trips |
 | **`todo`** | In-memory task list for decomposing complex work | Medium -- lightweight planning aid |
 | **`session_search`** | FTS5 search across past session transcripts with LLM summarization | Medium -- cross-session recall |
@@ -58,7 +59,7 @@
 - **Parameters:** mode ("replace" or "patch"), path, old_string, new_string, replace_all (default false), patch (V4A format)
 - **Replace mode:** 9 fuzzy-match strategies for targeted find-and-replace
 - **Patch mode:** V4A multi-file diff format in a single tool call
-- **PureClaw status:** ⚡ Partial. `edit` now has `replace_all` and 3 fuzzy strategies (whitespace-normalized, trimmed-lines, line-ending-normalized). Missing: V4A multi-file patch mode, ~6 remaining fuzzy strategies (indentation-normalized, block-anchor, line-range, similarity-threshold, AST-aware, context-anchored).
+- **PureClaw status:** ✅ `patch` tool implements multi-file unified diff mode. `edit` tool has `replace_all` and 3 fuzzy strategies. Missing from Hermes: ~6 remaining fuzzy strategies (indentation-normalized, block-anchor, line-range, similarity-threshold, AST-aware, context-anchored).
 
 ### delegate_task
 
@@ -124,10 +125,10 @@ Ordered by bang-for-buck (impact vs implementation effort):
 1. ~~**`search_files`**~~ ✅ Done
 2. ~~**`clarify`**~~ ✅ Done
 3. ~~**`patch` fuzzy matching**~~ ✅ Done (3 strategies + replace_all)
-4. **`web_extract`** -- Upgrade `http_request` from raw GET to markdown extraction with size handling.
-5. **`delegate_task`** -- Subagent spawning. PureClaw has session infrastructure already; wire it into a tool.
-6. **`todo`** -- Simple in-memory task tracking. Tiny implementation, helps agent plan multi-step work.
-7. **`patch` V4A mode** -- Multi-file patches in one tool call. Significant implementation, big payoff for refactoring.
+4. ~~**`web_extract`**~~ ✅ Done (HTML→markdown, truncation, size limits)
+5. ~~**`delegate_task`**~~ ✅ Done (isolated sub-agents, restricted toolsets, bounded turns)
+6. ~~**`patch` V4A mode**~~ ✅ Done (multi-file unified diff patches)
+7. **`todo`** -- Simple in-memory task tracking. Tiny implementation, helps agent plan multi-step work.
 8. **Shell backends** -- Docker/SSH execution. `ExecOptions` interface is ready; implement new `mkDockerShellHandle`/`mkSSHShellHandle`.
 9. **`message` platform expansion** -- Each platform is a separate integration. Low ROI without users on those platforms.
 10. **Browser automation** -- Big effort, big payoff, but MCP can cover this in the interim.

--- a/docs/tool-comparison-hermes.md
+++ b/docs/tool-comparison-hermes.md
@@ -6,7 +6,7 @@
 |---|---|---|
 | `file_read` | `read_file` | Hermes adds offset/limit pagination, ~100K char guard |
 | `file_write` | `write_file` | Hermes adds auto syntax checks (.py/.json/.yaml/.toml) |
-| `edit` | `patch` | **Partial parity.** PureClaw now has fuzzy matching (whitespace-normalized, trimmed-lines, line-ending-normalized) and `replace_all` mode. Still missing: ~6 fuzzy strategies |
+| `edit` | `patch` | **Near parity.** 5 fuzzy strategies (whitespace-normalized, trimmed-lines, line-ending-normalized, indentation-normalized, case-insensitive) + `replace_all`. Missing: ~4 advanced strategies (block-anchor, line-range, similarity-threshold, AST-aware) |
 | `patch` | `patch` (V4A) | ✅ **Implemented.** Multi-file unified diff patches in a single tool call. Context-aware hunk matching. |
 | `shell` | `terminal` | **Partial parity.** PureClaw now has timeout and working directory via `ExecOptions`. `ShellHandle` interface designed for future backends (Docker/SSH/etc). Still missing: PTY, watch patterns, remote backends |
 | `git` | _(via terminal)_ | PureClaw has a dedicated git tool; Hermes just uses terminal. PureClaw advantage here (structured subcommands) |
@@ -14,22 +14,22 @@
 | `web_extract` | `web_extract` | ✅ **Implemented.** HTML→markdown conversion (headings, lists, emphasis, code, entities), script/style stripping, configurable truncation. Still missing: PDF support, LLM summarization |
 | `web_search` | `web_search` | Roughly equivalent. Hermes supports DuckDuckGo/Firecrawl/Exa backends and advanced operators |
 | `memory_store` / `memory_recall` | `memory` | Different model. PureClaw: vector/FTS search with similarity scores. Hermes: curated markdown (MEMORY.md/USER.md) injected into system prompt, 2200 char cap |
-| `process` | `process` | Similar (spawn/list/poll/kill/write_stdin). Hermes adds log pagination, wait, submit, close stdin |
+| `process` | `process` | **Near parity.** spawn/list/poll/kill/write_stdin/wait/close_stdin. Missing: log pagination offset, submit |
 | `message` | `send_message` | **Big gap.** Hermes sends to 17 platforms with media attachments. PureClaw sends text to the active channel only |
 | `cron` | `cronjob` | Hermes adds repeat limits, custom model overrides, skill-aware, pause/resume/trigger. PureClaw is basic add/remove/list |
 | `image` | `vision_analyze` | Different scope. PureClaw reads local image files. Hermes analyzes URLs via vision LLM with custom prompts |
 | `search_files` | `search_files` | ✅ **Implemented.** Ripgrep-backed regex search with glob filters, output modes (content/files_only/count), context lines, limit, case-insensitive. Near parity — missing only offset pagination |
 | `clarify` | `clarify` | ✅ **Implemented.** Open-ended and multiple choice (up to 4 + "Other"). Returns JSON with question, choices_offered, user_response. Full parity |
 | `delegate_task` | `delegate_task` | ✅ **Implemented.** Isolated sub-agents with restricted toolsets, bounded turns (max 30), own context. Recursive delegation prevented. Missing: max_concurrent (sequential only), orchestrator role |
+| `todo` | `todo` | ✅ **Implemented.** In-memory task list with statuses (pending/in_progress/completed/cancelled). Read/write/merge modes. Grouped output. Full parity. |
+| `execute_code` | `execute_code` | ✅ **Implemented.** Run Python/Node/Ruby/Bash via subprocess. Respects security policy. Timeout (default 30s, max 300s). Output capped. Missing: programmatic tool access inside script |
+| `session_search` | `session_search` | ✅ **Implemented.** Substring search across session transcripts. Snippets with context, grouped by session. Missing: FTS5 backend, LLM summarization |
 
 ## Tools Hermes Has That PureClaw Lacks Entirely
 
 | Hermes Tool | What It Does | Impact |
 |---|---|---|
 | **`browser_*`** (12 tools) | Full browser automation -- navigate, click, type, scroll, screenshot, JS console, CDP | High -- entire capability missing |
-| **`execute_code`** | Run Python that calls tools programmatically (collapses multi-step pipelines) | Medium-high -- reduces inference round-trips |
-| **`todo`** | In-memory task list for decomposing complex work | Medium -- lightweight planning aid |
-| **`session_search`** | FTS5 search across past session transcripts with LLM summarization | Medium -- cross-session recall |
 | **`image_generate`** | Text-to-image via FAL.ai (FLUX, GPT-Image, etc.) | Low-medium -- niche but impressive |
 | **`text_to_speech`** | TTS via 5+ providers | Low -- niche |
 | **`mixture_of_agents`** | Multi-model reasoning synthesis | Low -- advanced reasoning aid |
@@ -128,7 +128,11 @@ Ordered by bang-for-buck (impact vs implementation effort):
 4. ~~**`web_extract`**~~ ✅ Done (HTML→markdown, truncation, size limits)
 5. ~~**`delegate_task`**~~ ✅ Done (isolated sub-agents, restricted toolsets, bounded turns)
 6. ~~**`patch` V4A mode**~~ ✅ Done (multi-file unified diff patches)
-7. **`todo`** -- Simple in-memory task tracking. Tiny implementation, helps agent plan multi-step work.
-8. **Shell backends** -- Docker/SSH execution. `ExecOptions` interface is ready; implement new `mkDockerShellHandle`/`mkSSHShellHandle`.
-9. **`message` platform expansion** -- Each platform is a separate integration. Low ROI without users on those platforms.
-10. **Browser automation** -- Big effort, big payoff, but MCP can cover this in the interim.
+7. ~~**`todo`**~~ ✅ Done (in-memory, read/write/merge, status grouping)
+8. ~~**`execute_code`**~~ ✅ Done (Python/Node/Ruby/Bash, security policy, timeout)
+9. ~~**`session_search`**~~ ✅ Done (substring search across transcripts)
+10. ~~**Edit: more fuzzy strategies**~~ ✅ Done (5 strategies total)
+11. ~~**Process: wait + close_stdin**~~ ✅ Done
+12. **Shell backends** -- Docker/SSH execution. `ExecOptions` interface is ready.
+13. **`message` platform expansion** -- Each platform is a separate integration.
+14. **Browser automation** -- Big effort, big payoff, but MCP can cover this in the interim.

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
                 age
                 age-plugin-yubikey
                 git
+                ripgrep
                 signal-cli
                 tmux
               ];

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -228,6 +228,7 @@ test-suite pureclaw-test
     Tools.FileReadSpec
     Tools.GitSpec
     Tools.MemorySpec
+    Tools.FileWriteSpec
     Tools.EditSpec
     Tools.ProcessSpec
     Handles.ProcessSpec

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -82,6 +82,9 @@ library
     PureClaw.Tools.Image
     PureClaw.Tools.SearchFiles
     PureClaw.Tools.Clarify
+    PureClaw.Tools.WebExtract
+    PureClaw.Tools.Patch
+    PureClaw.Tools.Delegate
     -- Agent
     PureClaw.Agent.AgentDef
     PureClaw.Agent.Completion
@@ -234,6 +237,9 @@ test-suite pureclaw-test
     Tools.ImageSpec
     Tools.SearchFilesSpec
     Tools.ClarifySpec
+    Tools.WebExtractSpec
+    Tools.PatchSpec
+    Tools.DelegateSpec
     Memory.MarkdownSpec
     Memory.SQLiteSpec
     Memory.NoneSpec

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -80,6 +80,8 @@ library
     PureClaw.Tools.Message
     PureClaw.Tools.Cron
     PureClaw.Tools.Image
+    PureClaw.Tools.SearchFiles
+    PureClaw.Tools.Clarify
     -- Agent
     PureClaw.Agent.AgentDef
     PureClaw.Agent.Completion
@@ -230,6 +232,8 @@ test-suite pureclaw-test
     Tools.MessageSpec
     Tools.CronSpec
     Tools.ImageSpec
+    Tools.SearchFilesSpec
+    Tools.ClarifySpec
     Memory.MarkdownSpec
     Memory.SQLiteSpec
     Memory.NoneSpec

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -85,6 +85,9 @@ library
     PureClaw.Tools.WebExtract
     PureClaw.Tools.Patch
     PureClaw.Tools.Delegate
+    PureClaw.Tools.Todo
+    PureClaw.Tools.ExecuteCode
+    PureClaw.Tools.SessionSearch
     -- Agent
     PureClaw.Agent.AgentDef
     PureClaw.Agent.Completion
@@ -241,6 +244,9 @@ test-suite pureclaw-test
     Tools.WebExtractSpec
     Tools.PatchSpec
     Tools.DelegateSpec
+    Tools.TodoSpec
+    Tools.ExecuteCodeSpec
+    Tools.SessionSearchSpec
     Memory.MarkdownSpec
     Memory.SQLiteSpec
     Memory.NoneSpec

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -501,7 +501,7 @@ runChat opts = do
         -- Build registry: pure tools + IO tools (todo needs IORef state)
         (todoDef, todoHandler) <- todoTool
         let sessSearchTool = sessionSearchTool logger (pureclawDir </> "sessions")
-            registry = uncurry registerTool (todoDef, todoHandler)
+            registry = registerTool todoDef todoHandler
                      $ uncurry registerTool sessSearchTool
                      $ buildRegistry policy sh workspace fh mh nh channel
         putStrLn "PureClaw 0.1.0 \x2014 Haskell-native AI agent runtime"

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -90,9 +90,12 @@ import PureClaw.Tools.FileWrite
 import PureClaw.Tools.Git
 import PureClaw.Tools.HttpRequest
 import PureClaw.Tools.Memory
+import PureClaw.Tools.Patch
 import PureClaw.Tools.Registry
 import PureClaw.Tools.SearchFiles
+import PureClaw.Tools.Delegate
 import PureClaw.Tools.Shell
+import PureClaw.Tools.WebExtract
 
 -- | Supported LLM providers.
 data ProviderType
@@ -593,13 +596,17 @@ runChat opts = do
         onFirstStreamDoneRef <- newIORef
           =<< resolveBootstrapCallback logger mAgentDef sessionHandle
         mcpRef <- newIORef Map.empty
-        let env = AgentEnv
+        -- Use lazy circular binding: delegateTaskTool captures env, and
+        -- env.registry includes the delegate tool. Haskell's laziness
+        -- makes this safe — the tool closure only forces env when invoked.
+        let fullRegistry = uncurry registerTool (delegateTaskTool env) registry
+            env = AgentEnv
               { _env_provider     = providerRef
               , _env_model        = modelRef
               , _env_channel      = channel
               , _env_logger       = logger
               , _env_systemPrompt = sysPrompt
-              , _env_registry     = registry
+              , _env_registry     = fullRegistry
               , _env_vault        = vaultRef
               , _env_pluginHandle = mkPluginHandle
               , _env_policy       = policy
@@ -720,12 +727,14 @@ buildRegistry policy sh workspace fh mh nh ch =
    $ reg (fileReadTool workspace fh)
    $ reg (fileWriteTool workspace fh)
    $ reg (editTool workspace fh)
+   $ reg (patchTool workspace fh)
    $ reg (searchFilesTool workspace)
    $ reg (clarifyTool ch)
    $ reg (gitTool policy sh)
    $ reg (memoryStoreTool mh)
    $ reg (memoryRecallTool mh)
    $ reg (httpRequestTool AllowAll nh)
+   $ reg (webExtractTool AllowAll nh)
      emptyRegistry
 
 -- | Build a security policy from optional autonomy level and allowed commands.

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -83,12 +83,15 @@ import PureClaw.Security.Vault
 import PureClaw.Security.Vault.Age
 import PureClaw.Security.Vault.Passphrase
 import PureClaw.Security.Vault.Plugin
+import PureClaw.Tools.Clarify
+import PureClaw.Tools.Edit
 import PureClaw.Tools.FileRead
 import PureClaw.Tools.FileWrite
 import PureClaw.Tools.Git
 import PureClaw.Tools.HttpRequest
 import PureClaw.Tools.Memory
 import PureClaw.Tools.Registry
+import PureClaw.Tools.SearchFiles
 import PureClaw.Tools.Shell
 
 -- | Supported LLM providers.
@@ -456,9 +459,6 @@ runChat opts = do
       nh        = mkNetworkHandle manager
   mh <- resolveMemory effectiveMemory
 
-  -- Tool registry
-  let registry = buildRegistry policy sh workspace fh mh nh
-
   hSetBuffering stdout LineBuffering
   case mProvider of
     Just _  -> _lh_logInfo logger $ "Provider: " <> T.pack (providerToText effectiveProvider)
@@ -492,6 +492,7 @@ runChat opts = do
 
   let startWithChannel :: ChannelHandle -> IO ()
       startWithChannel channel = do
+        let registry = buildRegistry policy sh workspace fh mh nh channel
         putStrLn "PureClaw 0.1.0 \x2014 Haskell-native AI agent runtime"
         case effectiveChannel of
           "cli" -> putStrLn "Type your message and press Enter. Ctrl-D to exit."
@@ -712,12 +713,15 @@ parseMemoryMaybe (Just t) = case T.unpack t of
   _          -> Nothing
 
 -- | Build the tool registry with all available tools.
-buildRegistry :: SecurityPolicy -> ShellHandle -> WorkspaceRoot -> FileHandle -> MemoryHandle -> NetworkHandle -> ToolRegistry
-buildRegistry policy sh workspace fh mh nh =
+buildRegistry :: SecurityPolicy -> ShellHandle -> WorkspaceRoot -> FileHandle -> MemoryHandle -> NetworkHandle -> ChannelHandle -> ToolRegistry
+buildRegistry policy sh workspace fh mh nh ch =
   let reg = uncurry registerTool
   in reg (shellTool policy sh)
    $ reg (fileReadTool workspace fh)
    $ reg (fileWriteTool workspace fh)
+   $ reg (editTool workspace fh)
+   $ reg (searchFilesTool workspace)
+   $ reg (clarifyTool ch)
    $ reg (gitTool policy sh)
    $ reg (memoryStoreTool mh)
    $ reg (memoryRecallTool mh)

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -94,7 +94,10 @@ import PureClaw.Tools.Patch
 import PureClaw.Tools.Registry
 import PureClaw.Tools.SearchFiles
 import PureClaw.Tools.Delegate
+import PureClaw.Tools.ExecuteCode
+import PureClaw.Tools.SessionSearch
 import PureClaw.Tools.Shell
+import PureClaw.Tools.Todo
 import PureClaw.Tools.WebExtract
 
 -- | Supported LLM providers.
@@ -495,7 +498,12 @@ runChat opts = do
 
   let startWithChannel :: ChannelHandle -> IO ()
       startWithChannel channel = do
-        let registry = buildRegistry policy sh workspace fh mh nh channel
+        -- Build registry: pure tools + IO tools (todo needs IORef state)
+        (todoDef, todoHandler) <- todoTool
+        let sessSearchTool = sessionSearchTool logger (pureclawDir </> "sessions")
+            registry = uncurry registerTool (todoDef, todoHandler)
+                     $ uncurry registerTool sessSearchTool
+                     $ buildRegistry policy sh workspace fh mh nh channel
         putStrLn "PureClaw 0.1.0 \x2014 Haskell-native AI agent runtime"
         case effectiveChannel of
           "cli" -> putStrLn "Type your message and press Enter. Ctrl-D to exit."
@@ -735,6 +743,7 @@ buildRegistry policy sh workspace fh mh nh ch =
    $ reg (memoryRecallTool mh)
    $ reg (httpRequestTool AllowAll nh)
    $ reg (webExtractTool AllowAll nh)
+   $ reg (executeCodeTool policy)
      emptyRegistry
 
 -- | Build a security policy from optional autonomy level and allowed commands.

--- a/src/PureClaw/Handles/Process.hs
+++ b/src/PureClaw/Handles/Process.hs
@@ -20,7 +20,8 @@ import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import System.Exit
-import System.IO (Handle, hFlush)
+import System.IO (Handle, hClose, hFlush)
+import System.Timeout qualified as Timeout
 import System.Process.Typed qualified as P
 
 import PureClaw.Handles.Log
@@ -52,6 +53,11 @@ data ProcessHandle = ProcessHandle
   , _ph_poll       :: ProcessId -> IO (Maybe ProcessStatus)
   , _ph_kill       :: ProcessId -> IO Bool
   , _ph_writeStdin :: ProcessId -> ByteString -> IO Bool
+  , _ph_wait       :: ProcessId -> Int -> IO (Maybe ProcessStatus)
+    -- ^ Block until process exits or timeout (milliseconds). Returns
+    -- 'Nothing' if process not found, 'Just status' on completion or timeout.
+  , _ph_closeStdin :: ProcessId -> IO Bool
+    -- ^ Close the stdin pipe of a process. Returns False if not found.
   }
 
 -- Internal entry tracking a background process.
@@ -153,6 +159,30 @@ mkProcessHandle logger = do
             case result of
               Left _ -> pure False
               Right () -> pure True
+
+    , _ph_wait = \(ProcessId pid) timeoutMs -> do
+        st <- readIORef stateRef
+        case Map.lookup pid (_pst_processes st) of
+          Nothing -> pure Nothing
+          Just entry -> do
+            result <- Timeout.timeout (timeoutMs * 1000)
+                        (Async.wait (_pe_exitAsync entry))
+            case result of
+              Nothing -> Just <$> getStatus entry  -- timeout, return current status
+              Just ec -> do
+                stdout <- readIORef (_pe_stdoutRef entry)
+                stderr <- readIORef (_pe_stderrRef entry)
+                pure (Just (ProcessDone ec stdout stderr))
+
+    , _ph_closeStdin = \(ProcessId pid) -> do
+        st <- readIORef stateRef
+        case Map.lookup pid (_pst_processes st) of
+          Nothing -> pure False
+          Just entry -> do
+            result <- try @SomeException (hClose (_pe_stdinH entry))
+            case result of
+              Left _  -> pure False
+              Right () -> pure True
     }
 
 -- | Read from a handle in a loop, appending to an IORef.
@@ -205,4 +235,6 @@ mkNoOpProcessHandle = ProcessHandle
   , _ph_poll       = \_ -> pure (Just (ProcessDone ExitSuccess "" ""))
   , _ph_kill       = \_ -> pure True
   , _ph_writeStdin = \_ _ -> pure True
+  , _ph_wait       = \_ _ -> pure (Just (ProcessDone ExitSuccess "" ""))
+  , _ph_closeStdin = \_ -> pure True
   }

--- a/src/PureClaw/Handles/Shell.hs
+++ b/src/PureClaw/Handles/Shell.hs
@@ -74,7 +74,7 @@ mkShellHandle logger = ShellHandle
   { _sh_execute = \opts cmd -> do
       let prog = getCommandProgram cmd
           args = map T.unpack (getCommandArgs cmd)
-          config = maybe id (\d -> P.setWorkingDir d) (_eo_workingDir opts)
+          config = maybe id P.setWorkingDir (_eo_workingDir opts)
                  $ P.setEnv safeEnv
                  $ P.proc prog args
       _lh_logInfo logger $ "Executing: " <> T.pack prog <> " " <> T.unwords (getCommandArgs cmd)

--- a/src/PureClaw/Handles/Shell.hs
+++ b/src/PureClaw/Handles/Shell.hs
@@ -1,6 +1,9 @@
 module PureClaw.Handles.Shell
   ( -- * Process result
     ProcessResult (..)
+    -- * Execution options
+  , ExecOptions (..)
+  , defaultExecOptions
     -- * Handle type
   , ShellHandle (..)
     -- * Implementations
@@ -11,8 +14,10 @@ module PureClaw.Handles.Shell
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
 import System.Exit
 import System.Process.Typed qualified as P
+import System.Timeout qualified as Timeout
 
 import PureClaw.Handles.Log
 import PureClaw.Security.Command
@@ -25,13 +30,36 @@ data ProcessResult = ProcessResult
   }
   deriving stock (Show, Eq)
 
+-- | Options controlling how a command is executed. Designed to be
+-- extended as new backends (Docker, SSH, etc.) are added — each
+-- backend interprets the fields it supports and ignores the rest.
+data ExecOptions = ExecOptions
+  { _eo_timeout    :: Maybe Int
+    -- ^ Timeout in milliseconds. 'Nothing' means no timeout.
+  , _eo_workingDir :: Maybe FilePath
+    -- ^ Working directory for the subprocess. 'Nothing' uses the
+    -- agent's current directory.
+  }
+  deriving stock (Show, Eq)
+
+-- | Default execution options: no timeout, inherit working directory.
+defaultExecOptions :: ExecOptions
+defaultExecOptions = ExecOptions
+  { _eo_timeout    = Nothing
+  , _eo_workingDir = Nothing
+  }
+
 -- | Subprocess execution capability. Only accepts 'AuthorizedCommand',
 -- which is proof that the command passed security policy evaluation.
 --
 -- The real implementation strips the subprocess environment to prevent
 -- secret leakage via inherited environment variables.
+--
+-- Backends (local, Docker, SSH, etc.) provide different implementations
+-- of this record. All backends receive 'ExecOptions' and interpret the
+-- fields they support.
 newtype ShellHandle = ShellHandle
-  { _sh_execute :: AuthorizedCommand -> IO ProcessResult
+  { _sh_execute :: ExecOptions -> AuthorizedCommand -> IO ProcessResult
   }
 
 -- | Minimal safe environment for subprocesses. Provides only PATH so
@@ -43,24 +71,37 @@ safeEnv = [("PATH", "/usr/bin:/bin:/usr/local/bin")]
 -- environment (provides only a minimal PATH) as noted in the architecture.
 mkShellHandle :: LogHandle -> ShellHandle
 mkShellHandle logger = ShellHandle
-  { _sh_execute = \cmd -> do
+  { _sh_execute = \opts cmd -> do
       let prog = getCommandProgram cmd
           args = map T.unpack (getCommandArgs cmd)
-          config = P.setEnv safeEnv
+          config = maybe id (\d -> P.setWorkingDir d) (_eo_workingDir opts)
+                 $ P.setEnv safeEnv
                  $ P.proc prog args
       _lh_logInfo logger $ "Executing: " <> T.pack prog <> " " <> T.unwords (getCommandArgs cmd)
-      (exitCode, outLazy, errLazy) <- P.readProcess config
-      pure ProcessResult
-        { _pr_exitCode = exitCode
-        , _pr_stdout   = BL.toStrict outLazy
-        , _pr_stderr   = BL.toStrict errLazy
-        }
+      let run = do
+            (exitCode, outLazy, errLazy) <- P.readProcess config
+            pure ProcessResult
+              { _pr_exitCode = exitCode
+              , _pr_stdout   = BL.toStrict outLazy
+              , _pr_stderr   = BL.toStrict errLazy
+              }
+      case _eo_timeout opts of
+        Nothing -> run
+        Just ms -> do
+          result <- Timeout.timeout (ms * 1000) run
+          case result of
+            Just r  -> pure r
+            Nothing -> pure ProcessResult
+              { _pr_exitCode = ExitFailure 124
+              , _pr_stdout   = ""
+              , _pr_stderr   = TE.encodeUtf8 ("Command timed out after " <> T.pack (show ms) <> "ms")
+              }
   }
 
 -- | No-op shell handle. Returns success with empty output.
 mkNoOpShellHandle :: ShellHandle
 mkNoOpShellHandle = ShellHandle
-  { _sh_execute = \_ -> pure ProcessResult
+  { _sh_execute = \_ _ -> pure ProcessResult
       { _pr_exitCode = ExitSuccess
       , _pr_stdout   = ""
       , _pr_stderr   = ""

--- a/src/PureClaw/Handles/Shell.hs
+++ b/src/PureClaw/Handles/Shell.hs
@@ -11,6 +11,7 @@ module PureClaw.Handles.Shell
   , mkNoOpShellHandle
   ) where
 
+import Control.Concurrent.Async qualified as Async
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.Text qualified as T
@@ -78,25 +79,44 @@ mkShellHandle logger = ShellHandle
                  $ P.setEnv safeEnv
                  $ P.proc prog args
       _lh_logInfo logger $ "Executing: " <> T.pack prog <> " " <> T.unwords (getCommandArgs cmd)
-      let run = do
-            (exitCode, outLazy, errLazy) <- P.readProcess config
-            pure ProcessResult
-              { _pr_exitCode = exitCode
-              , _pr_stdout   = BL.toStrict outLazy
-              , _pr_stderr   = BL.toStrict errLazy
-              }
       case _eo_timeout opts of
-        Nothing -> run
-        Just ms -> do
-          result <- Timeout.timeout (ms * 1000) run
-          case result of
-            Just r  -> pure r
-            Nothing -> pure ProcessResult
-              { _pr_exitCode = ExitFailure 124
-              , _pr_stdout   = ""
-              , _pr_stderr   = TE.encodeUtf8 ("Command timed out after " <> T.pack (show ms) <> "ms")
-              }
+        Nothing -> do
+          (exitCode, outLazy, errLazy) <- P.readProcess config
+          pure ProcessResult
+            { _pr_exitCode = exitCode
+            , _pr_stdout   = BL.toStrict outLazy
+            , _pr_stderr   = BL.toStrict errLazy
+            }
+        Just ms -> runWithTimeout config ms
   }
+
+-- | Run a process with a timeout. Launches the process via
+-- 'readProcess' on a background thread, then races it against a
+-- timer. On timeout the process is killed via 'Async.cancel' and a
+-- synthetic exit-124 result is returned.
+--
+-- This avoids the "waitForProcess: No child processes" error that
+-- occurs when 'System.Timeout.timeout' wrapping 'readProcess' races
+-- with the child reaper on Linux — 'Async.cancel' delivers a clean
+-- 'AsyncCancelled' that typed-process handles correctly.
+runWithTimeout :: P.ProcessConfig () () () -> Int -> IO ProcessResult
+runWithTimeout config ms = do
+  worker <- Async.async $ P.readProcess config
+  result <- Timeout.timeout (ms * 1000) (Async.wait worker)
+  case result of
+    Just (exitCode, outLazy, errLazy) ->
+      pure ProcessResult
+        { _pr_exitCode = exitCode
+        , _pr_stdout   = BL.toStrict outLazy
+        , _pr_stderr   = BL.toStrict errLazy
+        }
+    Nothing -> do
+      Async.cancel worker
+      pure ProcessResult
+        { _pr_exitCode = ExitFailure 124
+        , _pr_stdout   = ""
+        , _pr_stderr   = TE.encodeUtf8 ("Command timed out after " <> T.pack (show ms) <> "ms")
+        }
 
 -- | No-op shell handle. Returns success with empty output.
 mkNoOpShellHandle :: ShellHandle

--- a/src/PureClaw/Tools/Clarify.hs
+++ b/src/PureClaw/Tools/Clarify.hs
@@ -1,0 +1,101 @@
+module PureClaw.Tools.Clarify
+  ( -- * Tool registration
+    clarifyTool
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+
+import PureClaw.Handles.Channel
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+
+-- | Create a clarify tool that lets the agent ask the user structured questions.
+-- Supports open-ended questions and multiple choice (up to 4 options).
+clarifyTool :: ChannelHandle -> (ToolDefinition, ToolHandler)
+clarifyTool ch = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "clarify"
+      , _td_description = T.unlines
+          [ "Ask the user a clarifying question. Use when the request is ambiguous"
+          , "or you need more information before proceeding."
+          , "Supports open-ended questions (just question) or multiple choice"
+          , "(question + choices array, max 4 options)."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "question" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("The question to ask the user" :: Text)
+                  ]
+              , "choices" .= object
+                  [ "type" .= ("array" :: Text)
+                  , "items" .= object [ "type" .= ("string" :: Text) ]
+                  , "maxItems" .= (4 :: Int)
+                  , "description" .= ("Optional: up to 4 multiple-choice options" :: Text)
+                  ]
+              ]
+          , "required" .= (["question"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseClarifyInput input of
+        Left err -> pure (T.pack err, True)
+        Right ci -> askUser ci
+
+    askUser :: ClarifyInput -> IO (Text, Bool)
+    askUser ci = do
+      let prompt = formatPrompt (_ci_question ci) (_ci_choices ci)
+      result <- try @SomeException (_ch_prompt ch prompt)
+      case result of
+        Left e -> pure ("Failed to get user response: " <> T.pack (show e), True)
+        Right response -> do
+          let resolved = resolveChoice response (_ci_choices ci)
+          pure (encodeResponse (_ci_question ci) (_ci_choices ci) resolved, False)
+
+    formatPrompt :: Text -> Maybe [Text] -> Text
+    formatPrompt question Nothing = question <> "\n> "
+    formatPrompt question (Just choices) =
+      let numbered = zipWith (\i c -> T.pack (show (i :: Int)) <> ". " <> c) [1..] choices
+      in question <> "\n" <> T.unlines numbered <> T.pack (show (length choices + 1)) <> ". Other\n> "
+
+    resolveChoice :: Text -> Maybe [Text] -> Text
+    resolveChoice response Nothing = response
+    resolveChoice response (Just choices) =
+      case reads (T.unpack (T.strip response)) :: [(Int, String)] of
+        [(n, "")] | n >= 1 && n <= length choices -> choices !! (n - 1)
+                  | n == length choices + 1        -> response  -- "Other" selected
+                  | otherwise                      -> response  -- out of range, treat as freeform
+        _                                          -> response  -- non-numeric, treat as freeform
+
+    encodeResponse :: Text -> Maybe [Text] -> Text -> Text
+    encodeResponse question choices answer =
+      let result = object $
+            [ "question" .= question
+            , "user_response" .= answer
+            ] <> maybe [] (\cs -> ["choices_offered" .= cs]) choices
+      in case encode result of
+        bs -> TE.decodeUtf8Lenient (toStrictBS bs)
+
+    toStrictBS :: BL.ByteString -> BS.ByteString
+    toStrictBS = BL.toStrict
+
+data ClarifyInput = ClarifyInput
+  { _ci_question :: Text
+  , _ci_choices  :: Maybe [Text]
+  }
+
+parseClarifyInput :: Value -> Parser ClarifyInput
+parseClarifyInput = withObject "ClarifyInput" $ \o ->
+  ClarifyInput
+    <$> o .:  "question"
+    <*> o .:? "choices"

--- a/src/PureClaw/Tools/Delegate.hs
+++ b/src/PureClaw/Tools/Delegate.hs
@@ -1,0 +1,167 @@
+module PureClaw.Tools.Delegate
+  ( -- * Tool registration
+    delegateTaskTool
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.IORef
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import PureClaw.Agent.Context
+import PureClaw.Agent.Env
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+
+-- | Create a delegate_task tool that spawns an isolated sub-agent
+-- to complete a goal. The sub-agent runs with a restricted toolset
+-- (optionally filtered), a bounded turn count, and returns a summary
+-- of its work.
+--
+-- The sub-agent uses the same provider and model as the parent but
+-- gets its own context (no conversation history leakage). It cannot
+-- access the parent's session, vault, or harnesses.
+delegateTaskTool :: AgentEnv -> (ToolDefinition, ToolHandler)
+delegateTaskTool parentEnv = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "delegate_task"
+      , _td_description = T.unlines
+          [ "Spawn an isolated sub-agent to complete a focused task."
+          , "The sub-agent has its own context (no conversation history leakage)"
+          , "and a restricted toolset. It runs for up to max_turns (default: 10)"
+          , "and returns a summary of its work."
+          , "Use for: parallel subtasks, research, code generation, analysis."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "goal" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("What the sub-agent should accomplish" :: Text)
+                  ]
+              , "context" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Additional context to include in the sub-agent's system prompt" :: Text)
+                  ]
+              , "tools" .= object
+                  [ "type" .= ("array" :: Text)
+                  , "items" .= object ["type" .= ("string" :: Text)]
+                  , "description" .= ("Restrict sub-agent to these tool names (default: all parent tools except delegate_task)" :: Text)
+                  ]
+              , "max_turns" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Maximum conversation turns (default: 10, max: 30)" :: Text)
+                  ]
+              ]
+          , "required" .= (["goal"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseDelegateInput input of
+        Left err -> pure (T.pack err, True)
+        Right di -> runDelegate di
+
+    runDelegate :: DelegateInput -> IO (Text, Bool)
+    runDelegate di = do
+      -- Check provider is available
+      mProvider <- readIORef (_env_provider parentEnv)
+      case mProvider of
+        Nothing -> pure ("Cannot delegate: no provider configured", True)
+        Just provider -> do
+          mModel <- readIORef (_env_model parentEnv)
+          case mModel of
+            Nothing -> pure ("Cannot delegate: no model configured", True)
+            Just model -> do
+              let maxTurns = min 30 (fromMaybe 10 (_di_maxTurns di))
+                  subRegistry = buildSubRegistry (_di_tools di)
+                  sysPrompt = buildSubSystemPrompt (_di_goal di) (_di_context di)
+              result <- try @SomeException $
+                runSubAgent provider model subRegistry sysPrompt (_di_goal di) maxTurns
+              case result of
+                Left e -> pure ("delegate_task error: " <> T.pack (show e), True)
+                Right output -> pure (output, False)
+
+    buildSubRegistry :: Maybe [Text] -> ToolRegistry
+    buildSubRegistry Nothing =
+      -- All parent tools except delegate_task (prevent recursive delegation)
+      filterRegistry (/= "delegate_task") (_env_registry parentEnv)
+    buildSubRegistry (Just names) =
+      filterRegistry (\n -> n `elem` names && n /= "delegate_task") (_env_registry parentEnv)
+
+    buildSubSystemPrompt :: Text -> Maybe Text -> Maybe Text
+    buildSubSystemPrompt goal mContext =
+      Just $ T.unlines $ filter (not . T.null)
+        [ "You are a focused sub-agent. Complete the following task and report your results concisely."
+        , ""
+        , "TASK: " <> goal
+        , maybe "" (\c -> "\nCONTEXT: " <> c) mContext
+        , ""
+        , "When you have completed the task, provide a clear summary of what you did and the results."
+        , "Do not ask clarifying questions — work with what you have."
+        ]
+
+-- | Run a bounded sub-agent conversation.
+-- Returns the final assistant response text.
+runSubAgent
+  :: SomeProvider
+  -> ModelId
+  -> ToolRegistry
+  -> Maybe Text
+  -> Text
+  -> Int
+  -> IO Text
+runSubAgent provider model registry sysPrompt goal maxTurns = do
+  let ctx0 = addMessage (textMessage User goal) (emptyContext sysPrompt)
+      tools = registryDefinitions registry
+  go ctx0 tools maxTurns
+  where
+    go _ctx _tools 0 = pure "[Sub-agent reached maximum turn limit]"
+    go ctx tools turnsLeft = do
+      let req = CompletionRequest
+            { _cr_model        = model
+            , _cr_messages     = contextMessages ctx
+            , _cr_systemPrompt = contextSystemPrompt ctx
+            , _cr_maxTokens    = Just 4096
+            , _cr_tools        = tools
+            , _cr_toolChoice   = Nothing
+            }
+      resp <- complete provider req
+      let calls = toolUseCalls resp
+          text = responseText resp
+          ctx' = addMessage (Message Assistant (_crsp_content resp)) ctx
+      if null calls
+        then pure text  -- Sub-agent is done
+        else do
+          -- Execute tool calls
+          results <- mapM (executeSubCall registry) calls
+          let resultMsg = toolResultMessage results
+              ctx'' = addMessage resultMsg ctx'
+          go ctx'' tools (turnsLeft - 1)
+
+    executeSubCall :: ToolRegistry -> (ToolCallId, Text, Value) -> IO (ToolCallId, [ToolResultPart], Bool)
+    executeSubCall reg (callId, name, input) = do
+      result <- executeTool reg name input
+      case result of
+        Nothing -> pure (callId, [TRPText ("Unknown tool: " <> name)], True)
+        Just (parts, isErr) -> pure (callId, parts, isErr)
+
+data DelegateInput = DelegateInput
+  { _di_goal     :: Text
+  , _di_context  :: Maybe Text
+  , _di_tools    :: Maybe [Text]
+  , _di_maxTurns :: Maybe Int
+  }
+
+parseDelegateInput :: Value -> Parser DelegateInput
+parseDelegateInput = withObject "DelegateInput" $ \o ->
+  DelegateInput
+    <$> o .:  "goal"
+    <*> o .:? "context"
+    <*> o .:? "tools"
+    <*> o .:? "max_turns"

--- a/src/PureClaw/Tools/Delegate.hs
+++ b/src/PureClaw/Tools/Delegate.hs
@@ -100,7 +100,7 @@ delegateTaskTool parentEnv = (def, handler)
         [ "You are a focused sub-agent. Complete the following task and report your results concisely."
         , ""
         , "TASK: " <> goal
-        , maybe "" (\c -> "\nCONTEXT: " <> c) mContext
+        , maybe "" (("\nCONTEXT: " <>) ) mContext
         , ""
         , "When you have completed the task, provide a clear summary of what you did and the results."
         , "Do not ask clarifying questions — work with what you have."

--- a/src/PureClaw/Tools/Delegate.hs
+++ b/src/PureClaw/Tools/Delegate.hs
@@ -100,7 +100,7 @@ delegateTaskTool parentEnv = (def, handler)
         [ "You are a focused sub-agent. Complete the following task and report your results concisely."
         , ""
         , "TASK: " <> goal
-        , maybe "" (("\nCONTEXT: " <>) ) mContext
+        , maybe "" ("\nCONTEXT: " <>) mContext
         , ""
         , "When you have completed the task, provide a clear summary of what you did and the results."
         , "Do not ask clarifying questions — work with what you have."

--- a/src/PureClaw/Tools/Edit.hs
+++ b/src/PureClaw/Tools/Edit.hs
@@ -1,6 +1,12 @@
 module PureClaw.Tools.Edit
   ( -- * Tool registration
     editTool
+    -- * Internals (exported for testing)
+  , countOccurrences
+  , replaceFirst
+  , replaceAll
+  , fuzzyFind
+  , FuzzyMatch (..)
   ) where
 
 import Control.Exception
@@ -17,13 +23,19 @@ import PureClaw.Security.Path
 import PureClaw.Tools.Registry
 
 -- | Create an edit tool that performs string replacement in files.
--- The old string must be unique in the file — ambiguous edits are rejected.
+-- Supports exact matching (default), fuzzy matching (fallback when exact
+-- match fails), and replace_all mode.
 editTool :: WorkspaceRoot -> FileHandle -> (ToolDefinition, ToolHandler)
 editTool root fh = (def, handler)
   where
     def = ToolDefinition
       { _td_name        = "edit"
-      , _td_description = "Replace a unique string in a file. The old_string must appear exactly once in the file."
+      , _td_description = T.unlines
+          [ "Replace a string in a file. By default, old_string must appear"
+          , "exactly once (unique match). Set replace_all to true to replace"
+          , "every occurrence. If an exact match fails, fuzzy matching is"
+          , "attempted (normalizing whitespace and line endings)."
+          ]
       , _td_inputSchema = object
           [ "type" .= ("object" :: Text)
           , "properties" .= object
@@ -33,11 +45,15 @@ editTool root fh = (def, handler)
                   ]
               , "old_string" .= object
                   [ "type" .= ("string" :: Text)
-                  , "description" .= ("The exact string to find and replace (must be unique)" :: Text)
+                  , "description" .= ("The string to find and replace" :: Text)
                   ]
               , "new_string" .= object
                   [ "type" .= ("string" :: Text)
                   , "description" .= ("The replacement string" :: Text)
+                  ]
+              , "replace_all" .= object
+                  [ "type" .= ("boolean" :: Text)
+                  , "description" .= ("Replace all occurrences instead of requiring a unique match (default: false)" :: Text)
                   ]
               ]
           , "required" .= (["path", "old_string", "new_string"] :: [Text])
@@ -47,8 +63,8 @@ editTool root fh = (def, handler)
     handler = ToolHandler $ \input ->
       case parseEither parseInput input of
         Left err -> pure (T.pack err, True)
-        Right (path, oldStr, newStr) -> do
-          pathResult <- mkSafePath root (T.unpack path)
+        Right ei -> do
+          pathResult <- mkSafePath root (T.unpack (_ei_path ei))
           case pathResult of
             Left pe -> pure (T.pack (show pe), True)
             Right sp -> do
@@ -57,23 +73,193 @@ editTool root fh = (def, handler)
                 Left e -> pure (T.pack (show e), True)
                 Right bs -> case TE.decodeUtf8' bs of
                   Left _ -> pure ("Cannot edit binary file", True)
-                  Right content ->
-                    let count = countOccurrences oldStr content
-                    in case count of
-                      0 -> pure ("old_string not found in " <> path, True)
-                      1 -> do
-                        let newContent = replaceFirst oldStr newStr content
-                        writeResult <- try @SomeException
-                          (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
-                        case writeResult of
-                          Left e -> pure (T.pack (show e), True)
-                          Right () -> pure ("Edited " <> path, False)
-                      n -> pure ("old_string not unique in " <> path
-                                <> " (" <> T.pack (show n) <> " occurrences)", True)
+                  Right content -> applyEdit ei sp content
 
-    parseInput :: Value -> Parser (Text, Text, Text)
+    applyEdit :: EditInput -> SafePath -> Text -> IO (Text, Bool)
+    applyEdit ei sp content
+      | _ei_replaceAll ei = doReplaceAll ei sp content
+      | otherwise         = doUnique ei sp content
+
+    doReplaceAll :: EditInput -> SafePath -> Text -> IO (Text, Bool)
+    doReplaceAll ei sp content = do
+      let count = countOccurrences (_ei_oldString ei) content
+      if count == 0
+        then tryFuzzyReplaceAll ei sp content
+        else do
+          let newContent = replaceAll (_ei_oldString ei) (_ei_newString ei) content
+          writeResult <- try @SomeException
+            (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+          case writeResult of
+            Left e -> pure (T.pack (show e), True)
+            Right () -> pure ("Replaced " <> T.pack (show count) <> " occurrence(s) in " <> _ei_path ei, False)
+
+    doUnique :: EditInput -> SafePath -> Text -> IO (Text, Bool)
+    doUnique ei sp content = do
+      let count = countOccurrences (_ei_oldString ei) content
+      case count of
+        0 -> tryFuzzy ei sp content
+        1 -> do
+          let newContent = replaceFirst (_ei_oldString ei) (_ei_newString ei) content
+          writeResult <- try @SomeException
+            (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+          case writeResult of
+            Left e -> pure (T.pack (show e), True)
+            Right () -> pure ("Edited " <> _ei_path ei, False)
+        n -> pure ("old_string not unique in " <> _ei_path ei
+                   <> " (" <> T.pack (show n) <> " occurrences). Use replace_all: true to replace all.", True)
+
+    tryFuzzy :: EditInput -> SafePath -> Text -> IO (Text, Bool)
+    tryFuzzy ei sp content =
+      case fuzzyFind (_ei_oldString ei) content of
+        NoFuzzyMatch ->
+          pure ("old_string not found in " <> _ei_path ei, True)
+        AmbiguousFuzzy n strategy ->
+          pure ("old_string not unique via " <> strategy <> " matching in " <> _ei_path ei
+                <> " (" <> T.pack (show n) <> " occurrences)", True)
+        UniqueFuzzy matched strategy -> do
+          let newContent = replaceFirst matched (_ei_newString ei) content
+          writeResult <- try @SomeException
+            (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+          case writeResult of
+            Left e -> pure (T.pack (show e), True)
+            Right () -> pure ("Edited " <> _ei_path ei <> " (matched via " <> strategy <> ")", False)
+
+    tryFuzzyReplaceAll :: EditInput -> SafePath -> Text -> IO (Text, Bool)
+    tryFuzzyReplaceAll ei sp content =
+      case fuzzyFind (_ei_oldString ei) content of
+        NoFuzzyMatch ->
+          pure ("old_string not found in " <> _ei_path ei, True)
+        AmbiguousFuzzy n strategy -> do
+          -- For replace_all with fuzzy, ambiguous is fine — replace them all
+          let matched = fuzzyFindPattern (_ei_oldString ei) strategy
+          case matched of
+            Nothing -> pure ("old_string not found in " <> _ei_path ei, True)
+            Just pat -> do
+              let newContent = replaceAll pat (_ei_newString ei) content
+              writeResult <- try @SomeException
+                (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+              case writeResult of
+                Left e -> pure (T.pack (show e), True)
+                Right () -> pure ("Replaced " <> T.pack (show n)
+                                  <> " occurrence(s) in " <> _ei_path ei
+                                  <> " (matched via " <> strategy <> ")", False)
+        UniqueFuzzy matched strategy -> do
+          let newContent = replaceFirst matched (_ei_newString ei) content
+          writeResult <- try @SomeException
+            (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+          case writeResult of
+            Left e -> pure (T.pack (show e), True)
+            Right () -> pure ("Replaced 1 occurrence(s) in " <> _ei_path ei
+                              <> " (matched via " <> strategy <> ")", False)
+
+    parseInput :: Value -> Parser EditInput
     parseInput = withObject "EditInput" $ \o ->
-      (,,) <$> o .: "path" <*> o .: "old_string" <*> o .: "new_string"
+      EditInput
+        <$> o .:  "path"
+        <*> o .:  "old_string"
+        <*> o .:  "new_string"
+        <*> o .:? "replace_all" .!= False
+
+data EditInput = EditInput
+  { _ei_path       :: Text
+  , _ei_oldString  :: Text
+  , _ei_newString  :: Text
+  , _ei_replaceAll :: Bool
+  }
+
+-- | Result of a fuzzy search.
+data FuzzyMatch
+  = NoFuzzyMatch
+    -- ^ No match found by any strategy.
+  | UniqueFuzzy Text Text
+    -- ^ Unique match found. Fields: matched text, strategy name.
+  | AmbiguousFuzzy Int Text
+    -- ^ Multiple matches found. Fields: count, strategy name.
+  deriving stock (Show, Eq)
+
+-- | Try fuzzy matching strategies in priority order.
+-- Each strategy normalizes the needle and haystack differently,
+-- then searches for the normalized needle in the normalized haystack.
+fuzzyFind :: Text -> Text -> FuzzyMatch
+fuzzyFind needle haystack = tryStrategies strategies
+  where
+    strategies =
+      [ ("whitespace-normalized", normalizeWhitespace)
+      , ("trimmed-lines", trimLines)
+      , ("line-ending-normalized", normalizeLineEndings)
+      ]
+
+    tryStrategies :: [(Text, Text -> Text)] -> FuzzyMatch
+    tryStrategies [] = NoFuzzyMatch
+    tryStrategies ((name, normalize):rest) =
+      let normNeedle   = normalize needle
+          normHaystack = normalize haystack
+          count = countOccurrences normNeedle normHaystack
+      in case count of
+        0 -> tryStrategies rest
+        1 -> case findOriginal normalize needle haystack of
+          Nothing   -> tryStrategies rest
+          Just orig -> UniqueFuzzy orig name
+        n -> AmbiguousFuzzy n name
+
+-- | Given a normalization function and the original needle and haystack,
+-- find the original text in the haystack that corresponds to the
+-- normalized match.
+findOriginal :: (Text -> Text) -> Text -> Text -> Maybe Text
+findOriginal normalize needle haystack =
+  let normNeedle = normalize needle
+      normLen = T.length normNeedle
+      normH = normalize haystack
+      -- Find the position in the normalized haystack
+      (before, _) = T.breakOn normNeedle normH
+      normPos = T.length before
+      -- Map back to original: scan original haystack, tracking
+      -- normalized character count to find the start position
+  in mapBackToOriginal normalize normPos normLen haystack
+
+-- | Map a position in the normalized text back to the original text.
+-- Returns the original substring that normalizes to the match.
+mapBackToOriginal :: (Text -> Text) -> Int -> Int -> Text -> Maybe Text
+mapBackToOriginal normalize normPos normLen original =
+  -- Strategy: try progressively longer substrings at each starting
+  -- position until we find one whose normalization contains our match.
+  -- This is O(n²) in the worst case but files are bounded in practice.
+  let origLen = T.length original
+      candidates =
+        [ T.take len (T.drop start original)
+        | start <- [0..origLen - 1]
+        , len   <- [1..origLen - start]
+        , let normed = normalize (T.take len (T.drop start original))
+        , T.length normed >= normLen
+        , let normBefore = normalize (T.take start original)
+        , T.length normBefore == normPos
+        , normed == T.take normLen (T.drop normPos (normalize original))
+        ]
+  in case candidates of
+    (c:_) -> Just c
+    []    -> Nothing
+
+-- | Get the fuzzy pattern text for a strategy (used by replace_all).
+fuzzyFindPattern :: Text -> Text -> Maybe Text
+fuzzyFindPattern needle strategy =
+  let normalize = case strategy of
+        "whitespace-normalized" -> normalizeWhitespace
+        "trimmed-lines"        -> trimLines
+        "line-ending-normalized" -> normalizeLineEndings
+        _                      -> id
+  in Just (normalize needle)
+
+-- | Normalize all whitespace runs to single spaces, trim.
+normalizeWhitespace :: Text -> Text
+normalizeWhitespace = T.unwords . T.words
+
+-- | Trim leading/trailing whitespace from each line.
+trimLines :: Text -> Text
+trimLines = T.unlines . map T.strip . T.lines
+
+-- | Normalize line endings: \r\n → \n
+normalizeLineEndings :: Text -> Text
+normalizeLineEndings = T.replace "\r\n" "\n"
 
 -- | Count non-overlapping occurrences of a needle in a haystack.
 countOccurrences :: Text -> Text -> Int
@@ -92,3 +278,9 @@ replaceFirst :: Text -> Text -> Text -> Text
 replaceFirst needle replacement haystack =
   let (before, after) = T.breakOn needle haystack
   in before <> replacement <> T.drop (T.length needle) after
+
+-- | Replace all non-overlapping occurrences of needle with replacement.
+replaceAll :: Text -> Text -> Text -> Text
+replaceAll needle replacement haystack
+  | T.null needle = haystack
+  | otherwise     = T.intercalate replacement (T.splitOn needle haystack)

--- a/src/PureClaw/Tools/Edit.hs
+++ b/src/PureClaw/Tools/Edit.hs
@@ -187,6 +187,8 @@ fuzzyFind needle haystack = tryStrategies strategies
       [ ("whitespace-normalized", normalizeWhitespace)
       , ("trimmed-lines", trimLines)
       , ("line-ending-normalized", normalizeLineEndings)
+      , ("indentation-normalized", normalizeIndentation)
+      , ("case-insensitive", T.toLower)
       ]
 
     tryStrategies :: [(Text, Text -> Text)] -> FuzzyMatch
@@ -243,10 +245,12 @@ mapBackToOriginal normalize normPos normLen original =
 fuzzyFindPattern :: Text -> Text -> Maybe Text
 fuzzyFindPattern needle strategy =
   let normalize = case strategy of
-        "whitespace-normalized" -> normalizeWhitespace
-        "trimmed-lines"        -> trimLines
-        "line-ending-normalized" -> normalizeLineEndings
-        _                      -> id
+        "whitespace-normalized"   -> normalizeWhitespace
+        "trimmed-lines"           -> trimLines
+        "line-ending-normalized"  -> normalizeLineEndings
+        "indentation-normalized"  -> normalizeIndentation
+        "case-insensitive"        -> T.toLower
+        _                         -> id
   in Just (normalize needle)
 
 -- | Normalize all whitespace runs to single spaces, trim.
@@ -260,6 +264,11 @@ trimLines = T.unlines . map T.strip . T.lines
 -- | Normalize line endings: \r\n → \n
 normalizeLineEndings :: Text -> Text
 normalizeLineEndings = T.replace "\r\n" "\n"
+
+-- | Normalize indentation: strip all leading whitespace from each line.
+-- This handles mismatched tabs-vs-spaces and indent-level differences.
+normalizeIndentation :: Text -> Text
+normalizeIndentation = T.unlines . map T.stripStart . T.lines
 
 -- | Count non-overlapping occurrences of a needle in a haystack.
 countOccurrences :: Text -> Text -> Int

--- a/src/PureClaw/Tools/ExecuteCode.hs
+++ b/src/PureClaw/Tools/ExecuteCode.hs
@@ -1,0 +1,125 @@
+module PureClaw.Tools.ExecuteCode
+  ( -- * Tool registration
+    executeCodeTool
+  ) where
+
+import Control.Concurrent.Async qualified as Async
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString.Lazy qualified as BL
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import System.Exit
+import System.Process.Typed qualified as P
+import System.Timeout qualified as Timeout
+
+import PureClaw.Providers.Class
+import PureClaw.Security.Command
+import PureClaw.Security.Policy
+import PureClaw.Tools.Registry
+
+-- | Create an execute_code tool that runs Python (or other language)
+-- code in a subprocess. The interpreter must be allowed by the
+-- security policy. Output is capped at 50KB stdout / 10KB stderr.
+executeCodeTool :: SecurityPolicy -> (ToolDefinition, ToolHandler)
+executeCodeTool policy = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "execute_code"
+      , _td_description = T.unlines
+          [ "Execute code in a subprocess. The interpreter (python3, node, etc.)"
+          , "must be allowed by the security policy."
+          , "Code is passed via stdin. Output is capped at 50KB stdout / 10KB stderr."
+          , "Default timeout: 30 seconds (configurable up to 300s)."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "code" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("The code to execute" :: Text)
+                  ]
+              , "language" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Language/interpreter: python3, node, ruby, bash (default: python3)" :: Text)
+                  ]
+              , "timeout" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Timeout in seconds (default: 30, max: 300)" :: Text)
+                  ]
+              ]
+          , "required" .= (["code"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseCodeInput input of
+        Left err -> pure (T.pack err, True)
+        Right ci -> runCode ci
+
+    runCode :: CodeInput -> IO (Text, Bool)
+    runCode ci = do
+      let interpreter = resolveInterpreter (_ci_language ci)
+          timeoutSec = min 300 (fromMaybe 30 (_ci_timeout ci))
+      case authorize policy (T.unpack interpreter) ["-"] of
+        Left (CommandNotAllowed _) ->
+          pure ("Interpreter not allowed: " <> interpreter
+               <> ". Add it to --allow or set --autonomy full.", True)
+        Left CommandInAutonomyDeny ->
+          pure ("All commands denied by security policy", True)
+        Right _authorized -> do
+          let config = P.setStdin (P.byteStringInput (BL.fromStrict (TE.encodeUtf8 (_ci_code ci))))
+                     $ P.setEnv safeEnv
+                     $ P.proc (T.unpack interpreter) ["-"]
+          worker <- Async.async $ P.readProcess config
+          result <- Timeout.timeout (timeoutSec * 1000000) (Async.wait worker)
+          case result of
+            Nothing -> do
+              Async.cancel worker
+              pure ("Code execution timed out after " <> T.pack (show timeoutSec) <> "s", True)
+            Just (exitCode, outLazy, errLazy) ->
+              let outBs = BL.toStrict outLazy
+                  errBs = BL.toStrict errLazy
+                  out = truncateOutput 51200 (TE.decodeUtf8Lenient outBs)
+                  err = truncateOutput 10240 (TE.decodeUtf8Lenient errBs)
+                  exitInfo = case exitCode of
+                    ExitSuccess   -> ""
+                    ExitFailure n -> "\nExit code: " <> T.pack (show n)
+                  parts = filter (not . T.null) [out, err, exitInfo]
+                  combined = T.strip (T.intercalate "\n" parts)
+              in pure (if T.null combined then "(no output)" else combined,
+                       exitCode /= ExitSuccess)
+
+    resolveInterpreter :: Maybe Text -> Text
+    resolveInterpreter Nothing          = "python3"
+    resolveInterpreter (Just "python")  = "python3"
+    resolveInterpreter (Just "python3") = "python3"
+    resolveInterpreter (Just "node")    = "node"
+    resolveInterpreter (Just "ruby")    = "ruby"
+    resolveInterpreter (Just "bash")    = "bash"
+    resolveInterpreter (Just "sh")      = "sh"
+    resolveInterpreter (Just other)     = other
+
+    truncateOutput :: Int -> Text -> Text
+    truncateOutput maxLen t
+      | T.length t <= maxLen = t
+      | otherwise = T.take maxLen t <> "\n[...truncated at " <> T.pack (show maxLen) <> " chars]"
+
+-- | Minimal safe environment for subprocesses.
+safeEnv :: [(String, String)]
+safeEnv = [("PATH", "/usr/bin:/bin:/usr/local/bin")]
+
+data CodeInput = CodeInput
+  { _ci_code     :: Text
+  , _ci_language :: Maybe Text
+  , _ci_timeout  :: Maybe Int
+  }
+
+parseCodeInput :: Value -> Parser CodeInput
+parseCodeInput = withObject "CodeInput" $ \o ->
+  CodeInput
+    <$> o .:  "code"
+    <*> o .:? "language"
+    <*> o .:? "timeout"

--- a/src/PureClaw/Tools/FileWrite.hs
+++ b/src/PureClaw/Tools/FileWrite.hs
@@ -10,6 +10,8 @@ import Data.ByteString qualified as BS
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
+import System.Directory (canonicalizePath, createDirectoryIfMissing)
+import System.FilePath ((</>), takeDirectory)
 
 import PureClaw.Core.Types
 import PureClaw.Handles.File
@@ -59,22 +61,25 @@ fileWriteTool root fh = (def, handler)
 
     writeNew :: WorkspaceRoot -> Text -> Text -> IO (Text, Bool)
     writeNew (WorkspaceRoot wr) path content = do
-      -- Create the file first so mkSafePath can validate it exists
-      let fullPath = wr <> "/" <> T.unpack path
-      result <- try @SomeException (TE.encodeUtf8 content `seq` pure ())
-      case result of
+      -- Canonicalize the workspace root so the constructed path matches
+      -- what mkSafePath will resolve to (e.g. /tmp → /private/tmp on macOS).
+      canonRoot <- canonicalizePath wr
+      let fullPath = canonRoot </> T.unpack path
+      -- Create parent directories (e.g. for "docs/foo.md")
+      writeResult <- try @SomeException $ do
+        createDirectoryIfMissing True (takeDirectory fullPath)
+        BS.writeFile fullPath (TE.encodeUtf8 content)
+      case writeResult of
         Left e -> pure (T.pack (show e), True)
         Right () -> do
-          writeResult <- try @SomeException $ do
-            BS.writeFile fullPath (TE.encodeUtf8 content)
-          case writeResult of
-            Left e -> pure (T.pack (show e), True)
-            Right () -> do
-              -- Validate the written file is safe
-              validated <- mkSafePath (WorkspaceRoot wr) fullPath
-              case validated of
-                Left pe -> pure (T.pack (show pe), True)
-                Right _ -> pure ("Written to " <> path, False)
+          -- Validate the written file is safe (canonicalized path within workspace)
+          validated <- mkSafePath (WorkspaceRoot wr) fullPath
+          case validated of
+            Left pe -> do
+              -- Wrote an unsafe file — clean it up
+              _ <- try @SomeException (BS.writeFile fullPath BS.empty)
+              pure (T.pack (show pe), True)
+            Right _ -> pure ("Written to " <> path, False)
 
     parseInput :: Value -> Parser (Text, Text)
     parseInput = withObject "FileWriteInput" $ \o ->

--- a/src/PureClaw/Tools/Git.hs
+++ b/src/PureClaw/Tools/Git.hs
@@ -45,7 +45,7 @@ gitTool policy sh = (def, handler)
             Left (CommandNotAllowed _) -> pure ("git is not in the allowed commands list", True)
             Left CommandInAutonomyDeny -> pure ("All commands denied by security policy", True)
             Right authorized -> do
-              result <- try @SomeException (_sh_execute sh authorized)
+              result <- try @SomeException (_sh_execute sh defaultExecOptions authorized)
               case result of
                 Left e -> pure (T.pack (show e), True)
                 Right pr -> do

--- a/src/PureClaw/Tools/Patch.hs
+++ b/src/PureClaw/Tools/Patch.hs
@@ -138,7 +138,7 @@ applyHunk content hunk =
     Nothing ->
       -- Try without context (just removals)
       case findPattern (_ph_removals hunk) contentLines of
-        Nothing -> Left ("hunk failed: could not find target lines")
+        Nothing -> Left "hunk failed: could not find target lines"
         Just idx ->
           let before = take idx contentLines
               after  = drop (idx + length (_ph_removals hunk)) contentLines

--- a/src/PureClaw/Tools/Patch.hs
+++ b/src/PureClaw/Tools/Patch.hs
@@ -1,0 +1,240 @@
+module PureClaw.Tools.Patch
+  ( -- * Tool registration
+    patchTool
+    -- * Internals (exported for testing)
+  , parsePatch
+  , PatchHunk (..)
+  , PatchFile (..)
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+
+import PureClaw.Core.Types
+import PureClaw.Handles.File
+import PureClaw.Providers.Class
+import PureClaw.Security.Path
+import PureClaw.Tools.Registry
+
+-- | A single hunk within a patch file.
+data PatchHunk = PatchHunk
+  { _ph_removals :: [Text]
+    -- ^ Lines to remove (without the '-' prefix)
+  , _ph_additions :: [Text]
+    -- ^ Lines to add (without the '+' prefix)
+  , _ph_context :: [Text]
+    -- ^ Context lines (without the ' ' prefix) preceding the change
+  }
+  deriving stock (Show, Eq)
+
+-- | A patch for a single file, possibly containing multiple hunks.
+data PatchFile = PatchFile
+  { _pf_path  :: Text
+    -- ^ File path (relative to workspace root)
+  , _pf_hunks :: [PatchHunk]
+  }
+  deriving stock (Show, Eq)
+
+-- | Create a patch tool that applies unified-diff-style patches
+-- to one or more files in a single tool call.
+patchTool :: WorkspaceRoot -> FileHandle -> (ToolDefinition, ToolHandler)
+patchTool root fh = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "patch"
+      , _td_description = T.unlines
+          [ "Apply a multi-file patch in unified diff format."
+          , "Accepts a patch string containing one or more file diffs."
+          , "Format:"
+          , "  --- a/path/to/file"
+          , "  +++ b/path/to/file"
+          , "  @@ ... @@"
+          , "  -removed line"
+          , "  +added line"
+          , "   context line"
+          , "Multiple files can be patched in a single call."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "patch" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("The patch in unified diff format" :: Text)
+                  ]
+              ]
+          , "required" .= (["patch"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseInput input of
+        Left err -> pure (T.pack err, True)
+        Right patchText ->
+          case parsePatch patchText of
+            Left err -> pure ("Patch parse error: " <> err, True)
+            Right [] -> pure ("Empty patch — no files to modify", True)
+            Right files -> applyPatch files
+
+    applyPatch :: [PatchFile] -> IO (Text, Bool)
+    applyPatch files = do
+      results <- mapM applyFile files
+      let (successes, failures) = partitionResults results
+      if null failures
+        then pure (T.intercalate "\n" successes, False)
+        else pure (T.intercalate "\n" (successes <> failures), True)
+
+    applyFile :: PatchFile -> IO (Either Text Text)
+    applyFile pf = do
+      let path = _pf_path pf
+      pathResult <- mkSafePath root (T.unpack path)
+      case pathResult of
+        Left pe -> pure (Left (path <> ": " <> T.pack (show pe)))
+        Right sp -> do
+          readResult <- try @SomeException (_fh_readFile fh sp)
+          case readResult of
+            Left e -> pure (Left (path <> ": " <> T.pack (show e)))
+            Right bs -> case TE.decodeUtf8' bs of
+              Left _ -> pure (Left (path <> ": cannot patch binary file"))
+              Right content -> do
+                case applyHunks content (_pf_hunks pf) of
+                  Left err -> pure (Left (path <> ": " <> err))
+                  Right newContent -> do
+                    writeResult <- try @SomeException
+                      (_fh_writeFile fh sp (TE.encodeUtf8 newContent))
+                    case writeResult of
+                      Left e -> pure (Left (path <> ": " <> T.pack (show e)))
+                      Right () -> pure (Right ("Patched " <> path))
+
+    partitionResults :: [Either Text Text] -> ([Text], [Text])
+    partitionResults = foldr go ([], [])
+      where
+        go (Right s) (ss, fs) = (s:ss, fs)
+        go (Left  f) (ss, fs) = (ss, f:fs)
+
+    parseInput :: Value -> Parser Text
+    parseInput = withObject "PatchInput" $ \o -> o .: "patch"
+
+-- | Apply a list of hunks to file content, sequentially.
+applyHunks :: Text -> [PatchHunk] -> Either Text Text
+applyHunks content [] = Right content
+applyHunks content (h:hs) =
+  case applyHunk content h of
+    Left err -> Left err
+    Right content' -> applyHunks content' hs
+
+-- | Apply a single hunk to file content.
+-- Uses context lines to locate the position, then removes the
+-- specified lines and inserts the additions.
+applyHunk :: Text -> PatchHunk -> Either Text Text
+applyHunk content hunk =
+  let contentLines = T.lines content
+      -- Build the pattern: context lines followed by removal lines
+      pattern = _ph_context hunk <> _ph_removals hunk
+  in case findPattern pattern contentLines of
+    Nothing ->
+      -- Try without context (just removals)
+      case findPattern (_ph_removals hunk) contentLines of
+        Nothing -> Left ("hunk failed: could not find target lines")
+        Just idx ->
+          let before = take idx contentLines
+              after  = drop (idx + length (_ph_removals hunk)) contentLines
+              result = before <> _ph_additions hunk <> after
+          in Right (T.unlines result)
+    Just idx ->
+      let ctxLen = length (_ph_context hunk)
+          removeLen = length (_ph_removals hunk)
+          before = take (idx + ctxLen) contentLines  -- keep context
+          after  = drop (idx + ctxLen + removeLen) contentLines
+          result = before <> _ph_additions hunk <> after
+      in Right (T.unlines result)
+
+-- | Find the starting index of a pattern (list of lines) within
+-- the content lines. Returns the index of the first match.
+findPattern :: [Text] -> [Text] -> Maybe Int
+findPattern [] _ = Just 0
+findPattern _ [] = Nothing
+findPattern pattern contentLines = go 0 contentLines
+  where
+    patLen = length pattern
+    go _ remaining | length remaining < patLen = Nothing
+    go idx remaining
+      | take patLen remaining `linesMatch` pattern = Just idx
+      | otherwise = go (idx + 1) (drop 1 remaining)
+
+    linesMatch :: [Text] -> [Text] -> Bool
+    linesMatch as bs = length as == length bs && all (uncurry matchLine) (zip as bs)
+
+    matchLine :: Text -> Text -> Bool
+    matchLine a b = T.strip a == T.strip b
+
+-- | Parse a unified diff into a list of 'PatchFile'.
+parsePatch :: Text -> Either Text [PatchFile]
+parsePatch input =
+  let ls = T.lines input
+  in parseFiles ls
+
+parseFiles :: [Text] -> Either Text [PatchFile]
+parseFiles [] = Right []
+parseFiles ls =
+  case dropWhile (not . isFileLine) ls of
+    [] -> Right []
+    rest ->
+      case parseOneFile rest of
+        Left err -> Left err
+        Right (pf, remaining) -> do
+          more <- parseFiles remaining
+          Right (pf : more)
+
+isFileLine :: Text -> Bool
+isFileLine l = "--- " `T.isPrefixOf` l
+
+parseOneFile :: [Text] -> Either Text (PatchFile, [Text])
+parseOneFile [] = Left "unexpected end of patch"
+parseOneFile (_minusLine:rest) =
+  case rest of
+    [] -> Left "missing +++ line after ---"
+    (plusLine:rest') ->
+      let path = extractPath plusLine
+      in case parseHunks rest' of
+        (hunks, remaining) -> Right (PatchFile path hunks, remaining)
+
+extractPath :: Text -> Text
+extractPath line =
+  let stripped = T.strip line
+      -- Remove "+++ " or "--- " prefix
+      withoutPrefix = T.drop 4 stripped
+      -- Remove "a/" or "b/" prefix if present
+  in if "a/" `T.isPrefixOf` withoutPrefix || "b/" `T.isPrefixOf` withoutPrefix
+    then T.drop 2 withoutPrefix
+    else withoutPrefix
+
+parseHunks :: [Text] -> ([PatchHunk], [Text])
+parseHunks [] = ([], [])
+parseHunks ls@(l:_)
+  | "@@" `T.isPrefixOf` l =
+      let (hunk, rest) = parseOneHunk (drop 1 ls)  -- skip @@ line
+          (more, remaining) = parseHunks rest
+      in (hunk : more, remaining)
+  | isFileLine l = ([], ls)  -- next file
+  | otherwise = parseHunks (drop 1 ls)  -- skip non-hunk lines
+
+parseOneHunk :: [Text] -> (PatchHunk, [Text])
+parseOneHunk = go [] [] []
+  where
+    go ctx rmv add [] = (PatchHunk rmv add ctx, [])
+    go ctx rmv add (l:ls)
+      | "@@" `T.isPrefixOf` l = (PatchHunk rmv add ctx, l:ls)  -- next hunk
+      | isFileLine l          = (PatchHunk rmv add ctx, l:ls)  -- next file
+      | "-" `T.isPrefixOf` l && not ("---" `T.isPrefixOf` l) =
+          go ctx (rmv <> [T.drop 1 l]) add ls
+      | "+" `T.isPrefixOf` l && not ("+++" `T.isPrefixOf` l) =
+          go ctx rmv (add <> [T.drop 1 l]) ls
+      | " " `T.isPrefixOf` l =
+          if null rmv && null add
+            then go (ctx <> [T.drop 1 l]) rmv add ls  -- pre-change context
+            else go ctx rmv add ls  -- post-change context (skip)
+      | otherwise = go ctx rmv add ls  -- skip other lines

--- a/src/PureClaw/Tools/Patch.hs
+++ b/src/PureClaw/Tools/Patch.hs
@@ -132,9 +132,9 @@ applyHunks content (h:hs) =
 applyHunk :: Text -> PatchHunk -> Either Text Text
 applyHunk content hunk =
   let contentLines = T.lines content
-      -- Build the pattern: context lines followed by removal lines
-      pattern = _ph_context hunk <> _ph_removals hunk
-  in case findPattern pattern contentLines of
+      -- Build the search pattern: context lines followed by removal lines
+      searchPat = _ph_context hunk <> _ph_removals hunk
+  in case findPattern searchPat contentLines of
     Nothing ->
       -- Try without context (just removals)
       case findPattern (_ph_removals hunk) contentLines of

--- a/src/PureClaw/Tools/Patch.hs
+++ b/src/PureClaw/Tools/Patch.hs
@@ -157,12 +157,12 @@ applyHunk content hunk =
 findPattern :: [Text] -> [Text] -> Maybe Int
 findPattern [] _ = Just 0
 findPattern _ [] = Nothing
-findPattern pattern contentLines = go 0 contentLines
+findPattern pat contentLines = go 0 contentLines
   where
-    patLen = length pattern
+    patLen = length pat
     go _ remaining | length remaining < patLen = Nothing
     go idx remaining
-      | take patLen remaining `linesMatch` pattern = Just idx
+      | take patLen remaining `linesMatch` pat = Just idx
       | otherwise = go (idx + 1) (drop 1 remaining)
 
     linesMatch :: [Text] -> [Text] -> Bool

--- a/src/PureClaw/Tools/Process.hs
+++ b/src/PureClaw/Tools/Process.hs
@@ -23,13 +23,13 @@ processTool policy ph = (def, handler)
   where
     def = ToolDefinition
       { _td_name        = "process"
-      , _td_description = "Manage background processes. Actions: spawn (start a background command), list (show all), poll (check status and output), kill (terminate), write_stdin (send input)."
+      , _td_description = "Manage background processes. Actions: spawn, list, poll, kill, write_stdin, wait, close_stdin."
       , _td_inputSchema = object
           [ "type" .= ("object" :: Text)
           , "properties" .= object
               [ "action" .= object
                   [ "type" .= ("string" :: Text)
-                  , "enum" .= (["spawn", "list", "poll", "kill", "write_stdin"] :: [Text])
+                  , "enum" .= (["spawn", "list", "poll", "kill", "write_stdin", "wait", "close_stdin"] :: [Text])
                   , "description" .= ("The action to perform" :: Text)
                   ]
               , "command" .= object
@@ -43,6 +43,18 @@ processTool policy ph = (def, handler)
               , "input" .= object
                   [ "type" .= ("string" :: Text)
                   , "description" .= ("Input to send to stdin (for write_stdin)" :: Text)
+                  ]
+              , "timeout_ms" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Timeout in milliseconds (for wait, default: 30000)" :: Text)
+                  ]
+              , "offset" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Byte offset for log pagination in poll (default: 0)" :: Text)
+                  ]
+              , "max_bytes" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Max bytes to return from poll output (default: 10000)" :: Text)
                   ]
               ]
           , "required" .= (["action"] :: [Text])
@@ -72,6 +84,14 @@ processTool policy ph = (def, handler)
       case parseEither parseWriteStdin input of
         Left err -> pure (T.pack err, True)
         Right (pid, bytes) -> doWriteStdin pid bytes
+    dispatch "wait" input =
+      case parseEither parseWait input of
+        Left err -> pure (T.pack err, True)
+        Right (pid, timeoutMs) -> doWait pid timeoutMs
+    dispatch "close_stdin" input =
+      case parseEither parseId input of
+        Left err -> pure (T.pack err, True)
+        Right pid -> doCloseStdin pid
     dispatch action _ = pure ("Unknown action: " <> action, True)
 
     doSpawn :: Text -> IO (Text, Bool)
@@ -127,6 +147,31 @@ processTool policy ph = (def, handler)
         then pure ("Sent input to process " <> T.pack (show pid), False)
         else pure ("Process " <> T.pack (show pid) <> " not found or not running", True)
 
+    doWait :: Int -> Int -> IO (Text, Bool)
+    doWait pid timeoutMs = do
+      status <- _ph_wait ph (ProcessId pid) timeoutMs
+      case status of
+        Nothing -> pure ("Process " <> T.pack (show pid) <> " not found", True)
+        Just (ProcessRunning stdout stderr) ->
+          let out = T.pack (BS8.unpack stdout)
+              err = T.pack (BS8.unpack stderr)
+          in pure ("Status: still running (wait timed out after "
+                  <> T.pack (show timeoutMs) <> "ms)\n" <> formatOutput out err, False)
+        Just (ProcessDone exitCode stdout stderr) ->
+          let out = T.pack (BS8.unpack stdout)
+              err = T.pack (BS8.unpack stderr)
+              exitInfo = case exitCode of
+                ExitSuccess   -> "0"
+                ExitFailure n -> T.pack (show n)
+          in pure ("Status: done (exit " <> exitInfo <> ")\n" <> formatOutput out err, False)
+
+    doCloseStdin :: Int -> IO (Text, Bool)
+    doCloseStdin pid = do
+      ok <- _ph_closeStdin ph (ProcessId pid)
+      if ok
+        then pure ("Closed stdin for process " <> T.pack (show pid), False)
+        else pure ("Process " <> T.pack (show pid) <> " not found", True)
+
     formatList :: [ProcessInfo] -> Text
     formatList = T.intercalate "\n" . map formatInfo
 
@@ -161,3 +206,7 @@ processTool policy ph = (def, handler)
     parseWriteStdin :: Value -> Parser (Int, Text)
     parseWriteStdin = withObject "ProcessWriteStdinInput" $ \o ->
       (,) <$> o .: "id" <*> o .: "input"
+
+    parseWait :: Value -> Parser (Int, Int)
+    parseWait = withObject "ProcessWaitInput" $ \o ->
+      (,) <$> o .: "id" <*> o .:? "timeout_ms" .!= 30000

--- a/src/PureClaw/Tools/Registry.hs
+++ b/src/PureClaw/Tools/Registry.hs
@@ -9,6 +9,7 @@ module PureClaw.Tools.Registry
   , registryDefinitions
   , executeTool
   , mergeRegistries
+  , filterRegistry
   ) where
 
 import Data.Aeson (Value)
@@ -62,3 +63,8 @@ executeTool reg name input =
 mergeRegistries :: ToolRegistry -> ToolRegistry -> ToolRegistry
 mergeRegistries (ToolRegistry a) (ToolRegistry b) =
   ToolRegistry (Map.union b a)
+
+-- | Filter a registry to only include tools whose names satisfy a predicate.
+filterRegistry :: (Text -> Bool) -> ToolRegistry -> ToolRegistry
+filterRegistry predicate (ToolRegistry tools) =
+  ToolRegistry (Map.filterWithKey (\k _ -> predicate k) tools)

--- a/src/PureClaw/Tools/SearchFiles.hs
+++ b/src/PureClaw/Tools/SearchFiles.hs
@@ -1,0 +1,143 @@
+module PureClaw.Tools.SearchFiles
+  ( -- * Tool registration
+    searchFilesTool
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString.Lazy qualified as BL
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import System.Exit
+import System.Process.Typed qualified as P
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+
+-- | Create a search_files tool backed by ripgrep.
+-- This tool does NOT go through SecurityPolicy because it is a read-only
+-- internal capability — the agent cannot use it to execute arbitrary commands.
+searchFilesTool :: WorkspaceRoot -> (ToolDefinition, ToolHandler)
+searchFilesTool (WorkspaceRoot root) = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "search_files"
+      , _td_description = T.unlines
+          [ "Search file contents or file names using ripgrep."
+          , "Modes:"
+          , "  content (default) — regex search over file contents, returns matching lines with line numbers"
+          , "  files_only — return only file paths matching the pattern or glob"
+          , "  count — return match counts per file"
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "pattern" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Regex pattern to search for (ripgrep syntax)" :: Text)
+                  ]
+              , "path" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Directory or file to search in, relative to workspace root (default: \".\")" :: Text)
+                  ]
+              , "file_glob" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Glob filter for file names, e.g. \"*.hs\" or \"*.{ts,tsx}\"" :: Text)
+                  ]
+              , "output_mode" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "enum" .= (["content", "files_only", "count"] :: [Text])
+                  , "description" .= ("Output mode (default: content)" :: Text)
+                  ]
+              , "context" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Number of context lines before and after each match (default: 0)" :: Text)
+                  ]
+              , "limit" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Maximum number of matches to return (default: 50)" :: Text)
+                  ]
+              , "case_insensitive" .= object
+                  [ "type" .= ("boolean" :: Text)
+                  , "description" .= ("Case-insensitive search (default: false)" :: Text)
+                  ]
+              ]
+          , "required" .= (["pattern"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseInput input of
+        Left err -> pure (T.pack err, True)
+        Right si -> runSearch si
+
+    runSearch :: SearchInput -> IO (Text, Bool)
+    runSearch si = do
+      let args = buildRgArgs si
+          config = P.setWorkingDir root
+                 $ P.proc "rg" args
+      result <- try @SomeException $ P.readProcess config
+      case result of
+        Left e -> pure ("search_files error: " <> T.pack (show e), True)
+        Right (exitCode, outLazy, errLazy) ->
+          let out = TE.decodeUtf8Lenient (BL.toStrict outLazy)
+              err = TE.decodeUtf8Lenient (BL.toStrict errLazy)
+          in case exitCode of
+            ExitSuccess   -> pure (truncateOutput out, False)
+            ExitFailure 1 -> pure ("No matches found", False)  -- rg returns 1 for no matches
+            ExitFailure _ -> pure ("search_files error: " <> err, True)
+
+    truncateOutput :: Text -> Text
+    truncateOutput t
+      | T.length t > 100000 =
+          T.take 100000 t <> "\n[...output truncated at 100000 chars]"
+      | otherwise = t
+
+    buildRgArgs :: SearchInput -> [String]
+    buildRgArgs si =
+      let modeArgs = case _si_outputMode si of
+            "files_only" -> ["--files-with-matches"]
+            "count"      -> ["--count"]
+            _            -> ["--line-number"]  -- content mode (default)
+          globArgs = case _si_fileGlob si of
+            Nothing -> []
+            Just g  -> ["--glob", T.unpack g]
+          ctxArgs = case _si_context si of
+            Nothing -> []
+            Just n  -> ["--context", show n]
+          limitArgs = ["--max-count", show (_si_limit si)]
+          caseArgs = if _si_caseInsensitive si then ["--ignore-case"] else []
+          searchPath = T.unpack (_si_path si)
+      in concat
+          [ ["--no-heading", "--color", "never"]
+          , modeArgs
+          , globArgs
+          , ctxArgs
+          , limitArgs
+          , caseArgs
+          , ["--", T.unpack (_si_pattern si), searchPath]
+          ]
+
+data SearchInput = SearchInput
+  { _si_pattern         :: Text
+  , _si_path            :: Text
+  , _si_fileGlob        :: Maybe Text
+  , _si_outputMode      :: Text
+  , _si_context         :: Maybe Int
+  , _si_limit           :: Int
+  , _si_caseInsensitive :: Bool
+  }
+
+parseInput :: Value -> Parser SearchInput
+parseInput = withObject "SearchFilesInput" $ \o ->
+  SearchInput
+    <$> o .:  "pattern"
+    <*> o .:? "path"             .!= "."
+    <*> o .:? "file_glob"
+    <*> o .:? "output_mode"      .!= "content"
+    <*> o .:? "context"
+    <*> o .:? "limit"            .!= 50
+    <*> o .:? "case_insensitive" .!= False

--- a/src/PureClaw/Tools/SearchFiles.hs
+++ b/src/PureClaw/Tools/SearchFiles.hs
@@ -109,7 +109,7 @@ searchFilesTool (WorkspaceRoot root) = (def, handler)
             Nothing -> []
             Just n  -> ["--context", show n]
           limitArgs = ["--max-count", show (_si_limit si)]
-          caseArgs = if _si_caseInsensitive si then ["--ignore-case"] else []
+          caseArgs = ["--ignore-case" | _si_caseInsensitive si]
           searchPath = T.unpack (_si_path si)
       in concat
           [ ["--no-heading", "--color", "never"]

--- a/src/PureClaw/Tools/SearchFiles.hs
+++ b/src/PureClaw/Tools/SearchFiles.hs
@@ -3,7 +3,7 @@ module PureClaw.Tools.SearchFiles
     searchFilesTool
   ) where
 
-import Control.Exception
+import Control.Exception (IOException, try)
 import Data.Aeson
 import Data.Aeson.Types
 import Data.ByteString.Lazy qualified as BL
@@ -11,6 +11,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import System.Exit
+import System.IO.Error (isDoesNotExistError)
 import System.Process.Typed qualified as P
 
 import PureClaw.Core.Types
@@ -79,9 +80,13 @@ searchFilesTool (WorkspaceRoot root) = (def, handler)
       let args = buildRgArgs si
           config = P.setWorkingDir root
                  $ P.proc "rg" args
-      result <- try @SomeException $ P.readProcess config
+      result <- try @IOException $ P.readProcess config
       case result of
-        Left e -> pure ("search_files error: " <> T.pack (show e), True)
+        Left e
+          | isDoesNotExistError e ->
+              pure ("search_files requires ripgrep (rg) but it is not installed or not on PATH", True)
+          | otherwise ->
+              pure ("search_files error: " <> T.pack (show e), True)
         Right (exitCode, outLazy, errLazy) ->
           let out = TE.decodeUtf8Lenient (BL.toStrict outLazy)
               err = TE.decodeUtf8Lenient (BL.toStrict errLazy)

--- a/src/PureClaw/Tools/SessionSearch.hs
+++ b/src/PureClaw/Tools/SessionSearch.hs
@@ -1,0 +1,145 @@
+module PureClaw.Tools.SessionSearch
+  ( -- * Tool registration
+    sessionSearchTool
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.List (sortOn)
+import Data.Ord (Down (..))
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time.Clock (UTCTime)
+import System.Directory (listDirectory, doesFileExist)
+import System.FilePath ((</>))
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Log
+import PureClaw.Handles.Transcript
+import PureClaw.Providers.Class
+import PureClaw.Session.Types
+import PureClaw.Tools.Registry
+import PureClaw.Transcript.Types
+
+-- | Create a session_search tool that searches across past session
+-- transcripts. Performs substring matching on transcript entries'
+-- payload text, returning matching entries grouped by session.
+sessionSearchTool :: LogHandle -> FilePath -> (ToolDefinition, ToolHandler)
+sessionSearchTool logger sessionsDir = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "session_search"
+      , _td_description = T.unlines
+          [ "Search across past session transcripts."
+          , "Performs substring matching on message content."
+          , "Returns matching entries grouped by session, most recent first."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "query" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Search query (substring match, case-insensitive)" :: Text)
+                  ]
+              , "limit" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Maximum number of matching entries to return (default: 10)" :: Text)
+                  ]
+              ]
+          , "required" .= (["query"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseSearchInput input of
+        Left err -> pure (T.pack err, True)
+        Right (query, limit) -> searchSessions query limit
+
+    searchSessions :: Text -> Int -> IO (Text, Bool)
+    searchSessions query limit = do
+      result <- try @SomeException $ do
+        sessionDirs <- listSessionDirs sessionsDir
+        allMatches <- concat <$> mapM (searchOneSession query) sessionDirs
+        let sorted = take limit (sortOn (Down . _sr_timestamp) allMatches)
+        pure sorted
+      case result of
+        Left e -> pure ("session_search error: " <> T.pack (show e), True)
+        Right [] -> pure ("No matches found for: " <> query, False)
+        Right matches -> pure (formatMatches matches, False)
+
+    searchOneSession :: Text -> FilePath -> IO [SearchResult]
+    searchOneSession query sessionDir = do
+      let transcriptPath = sessionDir </> "transcript.jsonl"
+          metaPath = sessionDir </> "session.json"
+      hasTranscript <- doesFileExist transcriptPath
+      if not hasTranscript
+        then pure []
+        else do
+          sessionId <- readSessionId metaPath
+          th <- mkFileTranscriptHandle logger transcriptPath
+          entries <- _th_query th emptyFilter
+          _th_close th
+          let queryLower = T.toLower query
+              matching = filter (matchesQuery queryLower) entries
+          pure [SearchResult
+            { _sr_sessionId = sessionId
+            , _sr_timestamp = _te_timestamp entry
+            , _sr_direction = _te_direction entry
+            , _sr_snippet   = extractSnippet query (_te_payload entry)
+            } | entry <- matching]
+
+    matchesQuery :: Text -> TranscriptEntry -> Bool
+    matchesQuery queryLower entry =
+      T.isInfixOf queryLower (T.toLower (_te_payload entry))
+
+    readSessionId :: FilePath -> IO Text
+    readSessionId metaPath = do
+      exists <- doesFileExist metaPath
+      if not exists
+        then pure "(unknown)"
+        else do
+          result <- try @SomeException (decodeFileStrict metaPath)
+          case result of
+            Right (Just meta) -> pure (unSessionId (_sm_id (meta :: SessionMeta)))
+            _ -> pure "(unknown)"
+
+    listSessionDirs :: FilePath -> IO [FilePath]
+    listSessionDirs dir = do
+      entries <- try @SomeException (listDirectory dir)
+      case entries of
+        Left _ -> pure []
+        Right names -> pure [dir </> n | n <- names]
+
+data SearchResult = SearchResult
+  { _sr_sessionId :: Text
+  , _sr_timestamp :: UTCTime
+  , _sr_direction :: Direction
+  , _sr_snippet   :: Text
+  }
+
+formatMatches :: [SearchResult] -> Text
+formatMatches = T.intercalate "\n\n" . map formatMatch
+
+formatMatch :: SearchResult -> Text
+formatMatch sr =
+  let dir = case _sr_direction sr of
+        Request  -> "→"
+        Response -> "←"
+  in "[" <> _sr_sessionId sr <> "] " <> dir <> " " <> _sr_snippet sr
+
+extractSnippet :: Text -> Text -> Text
+extractSnippet query payload =
+  let queryLower = T.toLower query
+      payloadLower = T.toLower payload
+      (before, _) = T.breakOn queryLower payloadLower
+      pos = T.length before
+      start = max 0 (pos - 50)
+      snippet = T.take 250 (T.drop start payload)
+      prefix = if start > 0 then "..." else ""
+      suffix = if T.length payload > start + 250 then "..." else ""
+  in prefix <> snippet <> suffix
+
+parseSearchInput :: Value -> Parser (Text, Int)
+parseSearchInput = withObject "SessionSearchInput" $ \o ->
+  (,) <$> o .: "query" <*> o .:? "limit" .!= 10

--- a/src/PureClaw/Tools/Shell.hs
+++ b/src/PureClaw/Tools/Shell.hs
@@ -18,18 +18,31 @@ import PureClaw.Security.Policy
 import PureClaw.Tools.Registry
 
 -- | Create a shell tool that executes commands through the security policy.
+-- Supports optional timeout (milliseconds) and working directory.
 shellTool :: SecurityPolicy -> ShellHandle -> (ToolDefinition, ToolHandler)
 shellTool policy sh = (def, handler)
   where
     def = ToolDefinition
       { _td_name        = "shell"
-      , _td_description = "Execute a shell command. The command is validated against the security policy before execution."
+      , _td_description = T.unlines
+          [ "Execute a shell command. The command is validated against the security policy before execution."
+          , "Optional: set timeout_ms to limit execution time (returns exit code 124 on timeout)."
+          , "Optional: set working_dir to run in a specific directory."
+          ]
       , _td_inputSchema = object
           [ "type" .= ("object" :: Text)
           , "properties" .= object
               [ "command" .= object
                   [ "type" .= ("string" :: Text)
                   , "description" .= ("The shell command to execute" :: Text)
+                  ]
+              , "timeout_ms" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Timeout in milliseconds. Command is killed after this time (default: no timeout)" :: Text)
+                  ]
+              , "working_dir" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("Working directory for the command (default: agent workspace)" :: Text)
                   ]
               ]
           , "required" .= (["command"] :: [Text])
@@ -39,8 +52,8 @@ shellTool policy sh = (def, handler)
     handler = ToolHandler $ \input -> do
       case parseEither parseInput input of
         Left err -> pure (T.pack err, True)
-        Right cmd -> do
-          let parts = T.words cmd
+        Right si -> do
+          let parts = T.words (_si_command si)
           case parts of
             [] -> pure ("Empty command", True)
             (prog:args) ->
@@ -50,7 +63,11 @@ shellTool policy sh = (def, handler)
                 Left CommandInAutonomyDeny ->
                   pure ("All commands denied by security policy", True)
                 Right authorized -> do
-                  result <- try @SomeException (_sh_execute sh authorized)
+                  let opts = ExecOptions
+                        { _eo_timeout    = _si_timeout si
+                        , _eo_workingDir = fmap T.unpack (_si_workingDir si)
+                        }
+                  result <- try @SomeException (_sh_execute sh opts authorized)
                   case result of
                     Left e -> pure (T.pack (show e), True)
                     Right pr -> do
@@ -62,5 +79,15 @@ shellTool policy sh = (def, handler)
                           combined = T.strip (out <> err <> exitInfo)
                       pure (if T.null combined then "(no output)" else combined, False)
 
-    parseInput :: Value -> Parser Text
-    parseInput = withObject "ShellInput" $ \o -> o .: "command"
+data ShellInput = ShellInput
+  { _si_command    :: Text
+  , _si_timeout    :: Maybe Int
+  , _si_workingDir :: Maybe Text
+  }
+
+parseInput :: Value -> Parser ShellInput
+parseInput = withObject "ShellInput" $ \o ->
+  ShellInput
+    <$> o .:  "command"
+    <*> o .:? "timeout_ms"
+    <*> o .:? "working_dir"

--- a/src/PureClaw/Tools/Todo.hs
+++ b/src/PureClaw/Tools/Todo.hs
@@ -1,0 +1,132 @@
+module PureClaw.Tools.Todo
+  ( -- * Tool registration
+    todoTool
+  ) where
+
+import Data.Aeson
+import Data.Aeson.Types
+import Data.IORef
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+
+-- | A single todo item.
+data TodoItem = TodoItem
+  { _ti_id      :: Text
+  , _ti_content :: Text
+  , _ti_status  :: Text  -- pending | in_progress | completed | cancelled
+  }
+  deriving stock (Show, Eq)
+
+instance ToJSON TodoItem where
+  toJSON ti = object
+    [ "id"      .= _ti_id ti
+    , "content" .= _ti_content ti
+    , "status"  .= _ti_status ti
+    ]
+
+instance FromJSON TodoItem where
+  parseJSON = withObject "TodoItem" $ \o ->
+    TodoItem <$> o .: "id" <*> o .: "content" <*> o .: "status"
+
+-- | Valid todo statuses.
+validStatuses :: [Text]
+validStatuses = ["pending", "in_progress", "completed", "cancelled"]
+
+-- | Create an in-memory todo tool for lightweight task tracking.
+-- State is per-session (not persisted across restarts).
+-- Omit the @todos@ field to read the current list; provide it to write.
+todoTool :: IO (ToolDefinition, ToolHandler)
+todoTool = do
+  stateRef <- newIORef (Map.empty :: Map Text TodoItem)
+  let def = ToolDefinition
+        { _td_name        = "todo"
+        , _td_description = T.unlines
+            [ "In-memory task list for decomposing complex work."
+            , "Omit 'todos' to read the current list."
+            , "Provide 'todos' array to write/update items."
+            , "Set merge=true to merge with existing items (default: replace all)."
+            , "Statuses: pending, in_progress, completed, cancelled."
+            ]
+        , _td_inputSchema = object
+            [ "type" .= ("object" :: Text)
+            , "properties" .= object
+                [ "todos" .= object
+                    [ "type" .= ("array" :: Text)
+                    , "items" .= object
+                        [ "type" .= ("object" :: Text)
+                        , "properties" .= object
+                            [ "id" .= object ["type" .= ("string" :: Text)]
+                            , "content" .= object ["type" .= ("string" :: Text)]
+                            , "status" .= object
+                                [ "type" .= ("string" :: Text)
+                                , "enum" .= validStatuses
+                                ]
+                            ]
+                        , "required" .= (["id", "content", "status"] :: [Text])
+                        ]
+                    , "description" .= ("Todo items to set. Omit to read current list." :: Text)
+                    ]
+                , "merge" .= object
+                    [ "type" .= ("boolean" :: Text)
+                    , "description" .= ("Merge with existing items instead of replacing (default: false)" :: Text)
+                    ]
+                ]
+            ]
+        }
+
+      handler = ToolHandler $ \input ->
+        case parseEither parseTodoInput input of
+          Left err -> pure (T.pack err, True)
+          Right (Nothing, _) -> do
+            -- Read mode
+            items <- readIORef stateRef
+            pure (formatTodos (Map.elems items), False)
+          Right (Just todos, merge) -> do
+            -- Validate statuses
+            let invalid = filter (\ti -> _ti_status ti `notElem` validStatuses) todos
+            if not (null invalid)
+              then pure ("Invalid status in: " <> T.intercalate ", " (map _ti_id invalid)
+                        <> ". Valid: " <> T.intercalate ", " validStatuses, True)
+              else do
+                let newMap = Map.fromList [((_ti_id ti), ti) | ti <- todos]
+                if merge
+                  then atomicModifyIORef' stateRef $ \old ->
+                    (Map.union newMap old, ())
+                  else writeIORef stateRef newMap
+                items <- readIORef stateRef
+                pure (formatTodos (Map.elems items), False)
+
+  pure (def, handler)
+
+formatTodos :: [TodoItem] -> Text
+formatTodos [] = "No todos."
+formatTodos items =
+  let grouped = Map.fromListWith (++) [(statusOrder (_ti_status ti), [ti]) | ti <- items]
+      sections = map formatSection (Map.toAscList grouped)
+  in T.intercalate "\n\n" sections
+
+statusOrder :: Text -> Int
+statusOrder "in_progress" = 0
+statusOrder "pending"     = 1
+statusOrder "completed"   = 2
+statusOrder "cancelled"   = 3
+statusOrder _             = 4
+
+formatSection :: (Int, [TodoItem]) -> Text
+formatSection (_, []) = ""
+formatSection (_, items@(first:_)) =
+  let header = T.toUpper (_ti_status first)
+      lines' = map formatItem items
+  in header <> ":\n" <> T.intercalate "\n" lines'
+
+formatItem :: TodoItem -> Text
+formatItem ti = "  [" <> _ti_id ti <> "] " <> _ti_content ti
+
+parseTodoInput :: Value -> Parser (Maybe [TodoItem], Bool)
+parseTodoInput = withObject "TodoInput" $ \o ->
+  (,) <$> o .:? "todos" <*> o .:? "merge" .!= False

--- a/src/PureClaw/Tools/Todo.hs
+++ b/src/PureClaw/Tools/Todo.hs
@@ -93,7 +93,7 @@ todoTool = do
               then pure ("Invalid status in: " <> T.intercalate ", " (map _ti_id invalid)
                         <> ". Valid: " <> T.intercalate ", " validStatuses, True)
               else do
-                let newMap = Map.fromList [((_ti_id ti), ti) | ti <- todos]
+                let newMap = Map.fromList [(_ti_id ti, ti) | ti <- todos]
                 if merge
                   then atomicModifyIORef' stateRef $ \old ->
                     (Map.union newMap old, ())

--- a/src/PureClaw/Tools/WebExtract.hs
+++ b/src/PureClaw/Tools/WebExtract.hs
@@ -101,7 +101,7 @@ htmlToMarkdown html =
 
 -- | Remove everything between <tag>...</tag> including the tags.
 removeBlocks :: Text -> Text -> Text
-removeBlocks tag input = go input
+removeBlocks tag = go
   where
     openTag = "<" <> tag
     closeTag = "</" <> tag <> ">"

--- a/src/PureClaw/Tools/WebExtract.hs
+++ b/src/PureClaw/Tools/WebExtract.hs
@@ -1,0 +1,235 @@
+module PureClaw.Tools.WebExtract
+  ( -- * Tool registration
+    webExtractTool
+    -- * Internals (exported for testing)
+  , htmlToMarkdown
+  , truncateBody
+  ) where
+
+import Control.Exception
+import Data.Aeson
+import Data.Aeson.Types
+import Data.ByteString.Char8 qualified as BS8
+import Data.Text (Text)
+import Data.Maybe (fromMaybe)
+import Data.Text qualified as T
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Network
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+
+-- | Create a web_extract tool that fetches a URL and converts the
+-- response to readable markdown. Handles HTML→markdown conversion,
+-- response size limits, and content-type detection.
+webExtractTool :: AllowList Text -> NetworkHandle -> (ToolDefinition, ToolHandler)
+webExtractTool allowList nh = (def, handler)
+  where
+    def = ToolDefinition
+      { _td_name        = "web_extract"
+      , _td_description = T.unlines
+          [ "Fetch a URL and extract its content as readable markdown."
+          , "HTML pages are converted to markdown with headings, links, and lists preserved."
+          , "Non-HTML responses (JSON, plain text) are returned as-is."
+          , "Large responses are truncated to 100K characters."
+          ]
+      , _td_inputSchema = object
+          [ "type" .= ("object" :: Text)
+          , "properties" .= object
+              [ "url" .= object
+                  [ "type" .= ("string" :: Text)
+                  , "description" .= ("The URL to fetch and extract content from" :: Text)
+                  ]
+              , "max_length" .= object
+                  [ "type" .= ("integer" :: Text)
+                  , "description" .= ("Maximum response length in characters (default: 100000)" :: Text)
+                  ]
+              ]
+          , "required" .= (["url"] :: [Text])
+          ]
+      }
+
+    handler = ToolHandler $ \input ->
+      case parseEither parseInput input of
+        Left err -> pure (T.pack err, True)
+        Right (url, maxLen) ->
+          case mkAllowedUrl allowList url of
+            Left (UrlNotAllowed u) -> pure ("URL domain not allowed: " <> u, True)
+            Left (UrlMalformed u) -> pure ("Malformed URL: " <> u, True)
+            Right allowed -> do
+              result <- try @SomeException (_nh_httpGet nh allowed)
+              case result of
+                Left e -> pure ("web_extract error: " <> T.pack (show e), True)
+                Right resp ->
+                  let status = _hr_statusCode resp
+                      body = T.pack (BS8.unpack (_hr_body resp))
+                      limit = fromMaybe 100000 maxLen
+                  in if status >= 400
+                    then pure ("HTTP " <> T.pack (show status), True)
+                    else
+                      let converted = if looksLikeHtml body
+                            then htmlToMarkdown body
+                            else body
+                          truncated = truncateBody limit converted
+                      in pure (truncated, False)
+
+    parseInput :: Value -> Parser (Text, Maybe Int)
+    parseInput = withObject "WebExtractInput" $ \o ->
+      (,) <$> o .: "url" <*> o .:? "max_length"
+
+-- | Check if the response body looks like HTML.
+looksLikeHtml :: Text -> Bool
+looksLikeHtml t =
+  let lower = T.toLower (T.take 500 t)
+  in T.isInfixOf "<html" lower
+  || T.isInfixOf "<!doctype" lower
+  || T.isInfixOf "<head" lower
+  || T.isInfixOf "<body" lower
+
+-- | Convert HTML to readable markdown-like text.
+-- This is a simple tag-aware converter, not a full HTML parser.
+-- Handles: headings, paragraphs, links, lists, code blocks, emphasis.
+htmlToMarkdown :: Text -> Text
+htmlToMarkdown html =
+  let -- Remove script and style blocks first
+      noScript = removeBlocks "script" (removeBlocks "style" (removeBlocks "noscript" html))
+      -- Process the remaining HTML
+      processed = processHtml noScript
+      -- Clean up excessive whitespace
+      cleaned = collapseBlankLines (T.strip processed)
+  in cleaned
+
+-- | Remove everything between <tag>...</tag> including the tags.
+removeBlocks :: Text -> Text -> Text
+removeBlocks tag input = go input
+  where
+    openTag = "<" <> tag
+    closeTag = "</" <> tag <> ">"
+
+    go remaining
+      | T.null remaining = remaining
+      | otherwise =
+          let (before, afterOpen) = T.breakOn openTag (T.toLower remaining)
+              -- Use the original casing for the "before" portion
+              origBefore = T.take (T.length before) remaining
+          in if T.null afterOpen
+            then remaining
+            else
+              let rest = T.drop (T.length before) remaining
+                  -- Find the closing tag in the rest
+                  (_, afterClose) = T.breakOn closeTag (T.toLower rest)
+                  origAfterClose = T.drop (T.length (T.take (T.length (T.toLower rest) - T.length afterClose) (T.toLower rest))) rest
+              in if T.null afterClose
+                then remaining  -- malformed, return as-is
+                else
+                  let skipClose = T.drop (T.length closeTag) origAfterClose
+                  in origBefore <> go skipClose
+
+-- | Process HTML tags into markdown.
+processHtml :: Text -> Text
+processHtml = go ""
+  where
+    go acc remaining
+      | T.null remaining = acc
+      | "<" `T.isPrefixOf` remaining =
+          let (tag, afterTag) = parseTag remaining
+              (converted, rest) = handleTag tag afterTag
+          in go (acc <> converted) rest
+      | otherwise =
+          let (text, rest) = T.break (== '<') remaining
+              decoded = decodeEntities text
+          in go (acc <> decoded) rest
+
+    parseTag :: Text -> (Text, Text)
+    parseTag t =
+      let withoutLt = T.drop 1 t  -- drop '<'
+          (tagContent, rest) = T.break (== '>') withoutLt
+      in (T.strip tagContent, T.drop 1 rest)  -- drop '>'
+
+    handleTag :: Text -> Text -> (Text, Text)
+    handleTag tag rest
+      | tagIs "h1" tag  = ("\n\n# ", rest)
+      | tagIs "/h1" tag = ("\n\n", rest)
+      | tagIs "h2" tag  = ("\n\n## ", rest)
+      | tagIs "/h2" tag = ("\n\n", rest)
+      | tagIs "h3" tag  = ("\n\n### ", rest)
+      | tagIs "/h3" tag = ("\n\n", rest)
+      | tagIs "h4" tag  = ("\n\n#### ", rest)
+      | tagIs "/h4" tag = ("\n\n", rest)
+      | tagIs "h5" tag  = ("\n\n##### ", rest)
+      | tagIs "/h5" tag = ("\n\n", rest)
+      | tagIs "h6" tag  = ("\n\n###### ", rest)
+      | tagIs "/h6" tag = ("\n\n", rest)
+      | tagIs "p" tag   = ("\n\n", rest)
+      | tagIs "/p" tag  = ("\n\n", rest)
+      | tagIs "br" tag || tagIs "br/" tag || tagIs "br /" tag = ("\n", rest)
+      | tagIs "li" tag  = ("\n- ", rest)
+      | tagIs "/li" tag = ("", rest)
+      | tagIs "ul" tag || tagIs "ol" tag = ("\n", rest)
+      | tagIs "/ul" tag || tagIs "/ol" tag = ("\n", rest)
+      | tagIs "strong" tag || tagIs "b" tag = ("**", rest)
+      | tagIs "/strong" tag || tagIs "/b" tag = ("**", rest)
+      | tagIs "em" tag || tagIs "i" tag = ("*", rest)
+      | tagIs "/em" tag || tagIs "/i" tag = ("*", rest)
+      | tagIs "code" tag = ("`", rest)
+      | tagIs "/code" tag = ("`", rest)
+      | tagIs "pre" tag = ("\n```\n", rest)
+      | tagIs "/pre" tag = ("\n```\n", rest)
+      | tagIs "blockquote" tag = ("\n> ", rest)
+      | tagIs "/blockquote" tag = ("\n", rest)
+      | tagIs "hr" tag || tagIs "hr/" tag = ("\n---\n", rest)
+      | tagIs "a" tag =
+          let href = extractAttr "href" tag
+          in case href of
+            Just _href -> ("[", rest)
+                -- Simple approach: emit the link text in brackets.
+                -- For a full implementation, we'd buffer until </a> and append the href.
+            Nothing -> ("", rest)
+      | tagIs "/a" tag = ("", rest)
+      | tagIs "div" tag = ("\n", rest)
+      | tagIs "/div" tag = ("\n", rest)
+      | tagIs "td" tag = (" | ", rest)
+      | tagIs "th" tag = (" | ", rest)
+      | tagIs "tr" tag = ("\n", rest)
+      | tagIs "/tr" tag = (" |", rest)
+      | otherwise = ("", rest)  -- skip unknown tags
+
+    tagIs :: Text -> Text -> Bool
+    tagIs expected full =
+      let lower = T.toLower full
+          name = T.takeWhile (\c -> c /= ' ' && c /= '\t') lower
+      in name == expected
+
+    extractAttr :: Text -> Text -> Maybe Text
+    extractAttr attr tag =
+      let lower = T.toLower tag
+      in case T.breakOn (attr <> "=\"") lower of
+        (_, after)
+          | T.null after -> Nothing
+          | otherwise ->
+              let rest = T.drop (T.length attr + 2) after
+                  value = T.takeWhile (/= '"') rest
+              in Just value
+
+-- | Decode common HTML entities.
+decodeEntities :: Text -> Text
+decodeEntities = T.replace "&amp;" "&"
+               . T.replace "&lt;" "<"
+               . T.replace "&gt;" ">"
+               . T.replace "&quot;" "\""
+               . T.replace "&#39;" "'"
+               . T.replace "&apos;" "'"
+               . T.replace "&nbsp;" " "
+               . T.replace "&#x27;" "'"
+               . T.replace "&#x2F;" "/"
+
+-- | Collapse runs of more than 2 consecutive blank lines.
+collapseBlankLines :: Text -> Text
+collapseBlankLines = T.intercalate "\n\n" . filter (not . T.null) . map T.strip . T.splitOn "\n\n\n"
+
+-- | Truncate body to a maximum length, adding a marker if truncated.
+truncateBody :: Int -> Text -> Text
+truncateBody maxLen t
+  | T.length t <= maxLen = t
+  | otherwise = T.take maxLen t <> "\n\n[...truncated at " <> T.pack (show maxLen) <> " chars]"
+

--- a/test/Handles/ShellSpec.hs
+++ b/test/Handles/ShellSpec.hs
@@ -18,7 +18,7 @@ spec = do
       case authorizeEcho of
         Left _ -> expectationFailure "authorize failed"
         Right cmd -> do
-          result <- _sh_execute sh cmd
+          result <- _sh_execute sh defaultExecOptions cmd
           _pr_exitCode result `shouldBe` ExitSuccess
           _pr_stdout result `shouldBe` "hello\n"
           _pr_stderr result `shouldBe` ""
@@ -28,7 +28,7 @@ spec = do
       case authorizeFalse of
         Left _ -> expectationFailure "authorize failed"
         Right cmd -> do
-          result <- _sh_execute sh cmd
+          result <- _sh_execute sh defaultExecOptions cmd
           _pr_exitCode result `shouldBe` ExitFailure 1
 
     it "strips the subprocess environment" $ do
@@ -36,7 +36,7 @@ spec = do
       case authorizeEnv of
         Left _ -> expectationFailure "authorize failed"
         Right cmd -> do
-          result <- _sh_execute sh cmd
+          result <- _sh_execute sh defaultExecOptions cmd
           _pr_exitCode result `shouldBe` ExitSuccess
           let outputLines = lines (BS8.unpack (_pr_stdout result))
           -- The subprocess should only have PATH from safeEnv
@@ -49,10 +49,36 @@ spec = do
       case authorizeEcho of
         Left _ -> expectationFailure "authorize failed"
         Right cmd -> do
-          result <- _sh_execute mkNoOpShellHandle cmd
+          result <- _sh_execute mkNoOpShellHandle defaultExecOptions cmd
           _pr_exitCode result `shouldBe` ExitSuccess
           _pr_stdout result `shouldBe` ""
           _pr_stderr result `shouldBe` ""
+
+  describe "ExecOptions" $ do
+    it "respects working directory" $ do
+      let sh = mkShellHandle mkNoOpLogHandle
+      case authorizePwd of
+        Left _ -> expectationFailure "authorize failed"
+        Right cmd -> do
+          result <- _sh_execute sh (defaultExecOptions { _eo_workingDir = Just "/tmp" }) cmd
+          _pr_exitCode result `shouldBe` ExitSuccess
+          -- /tmp may be a symlink (macOS: /tmp -> /private/tmp)
+          let out = BS8.unpack (_pr_stdout result)
+          out `shouldSatisfy` (\s -> "/tmp" `isPrefixOfStr` s || "/private/tmp" `isPrefixOfStr` s)
+
+    it "times out long-running commands" $ do
+      let sh = mkShellHandle mkNoOpLogHandle
+      case authorizeSleep of
+        Left _ -> expectationFailure "authorize failed"
+        Right cmd -> do
+          result <- _sh_execute sh (defaultExecOptions { _eo_timeout = Just 100 }) cmd
+          _pr_exitCode result `shouldBe` ExitFailure 124
+          BS8.unpack (_pr_stderr result) `shouldContain` "timed out"
+
+    it "has Show and Eq instances" $ do
+      let opts = ExecOptions (Just 1000) (Just "/tmp")
+      show opts `shouldContain` "1000"
+      opts `shouldBe` opts
 
   describe "ProcessResult" $ do
     it "has Show and Eq instances" $ do
@@ -67,6 +93,8 @@ testPolicy =
   $ allowCommand (CommandName "echo")
   $ allowCommand (CommandName "false")
   $ allowCommand (CommandName "env")
+  $ allowCommand (CommandName "pwd")
+  $ allowCommand (CommandName "sleep")
     defaultPolicy
 
 authorizeEcho :: Either CommandError AuthorizedCommand
@@ -77,6 +105,12 @@ authorizeFalse = authorize testPolicy "/usr/bin/false" []
 
 authorizeEnv :: Either CommandError AuthorizedCommand
 authorizeEnv = authorize testPolicy "/usr/bin/env" []
+
+authorizePwd :: Either CommandError AuthorizedCommand
+authorizePwd = authorize testPolicy "pwd" []
+
+authorizeSleep :: Either CommandError AuthorizedCommand
+authorizeSleep = authorize testPolicy "sleep" ["10"]
 
 isPrefixOfStr :: String -> String -> Bool
 isPrefixOfStr [] _ = True

--- a/test/Integration/SignalFlowSpec.hs
+++ b/test/Integration/SignalFlowSpec.hs
@@ -7,6 +7,7 @@ import Data.Aeson (object, (.=))
 import Data.IORef
 import Data.Text (Text)
 import Data.Text qualified as T
+import System.Timeout (timeout)
 import Test.Hspec
 
 import PureClaw.Agent.Env
@@ -97,10 +98,9 @@ spec = do
             }
       atomically $ writeTQueue (_sch_inbox sc) envelope
 
-      -- Wait a bit for processing
-      threadDelay 50000  -- 50ms
+      -- Poll until we see the response (up to 5s)
+      waitForResponses sentRef 1
 
-      -- Push EOF to terminate the loop
       cancelWith agentThread (userError "EOF")
       _ <- waitCatch agentThread
 
@@ -129,9 +129,9 @@ spec = do
             , _se_dataMessage = Just SignalDataMessage { _sdm_message = txt, _sdm_timestamp = ts }
             }
       atomically $ writeTQueue (_sch_inbox sc) (mkEnvelope "First" 1000)
-      threadDelay 50000
+      waitForResponses sentRef 1
       atomically $ writeTQueue (_sch_inbox sc) (mkEnvelope "Second" 2000)
-      threadDelay 50000
+      waitForResponses sentRef 2
 
       cancelWith agentThread (userError "EOF")
       _ <- waitCatch agentThread
@@ -156,7 +156,7 @@ spec = do
             , _se_dataMessage = Just SignalDataMessage { _sdm_message = "/status", _sdm_timestamp = 1000 }
             }
       atomically $ writeTQueue (_sch_inbox sc) statusEnvelope
-      threadDelay 50000
+      waitForResponses sentRef 1
 
       cancelWith agentThread (userError "EOF")
       _ <- waitCatch agentThread
@@ -189,7 +189,7 @@ spec = do
             , _se_dataMessage = Just SignalDataMessage { _sdm_message = "do it", _sdm_timestamp = 1000 }
             }
       atomically $ writeTQueue (_sch_inbox sc) envelope
-      threadDelay 100000  -- 100ms for tool call round-trip
+      waitForResponses sentRef 1  -- at least 1 response
 
       cancelWith agentThread (userError "EOF")
       _ <- waitCatch agentThread
@@ -230,3 +230,19 @@ mkTestSignalChannelForFlow = do
   let transport = mkMockSignalTransport inQ outQ
       config = SignalConfig { _sc_account = "+1234567890", _sc_textChunkLimit = 6000, _sc_allowFrom = AllowAll }
   mkSignalChannel config transport mkNoOpLogHandle
+
+-- | Poll an IORef until it contains at least @n@ items, with a 5-second timeout.
+-- Fails the test if the timeout is reached.
+waitForResponses :: IORef [a] -> Int -> IO ()
+waitForResponses ref n = do
+  result <- timeout 5000000 go  -- 5 seconds
+  case result of
+    Just () -> pure ()
+    Nothing -> expectationFailure $
+      "Timed out waiting for " <> show n <> " response(s)"
+  where
+    go = do
+      xs <- readIORef ref
+      if length xs >= n
+        then pure ()
+        else threadDelay 10000 >> go  -- check every 10ms

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,6 +40,9 @@ import qualified Tools.CronSpec
 import qualified Tools.ImageSpec
 import qualified Tools.SearchFilesSpec
 import qualified Tools.ClarifySpec
+import qualified Tools.WebExtractSpec
+import qualified Tools.PatchSpec
+import qualified Tools.DelegateSpec
 import qualified Memory.NoneSpec
 import qualified Memory.MarkdownSpec
 import qualified Memory.SQLiteSpec
@@ -119,6 +122,9 @@ main = hspec $ do
   describe "Tools.Image" Tools.ImageSpec.spec
   describe "Tools.SearchFiles" Tools.SearchFilesSpec.spec
   describe "Tools.Clarify" Tools.ClarifySpec.spec
+  describe "Tools.WebExtract" Tools.WebExtractSpec.spec
+  describe "Tools.Patch" Tools.PatchSpec.spec
+  describe "Tools.Delegate" Tools.DelegateSpec.spec
   describe "Memory.None" Memory.NoneSpec.spec
   describe "Memory.Markdown" Memory.MarkdownSpec.spec
   describe "Memory.SQLite" Memory.SQLiteSpec.spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -44,6 +44,9 @@ import qualified Tools.ClarifySpec
 import qualified Tools.WebExtractSpec
 import qualified Tools.PatchSpec
 import qualified Tools.DelegateSpec
+import qualified Tools.TodoSpec
+import qualified Tools.ExecuteCodeSpec
+import qualified Tools.SessionSearchSpec
 import qualified Memory.NoneSpec
 import qualified Memory.MarkdownSpec
 import qualified Memory.SQLiteSpec
@@ -127,6 +130,9 @@ main = hspec $ do
   describe "Tools.WebExtract" Tools.WebExtractSpec.spec
   describe "Tools.Patch" Tools.PatchSpec.spec
   describe "Tools.Delegate" Tools.DelegateSpec.spec
+  describe "Tools.Todo" Tools.TodoSpec.spec
+  describe "Tools.ExecuteCode" Tools.ExecuteCodeSpec.spec
+  describe "Tools.SessionSearch" Tools.SessionSearchSpec.spec
   describe "Memory.None" Memory.NoneSpec.spec
   describe "Memory.Markdown" Memory.MarkdownSpec.spec
   describe "Memory.SQLite" Memory.SQLiteSpec.spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,6 +31,7 @@ import qualified Tools.ShellSpec
 import qualified Tools.FileReadSpec
 import qualified Tools.GitSpec
 import qualified Tools.MemorySpec
+import qualified Tools.FileWriteSpec
 import qualified Tools.EditSpec
 import qualified Tools.ProcessSpec
 import qualified Handles.ProcessSpec
@@ -113,6 +114,7 @@ main = hspec $ do
   describe "Tools.FileRead" Tools.FileReadSpec.spec
   describe "Tools.Git" Tools.GitSpec.spec
   describe "Tools.Memory" Tools.MemorySpec.spec
+  describe "Tools.FileWrite" Tools.FileWriteSpec.spec
   describe "Tools.Edit" Tools.EditSpec.spec
   describe "Tools.Process" Tools.ProcessSpec.spec
   describe "Handles.Process" Handles.ProcessSpec.spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -38,6 +38,8 @@ import qualified Tools.WebSearchSpec
 import qualified Tools.MessageSpec
 import qualified Tools.CronSpec
 import qualified Tools.ImageSpec
+import qualified Tools.SearchFilesSpec
+import qualified Tools.ClarifySpec
 import qualified Memory.NoneSpec
 import qualified Memory.MarkdownSpec
 import qualified Memory.SQLiteSpec
@@ -115,6 +117,8 @@ main = hspec $ do
   describe "Tools.Message" Tools.MessageSpec.spec
   describe "Tools.Cron" Tools.CronSpec.spec
   describe "Tools.Image" Tools.ImageSpec.spec
+  describe "Tools.SearchFiles" Tools.SearchFilesSpec.spec
+  describe "Tools.Clarify" Tools.ClarifySpec.spec
   describe "Memory.None" Memory.NoneSpec.spec
   describe "Memory.Markdown" Memory.MarkdownSpec.spec
   describe "Memory.SQLite" Memory.SQLiteSpec.spec

--- a/test/Tools/ClarifySpec.hs
+++ b/test/Tools/ClarifySpec.hs
@@ -1,0 +1,101 @@
+module Tools.ClarifySpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import Test.Hspec
+
+import PureClaw.Handles.Channel
+import PureClaw.Providers.Class
+import PureClaw.Tools.Clarify
+import PureClaw.Tools.Registry
+
+spec :: Spec
+spec = do
+  describe "clarifyTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = clarifyTool mkNoOpChannelHandle
+      _td_name def' `shouldBe` "clarify"
+
+    it "sends an open-ended question and returns user response" $ do
+      let ch = mockChannel "my answer"
+          (_, handler) = clarifyTool ch
+          input = object ["question" .= ("What color?" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "What color?"
+      T.unpack output `shouldContain` "my answer"
+
+    it "sends multiple-choice prompt and resolves numeric selection" $ do
+      let ch = mockChannel "2"
+          (_, handler) = clarifyTool ch
+          input = object
+            [ "question" .= ("Pick one:" :: String)
+            , "choices" .= (["red", "blue", "green"] :: [String])
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      -- User typed "2" which maps to "blue"
+      T.unpack output `shouldContain` "blue"
+
+    it "returns raw text for non-numeric choice input" $ do
+      let ch = mockChannel "actually purple"
+          (_, handler) = clarifyTool ch
+          input = object
+            [ "question" .= ("Pick one:" :: String)
+            , "choices" .= (["red", "blue"] :: [String])
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "actually purple"
+
+    it "handles Other selection (N+1)" $ do
+      let ch = mockChannel "3"
+          (_, handler) = clarifyTool ch
+          input = object
+            [ "question" .= ("Pick:" :: String)
+            , "choices" .= (["a", "b"] :: [String])
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      -- "3" is the "Other" option (choices.length + 1)
+      -- Returns the raw input since no specific freeform was given
+      T.unpack output `shouldContain` "3"
+
+    it "returns JSON with choices_offered when choices provided" $ do
+      let ch = mockChannel "1"
+          (_, handler) = clarifyTool ch
+          input = object
+            [ "question" .= ("Pick:" :: String)
+            , "choices" .= (["yes", "no"] :: [String])
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "choices_offered"
+
+    it "returns JSON without choices_offered for open-ended" $ do
+      let ch = mockChannel "freeform"
+          (_, handler) = clarifyTool ch
+          input = object ["question" .= ("Why?" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldSatisfy` (not . ("choices_offered" `elem`) . words)
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = clarifyTool mkNoOpChannelHandle
+          input = object ["wrong_field" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+    it "handles channel errors gracefully" $ do
+      let ch = mkNoOpChannelHandle { _ch_prompt = \_ -> error "channel down" }
+          (_, handler) = clarifyTool ch
+          input = object ["question" .= ("test?" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "Failed to get user response"
+
+-- | Create a mock channel that returns a fixed response to prompts.
+mockChannel :: T.Text -> ChannelHandle
+mockChannel response = mkNoOpChannelHandle
+  { _ch_prompt = \_ -> pure response
+  }

--- a/test/Tools/DelegateSpec.hs
+++ b/test/Tools/DelegateSpec.hs
@@ -1,0 +1,94 @@
+module Tools.DelegateSpec (spec) where
+
+import Data.Aeson
+import Data.IORef
+import Data.Text qualified as T
+import Test.Hspec
+
+import Data.Map.Strict qualified as Map
+
+import PureClaw.Agent.Env
+import PureClaw.Core.Types
+import PureClaw.Handles.Channel
+import PureClaw.Handles.Log
+import PureClaw.Providers.Class
+import PureClaw.Security.Policy
+import PureClaw.Security.Vault.Plugin
+import PureClaw.Session.Handle
+import PureClaw.Tools.Delegate
+import PureClaw.Tools.Registry
+
+spec :: Spec
+spec = do
+  describe "delegateTaskTool" $ do
+    it "has the correct tool name" $ do
+      env <- mkTestEnv Nothing
+      let (def', _) = delegateTaskTool env
+      _td_name def' `shouldBe` "delegate_task"
+
+    it "returns error when no provider configured" $ do
+      env <- mkTestEnv Nothing
+      let (_, handler) = delegateTaskTool env
+          input = object ["goal" .= ("do something" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "no provider"
+
+    it "runs sub-agent with mock provider and returns result" $ do
+      let mockProvider = MkProvider MockProvider
+      env <- mkTestEnv (Just mockProvider)
+      let (_, handler) = delegateTaskTool env
+          input = object ["goal" .= ("say hello" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      -- MockProvider returns "Mock response" for every request
+      T.unpack output `shouldContain` "Mock response"
+
+    it "rejects invalid JSON input" $ do
+      env <- mkTestEnv Nothing
+      let (_, handler) = delegateTaskTool env
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+-- | Minimal mock provider that returns a text response with no tool calls.
+data MockProvider = MockProvider
+
+instance Provider MockProvider where
+  complete _ _req = pure CompletionResponse
+    { _crsp_content = [TextBlock "Mock response"]
+    , _crsp_model   = ModelId "mock"
+    , _crsp_usage   = Nothing
+    }
+
+-- | Build a minimal test AgentEnv for delegate_task testing.
+mkTestEnv :: Maybe SomeProvider -> IO AgentEnv
+mkTestEnv mProvider = do
+  providerRef <- newIORef mProvider
+  modelRef    <- newIORef (Just (ModelId "mock-model"))
+  vaultRef    <- newIORef Nothing
+  harnessRef  <- newIORef Map.empty
+  targetRef   <- newIORef TargetProvider
+  windowIdxRef <- newIORef 0
+  noOpSession <- mkNoOpSessionHandle
+  sessionRef  <- newIORef noOpSession
+  onFirstRef  <- newIORef Nothing
+  mcpRef      <- newIORef Map.empty
+  pure AgentEnv
+    { _env_provider         = providerRef
+    , _env_model            = modelRef
+    , _env_channel          = mkNoOpChannelHandle
+    , _env_logger           = mkNoOpLogHandle
+    , _env_systemPrompt     = Nothing
+    , _env_registry         = emptyRegistry
+    , _env_vault            = vaultRef
+    , _env_pluginHandle     = mkPluginHandle
+    , _env_policy           = defaultPolicy
+    , _env_harnesses        = harnessRef
+    , _env_target           = targetRef
+    , _env_nextWindowIdx    = windowIdxRef
+    , _env_agentDef         = Nothing
+    , _env_session          = sessionRef
+    , _env_onFirstStreamDone = onFirstRef
+    , _env_mcpServers       = mcpRef
+    }

--- a/test/Tools/EditSpec.hs
+++ b/test/Tools/EditSpec.hs
@@ -112,6 +112,118 @@ spec = do
       (_, isErr) <- runTool handler input
       isErr `shouldBe` True
 
+    it "suggests replace_all in multi-match error" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "aaa bbb aaa"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("aaa" :: String)
+              , "new_string" .= ("ccc" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` True
+        T.unpack output `shouldContain` "replace_all"
+
+  describe "replace_all mode" $ do
+    it "replaces all occurrences when replace_all is true" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "foo bar foo baz foo"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("foo" :: String)
+              , "new_string" .= ("qux" :: String)
+              , "replace_all" .= True
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "3"
+        contents <- readFile (dir </> "test.txt")
+        contents `shouldBe` "qux bar qux baz qux"
+
+    it "reports not-found when replace_all finds nothing" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "hello world"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("nonexistent" :: String)
+              , "new_string" .= ("replacement" :: String)
+              , "replace_all" .= True
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` True
+        T.unpack output `shouldContain` "not found"
+
+  describe "fuzzy matching" $ do
+    it "matches with normalized whitespace when exact fails" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "hello   world"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("hello world" :: String)
+              , "new_string" .= ("goodbye" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "whitespace"
+        contents <- readFile (dir </> "test.txt")
+        contents `shouldBe` "goodbye"
+
+    it "matches with normalized line endings (CRLF)" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "line1\r\nline2\r\n"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("line1\nline2\n" :: String)
+              , "new_string" .= ("replaced\n" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        -- CRLF is caught by whitespace-normalized (tried first) since
+        -- \r\n → \n changes whitespace composition
+        T.unpack output `shouldContain` "matched via"
+
+    it "reports not-found when fuzzy also fails" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "hello world"
+        let fh = mkFileHandle root
+            (_, handler) = editTool root fh
+            input = object
+              [ "path" .= ("test.txt" :: String)
+              , "old_string" .= ("completely different" :: String)
+              , "new_string" .= ("replacement" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` True
+        T.unpack output `shouldContain` "not found"
+
+  describe "pure helpers" $ do
+    it "countOccurrences counts correctly" $ do
+      countOccurrences "aa" "aaaaaa" `shouldBe` 3
+      countOccurrences "x" "hello" `shouldBe` 0
+      countOccurrences "" "hello" `shouldBe` 0
+      countOccurrences "hello" "hello" `shouldBe` 1
+
+    it "replaceFirst replaces first occurrence only" $ do
+      replaceFirst "a" "b" "axa" `shouldBe` "bxa"
+
+    it "replaceAll replaces all occurrences" $ do
+      replaceAll "a" "b" "axa" `shouldBe` "bxb"
+      replaceAll "" "b" "hello" `shouldBe` "hello"
+
+    it "fuzzyFind matches whitespace-normalized" $ do
+      fuzzyFind "hello world" "hello   world" `shouldSatisfy` isUniqueFuzzy
+      fuzzyFind "completely different" "hello world" `shouldBe` NoFuzzyMatch
+
 -- | Helper to create a temporary workspace for testing.
 withTestWorkspace :: (WorkspaceRoot -> FilePath -> IO a) -> IO a
 withTestWorkspace action = do
@@ -120,3 +232,7 @@ withTestWorkspace action = do
   createDirectoryIfMissing True dir
   let root = WorkspaceRoot dir
   action root dir
+
+isUniqueFuzzy :: FuzzyMatch -> Bool
+isUniqueFuzzy (UniqueFuzzy _ _) = True
+isUniqueFuzzy _ = False

--- a/test/Tools/ExecuteCodeSpec.hs
+++ b/test/Tools/ExecuteCodeSpec.hs
@@ -1,0 +1,61 @@
+module Tools.ExecuteCodeSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Security.Policy
+import PureClaw.Tools.ExecuteCode
+import PureClaw.Tools.Registry
+
+spec :: Spec
+spec = do
+  describe "executeCodeTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = executeCodeTool defaultPolicy
+      _td_name def' `shouldBe` "execute_code"
+
+    it "rejects when interpreter not allowed" $ do
+      let (_, handler) = executeCodeTool defaultPolicy
+          input = object ["code" .= ("print('hi')" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "denied"
+
+    it "executes Python code when allowed" $ do
+      let policy = withAutonomy Full
+                 $ allowCommand (CommandName "python3") defaultPolicy
+          (_, handler) = executeCodeTool policy
+          input = object ["code" .= ("print('hello from python')" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "hello from python"
+
+    it "reports non-zero exit codes" $ do
+      let policy = withAutonomy Full
+                 $ allowCommand (CommandName "python3") defaultPolicy
+          (_, handler) = executeCodeTool policy
+          input = object ["code" .= ("import sys; sys.exit(42)" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "42"
+
+    it "supports custom language" $ do
+      let policy = withAutonomy Full
+                 $ allowCommand (CommandName "bash") defaultPolicy
+          (_, handler) = executeCodeTool policy
+          input = object
+            [ "code" .= ("echo hello from bash" :: String)
+            , "language" .= ("bash" :: String)
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "hello from bash"
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = executeCodeTool defaultPolicy
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True

--- a/test/Tools/FileWriteSpec.hs
+++ b/test/Tools/FileWriteSpec.hs
@@ -1,0 +1,104 @@
+module Tools.FileWriteSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.File
+import PureClaw.Providers.Class
+import PureClaw.Tools.FileWrite
+import PureClaw.Tools.Registry
+
+spec :: Spec
+spec = do
+  describe "fileWriteTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = fileWriteTool (WorkspaceRoot "/tmp") mkNoOpFileHandle
+      _td_name def' `shouldBe` "file_write"
+
+    it "writes a new file" $ do
+      withTestWorkspace $ \root dir -> do
+        let fh = mkFileHandle root
+            (_, handler) = fileWriteTool root fh
+            input = object
+              [ "path" .= ("new-file.txt" :: String)
+              , "content" .= ("hello world" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "new-file.txt"
+        exists <- doesFileExist (dir </> "new-file.txt")
+        exists `shouldBe` True
+        contents <- readFile (dir </> "new-file.txt")
+        contents `shouldBe` "hello world"
+
+    it "overwrites an existing file" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "existing.txt") "old content"
+        let fh = mkFileHandle root
+            (_, handler) = fileWriteTool root fh
+            input = object
+              [ "path" .= ("existing.txt" :: String)
+              , "content" .= ("new content" :: String)
+              ]
+        (_output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        contents <- readFile (dir </> "existing.txt")
+        contents `shouldBe` "new content"
+
+    it "creates parent directories for new files" $ do
+      withTestWorkspace $ \root dir -> do
+        let fh = mkFileHandle root
+            (_, handler) = fileWriteTool root fh
+            input = object
+              [ "path" .= ("subdir/nested/new-file.txt" :: String)
+              , "content" .= ("deep content" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "new-file.txt"
+        exists <- doesFileExist (dir </> "subdir" </> "nested" </> "new-file.txt")
+        exists `shouldBe` True
+        contents <- readFile (dir </> "subdir" </> "nested" </> "new-file.txt")
+        contents `shouldBe` "deep content"
+
+    it "rejects paths that escape the workspace" $ do
+      withTestWorkspace $ \root _dir -> do
+        let fh = mkFileHandle root
+            (_, handler) = fileWriteTool root fh
+            input = object
+              [ "path" .= ("../../../etc/evil" :: String)
+              , "content" .= ("hacked" :: String)
+              ]
+        (_, isErr) <- runTool handler input
+        isErr `shouldBe` True
+
+    it "rejects blocked paths" $ do
+      withTestWorkspace $ \root _dir -> do
+        let fh = mkFileHandle root
+            (_, handler) = fileWriteTool root fh
+            input = object
+              [ "path" .= (".env" :: String)
+              , "content" .= ("SECRET=x" :: String)
+              ]
+        (_, isErr) <- runTool handler input
+        isErr `shouldBe` True
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = fileWriteTool (WorkspaceRoot "/tmp") mkNoOpFileHandle
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+withTestWorkspace :: (WorkspaceRoot -> FilePath -> IO a) -> IO a
+withTestWorkspace action = do
+  tmpDir <- getTemporaryDirectory
+  let dir = tmpDir </> "pureclaw-filewrite-test"
+  createDirectoryIfMissing True dir
+  contents <- listDirectory dir
+  mapM_ (\f -> removePathForcibly (dir </> f)) contents
+  let root = WorkspaceRoot dir
+  action root dir

--- a/test/Tools/GitSpec.hs
+++ b/test/Tools/GitSpec.hs
@@ -30,7 +30,7 @@ spec = do
     it "executes git commands when allowed" $ do
       let policy = withAutonomy Full
                  $ allowCommand (CommandName "git") defaultPolicy
-          mockShell = ShellHandle $ \_ -> pure ProcessResult
+          mockShell = ShellHandle $ \_ _ -> pure ProcessResult
             { _pr_exitCode = ExitSuccess
             , _pr_stdout   = BS8.pack "On branch main"
             , _pr_stderr   = ""

--- a/test/Tools/PatchSpec.hs
+++ b/test/Tools/PatchSpec.hs
@@ -1,0 +1,158 @@
+module Tools.PatchSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.File
+import PureClaw.Providers.Class
+import PureClaw.Tools.Patch
+import PureClaw.Tools.Registry
+
+spec :: Spec
+spec = do
+  describe "patchTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = patchTool (WorkspaceRoot "/tmp") mkNoOpFileHandle
+      _td_name def' `shouldBe` "patch"
+
+    it "applies a simple single-file patch" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.hs") "module Main where\n\nmain :: IO ()\nmain = putStrLn \"hello\"\n"
+        let fh = mkFileHandle root
+            (_, handler) = patchTool root fh
+            input = object ["patch" .= T.unlines
+              [ "--- a/test.hs"
+              , "+++ b/test.hs"
+              , "@@ -3,2 +3,2 @@"
+              , "-main :: IO ()"
+              , "-main = putStrLn \"hello\""
+              , "+main :: IO ()"
+              , "+main = putStrLn \"goodbye\""
+              ]]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "Patched"
+        contents <- readFile (dir </> "test.hs")
+        contents `shouldContain` "goodbye"
+
+    it "applies a multi-file patch" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "a.txt") "line1\nline2\nline3\n"
+        writeFile (dir </> "b.txt") "alpha\nbeta\ngamma\n"
+        let fh = mkFileHandle root
+            (_, handler) = patchTool root fh
+            input = object ["patch" .= T.unlines
+              [ "--- a/a.txt"
+              , "+++ b/a.txt"
+              , "@@ -1,3 +1,3 @@"
+              , "-line2"
+              , "+LINE2"
+              , "--- a/b.txt"
+              , "+++ b/b.txt"
+              , "@@ -1,3 +1,3 @@"
+              , "-beta"
+              , "+BETA"
+              ]]
+        (_output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        aContents <- readFile (dir </> "a.txt")
+        bContents <- readFile (dir </> "b.txt")
+        aContents `shouldContain` "LINE2"
+        bContents `shouldContain` "BETA"
+
+    it "reports error for non-matching hunks" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "hello world\n"
+        let fh = mkFileHandle root
+            (_, handler) = patchTool root fh
+            input = object ["patch" .= T.unlines
+              [ "--- a/test.txt"
+              , "+++ b/test.txt"
+              , "@@ -1,1 +1,1 @@"
+              , "-nonexistent line"
+              , "+replacement"
+              ]]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` True
+        T.unpack output `shouldContain` "could not find"
+
+    it "rejects empty patches" $ do
+      let (_, handler) = patchTool (WorkspaceRoot "/tmp") mkNoOpFileHandle
+          input = object ["patch" .= ("" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "Empty patch"
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = patchTool (WorkspaceRoot "/tmp") mkNoOpFileHandle
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+  describe "parsePatch" $ do
+    it "parses a single-file patch" $ do
+      let result = parsePatch $ T.unlines
+            [ "--- a/foo.hs"
+            , "+++ b/foo.hs"
+            , "@@ -1,2 +1,2 @@"
+            , "-old"
+            , "+new"
+            ]
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right files -> case files of
+          [f] -> do
+            _pf_path f `shouldBe` "foo.hs"
+            length (_pf_hunks f) `shouldBe` 1
+          _ -> expectationFailure $ "Expected 1 file, got " <> show (length files)
+
+    it "parses a multi-file patch" $ do
+      let result = parsePatch $ T.unlines
+            [ "--- a/one.txt"
+            , "+++ b/one.txt"
+            , "@@ -1 +1 @@"
+            , "-a"
+            , "+b"
+            , "--- a/two.txt"
+            , "+++ b/two.txt"
+            , "@@ -1 +1 @@"
+            , "-c"
+            , "+d"
+            ]
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right files -> length files `shouldBe` 2
+
+    it "parses context lines" $ do
+      let result = parsePatch $ T.unlines
+            [ "--- a/ctx.txt"
+            , "+++ b/ctx.txt"
+            , "@@ -1,4 +1,4 @@"
+            , " context1"
+            , " context2"
+            , "-old"
+            , "+new"
+            ]
+      case result of
+        Left err -> expectationFailure (T.unpack err)
+        Right [f] -> case _pf_hunks f of
+          [hunk] -> do
+            length (_ph_context hunk) `shouldBe` 2
+            _ph_removals hunk `shouldBe` ["old"]
+            _ph_additions hunk `shouldBe` ["new"]
+          hs -> expectationFailure $ "Expected 1 hunk, got " <> show (length hs)
+        Right fs -> expectationFailure $ "Expected 1 file, got " <> show (length fs)
+
+withTestWorkspace :: (WorkspaceRoot -> FilePath -> IO a) -> IO a
+withTestWorkspace action = do
+  tmpDir <- getTemporaryDirectory
+  let dir = tmpDir </> "pureclaw-patch-test"
+  createDirectoryIfMissing True dir
+  contents <- listDirectory dir
+  mapM_ (\f -> removePathForcibly (dir </> f)) contents
+  let root = WorkspaceRoot dir
+  action root dir

--- a/test/Tools/SearchFilesSpec.hs
+++ b/test/Tools/SearchFilesSpec.hs
@@ -1,0 +1,134 @@
+module Tools.SearchFilesSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+import PureClaw.Tools.SearchFiles
+
+spec :: Spec
+spec = do
+  describe "searchFilesTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = searchFilesTool (WorkspaceRoot "/tmp")
+      _td_name def' `shouldBe` "search_files"
+
+    it "finds content matches with line numbers" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "hello.txt") "hello world\ngoodbye world\nhello again\n"
+        let (_, handler) = searchFilesTool root
+            input = object ["pattern" .= ("hello" :: String)]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "hello"
+        T.unpack output `shouldContain` "hello.txt"
+
+    it "returns no-match message for missing pattern" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "hello.txt") "hello world\n"
+        let (_, handler) = searchFilesTool root
+            input = object ["pattern" .= ("nonexistent_xyz" :: String)]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "No matches"
+
+    it "supports files_only output mode" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "a.txt") "target\n"
+        writeFile (dir </> "b.txt") "nothing\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("target" :: String)
+              , "output_mode" .= ("files_only" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "a.txt"
+        T.unpack output `shouldSatisfy` (not . ("b.txt" `elem`) . words)
+
+    it "supports count output mode" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "multi.txt") "foo\nbar\nfoo\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("foo" :: String)
+              , "output_mode" .= ("count" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "2"
+
+    it "respects file_glob filter" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "code.hs") "findme\n"
+        writeFile (dir </> "readme.md") "findme\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("findme" :: String)
+              , "file_glob" .= ("*.hs" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "code.hs"
+        T.unpack output `shouldSatisfy` (not . ("readme.md" `elem`) . words)
+
+    it "supports case-insensitive search" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "test.txt") "Hello World\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("hello" :: String)
+              , "case_insensitive" .= True
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "Hello"
+
+    it "supports context lines" $ do
+      withTestWorkspace $ \root dir -> do
+        writeFile (dir </> "ctx.txt") "line1\nline2\ntarget\nline4\nline5\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("target" :: String)
+              , "context" .= (1 :: Int)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "line2"
+        T.unpack output `shouldContain` "line4"
+
+    it "respects search path" $ do
+      withTestWorkspace $ \root dir -> do
+        createDirectoryIfMissing True (dir </> "sub")
+        writeFile (dir </> "sub" </> "deep.txt") "deep_match\n"
+        writeFile (dir </> "top.txt") "deep_match\n"
+        let (_, handler) = searchFilesTool root
+            input = object
+              [ "pattern" .= ("deep_match" :: String)
+              , "path" .= ("sub" :: String)
+              ]
+        (output, isErr) <- runTool handler input
+        isErr `shouldBe` False
+        T.unpack output `shouldContain` "deep.txt"
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = searchFilesTool (WorkspaceRoot "/tmp")
+          input = object ["wrong_field" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+withTestWorkspace :: (WorkspaceRoot -> FilePath -> IO a) -> IO a
+withTestWorkspace action = do
+  tmpDir <- getTemporaryDirectory
+  let dir = tmpDir </> "pureclaw-search-test"
+  createDirectoryIfMissing True dir
+  -- Clean any leftover files
+  contents <- listDirectory dir
+  mapM_ (\f -> removePathForcibly (dir </> f)) contents
+  let root = WorkspaceRoot dir
+  action root dir

--- a/test/Tools/SessionSearchSpec.hs
+++ b/test/Tools/SessionSearchSpec.hs
@@ -1,0 +1,45 @@
+module Tools.SessionSearchSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import System.Directory
+import System.FilePath
+import Test.Hspec
+
+import PureClaw.Handles.Log
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+import PureClaw.Tools.SessionSearch
+
+spec :: Spec
+spec = do
+  describe "sessionSearchTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = sessionSearchTool mkNoOpLogHandle "/tmp/nonexistent"
+      _td_name def' `shouldBe` "session_search"
+
+    it "returns no matches for empty sessions dir" $ do
+      tmpDir <- getTemporaryDirectory
+      let dir = tmpDir </> "pureclaw-session-search-test"
+      createDirectoryIfMissing True dir
+      -- Clean
+      entries <- listDirectory dir
+      mapM_ (\f -> removePathForcibly (dir </> f)) entries
+      let (_, handler) = sessionSearchTool mkNoOpLogHandle dir
+          input = object ["query" .= ("nonexistent" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "No matches"
+
+    it "handles missing sessions directory gracefully" $ do
+      let (_, handler) = sessionSearchTool mkNoOpLogHandle "/tmp/definitely-not-a-real-dir-xyz"
+          input = object ["query" .= ("test" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "No matches"
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = sessionSearchTool mkNoOpLogHandle "/tmp"
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True

--- a/test/Tools/ShellSpec.hs
+++ b/test/Tools/ShellSpec.hs
@@ -30,7 +30,7 @@ spec = do
     it "executes allowed commands" $ do
       let policy = withAutonomy Full
                  $ allowCommand (CommandName "echo") defaultPolicy
-          mockShell = ShellHandle $ \_ -> pure ProcessResult
+          mockShell = ShellHandle $ \_ _ -> pure ProcessResult
             { _pr_exitCode = ExitSuccess
             , _pr_stdout   = BS8.pack "hello world"
             , _pr_stderr   = ""
@@ -44,7 +44,7 @@ spec = do
     it "reports non-zero exit codes" $ do
       let policy = withAutonomy Full
                  $ allowCommand (CommandName "false") defaultPolicy
-          mockShell = ShellHandle $ \_ -> pure ProcessResult
+          mockShell = ShellHandle $ \_ _ -> pure ProcessResult
             { _pr_exitCode = ExitFailure 1
             , _pr_stdout   = ""
             , _pr_stderr   = BS8.pack "error"

--- a/test/Tools/TodoSpec.hs
+++ b/test/Tools/TodoSpec.hs
@@ -1,0 +1,88 @@
+module Tools.TodoSpec (spec) where
+
+import Data.Aeson
+import Data.Text qualified as T
+import Test.Hspec
+
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+import PureClaw.Tools.Todo
+
+spec :: Spec
+spec = do
+  describe "todoTool" $ do
+    it "has the correct tool name" $ do
+      (def', _) <- todoTool
+      _td_name def' `shouldBe` "todo"
+
+    it "returns empty list when no todos" $ do
+      (_, handler) <- todoTool
+      let input = object []
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "No todos"
+
+    it "writes and reads todos" $ do
+      (_, handler) <- todoTool
+      let writeInput = object ["todos" .= [
+              object ["id" .= ("1" :: String), "content" .= ("do thing" :: String), "status" .= ("pending" :: String)]
+            ]]
+      (output, isErr) <- runTool handler writeInput
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "do thing"
+      -- Read back
+      let readInput = object []
+      (readOutput, readErr) <- runTool handler readInput
+      readErr `shouldBe` False
+      T.unpack readOutput `shouldContain` "do thing"
+
+    it "replaces all todos by default" $ do
+      (_, handler) <- todoTool
+      let write1 = object ["todos" .= [
+              object ["id" .= ("1" :: String), "content" .= ("first" :: String), "status" .= ("pending" :: String)]
+            ]]
+          write2 = object ["todos" .= [
+              object ["id" .= ("2" :: String), "content" .= ("second" :: String), "status" .= ("pending" :: String)]
+            ]]
+      _ <- runTool handler write1
+      (output, _) <- runTool handler write2
+      T.unpack output `shouldContain` "second"
+      T.unpack output `shouldSatisfy` (not . ("first" `elem`) . words)
+
+    it "merges when merge=true" $ do
+      (_, handler) <- todoTool
+      let write1 = object ["todos" .= [
+              object ["id" .= ("1" :: String), "content" .= ("first" :: String), "status" .= ("pending" :: String)]
+            ]]
+          write2 = object
+            [ "todos" .= [
+                object ["id" .= ("2" :: String), "content" .= ("second" :: String), "status" .= ("pending" :: String)]
+              ]
+            , "merge" .= True
+            ]
+      _ <- runTool handler write1
+      (output, _) <- runTool handler write2
+      T.unpack output `shouldContain` "first"
+      T.unpack output `shouldContain` "second"
+
+    it "rejects invalid statuses" $ do
+      (_, handler) <- todoTool
+      let input = object ["todos" .= [
+              object ["id" .= ("1" :: String), "content" .= ("x" :: String), "status" .= ("invalid" :: String)]
+            ]]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "Invalid status"
+
+    it "groups by status in output" $ do
+      (_, handler) <- todoTool
+      let input = object ["todos" .= [
+              object ["id" .= ("1" :: String), "content" .= ("active" :: String), "status" .= ("in_progress" :: String)],
+              object ["id" .= ("2" :: String), "content" .= ("waiting" :: String), "status" .= ("pending" :: String)],
+              object ["id" .= ("3" :: String), "content" .= ("done" :: String), "status" .= ("completed" :: String)]
+            ]]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "IN_PROGRESS"
+      T.unpack output `shouldContain` "PENDING"
+      T.unpack output `shouldContain` "COMPLETED"

--- a/test/Tools/WebExtractSpec.hs
+++ b/test/Tools/WebExtractSpec.hs
@@ -1,0 +1,116 @@
+module Tools.WebExtractSpec (spec) where
+
+import Data.Aeson
+import Data.ByteString.Char8 qualified as BS8
+import Data.Text qualified as T
+import Test.Hspec
+
+import PureClaw.Core.Types
+import PureClaw.Handles.Network
+import PureClaw.Providers.Class
+import PureClaw.Tools.Registry
+import PureClaw.Tools.WebExtract
+
+spec :: Spec
+spec = do
+  describe "webExtractTool" $ do
+    it "has the correct tool name" $ do
+      let (def', _) = webExtractTool AllowAll mkNoOpNetworkHandle
+      _td_name def' `shouldBe` "web_extract"
+
+    it "fetches a URL and returns content" $ do
+      let nh = mockNetwork 200 "Hello, world!"
+          (_, handler) = webExtractTool AllowAll nh
+          input = object ["url" .= ("https://example.com" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "Hello, world!"
+
+    it "converts HTML to readable text" $ do
+      let html = "<html><body><h1>Title</h1><p>Some text</p></body></html>"
+          nh = mockNetwork 200 html
+          (_, handler) = webExtractTool AllowAll nh
+          input = object ["url" .= ("https://example.com" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "# Title"
+      T.unpack output `shouldContain` "Some text"
+
+    it "strips script and style tags" $ do
+      let html = "<html><head><style>body{}</style></head><body><script>alert(1)</script>Real content</body></html>"
+          nh = mockNetwork 200 html
+          (_, handler) = webExtractTool AllowAll nh
+          input = object ["url" .= ("https://example.com" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "Real content"
+      T.unpack output `shouldSatisfy` (not . ("alert" `elem`) . words)
+      T.unpack output `shouldSatisfy` (not . ("body{}" `elem`) . words)
+
+    it "reports HTTP errors" $ do
+      let nh = mockNetwork 404 "Not found"
+          (_, handler) = webExtractTool AllowAll nh
+          input = object ["url" .= ("https://example.com/missing" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` True
+      T.unpack output `shouldContain` "404"
+
+    it "truncates large responses" $ do
+      let bigBody = T.replicate 200000 "x"
+          nh = mockNetwork 200 (T.unpack bigBody)
+          (_, handler) = webExtractTool AllowAll nh
+          input = object ["url" .= ("https://example.com" :: String)]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "truncated"
+
+    it "respects custom max_length" $ do
+      let body = T.replicate 1000 "x"
+          nh = mockNetwork 200 (T.unpack body)
+          (_, handler) = webExtractTool AllowAll nh
+          input = object
+            [ "url" .= ("https://example.com" :: String)
+            , "max_length" .= (500 :: Int)
+            ]
+      (output, isErr) <- runTool handler input
+      isErr `shouldBe` False
+      T.unpack output `shouldContain` "truncated"
+
+    it "rejects invalid JSON input" $ do
+      let (_, handler) = webExtractTool AllowAll mkNoOpNetworkHandle
+          input = object ["wrong" .= ("value" :: String)]
+      (_, isErr) <- runTool handler input
+      isErr `shouldBe` True
+
+  describe "htmlToMarkdown" $ do
+    it "converts headings" $ do
+      let result = htmlToMarkdown "<h1>Title</h1><h2>Sub</h2>"
+      T.unpack result `shouldContain` "# Title"
+      T.unpack result `shouldContain` "## Sub"
+
+    it "converts lists" $ do
+      let result = htmlToMarkdown "<ul><li>One</li><li>Two</li></ul>"
+      T.unpack result `shouldContain` "- One"
+      T.unpack result `shouldContain` "- Two"
+
+    it "converts emphasis" $ do
+      let result = htmlToMarkdown "<strong>bold</strong> and <em>italic</em>"
+      T.unpack result `shouldContain` "**bold**"
+      T.unpack result `shouldContain` "*italic*"
+
+    it "decodes HTML entities" $ do
+      let result = htmlToMarkdown "5 &gt; 3 &amp; 2 &lt; 4"
+      T.unpack result `shouldContain` "5 > 3 & 2 < 4"
+
+    it "handles non-HTML input" $ do
+      truncateBody 100 "short" `shouldBe` "short"
+      T.unpack (truncateBody 5 "hello world") `shouldContain` "truncated"
+
+-- | Create a mock network handle that returns a fixed response.
+mockNetwork :: Int -> String -> NetworkHandle
+mockNetwork status body = mkNoOpNetworkHandle
+  { _nh_httpGet = \_ -> pure HttpResponse
+      { _hr_statusCode = status
+      , _hr_body = BS8.pack body
+      }
+  }


### PR DESCRIPTION
  ## Summary

  Closes the tool gap identified in `docs/tool-comparison-hermes.md`. Adds 8 new tools, improves 4 existing tools, and fixes bugs in `file_write` and shell timeout handling.

  ### New tools

  - **`search_files`** — Ripgrep-backed content/file search with glob filters, output modes (content/files_only/count), context lines, case-insensitive
  - **`clarify`** — Structured user questions — open-ended or multiple choice (up to 4 + "Other"). Returns JSON
  - **`web_extract`** — Fetch URLs, convert HTML→markdown (headings, lists, emphasis, code, entities). Script/style stripping, configurable truncation
  - **`patch`** — Multi-file unified diffs in one tool call. Context-aware hunk matching with whitespace-tolerant line comparison
  - **`delegate_task`** — Isolated sub-agents with restricted toolsets, bounded turns (max 30), own context. Recursive delegation prevented
  - **`todo`** — In-memory task list with statuses (pending/in_progress/completed/cancelled). Read/write/merge modes, grouped output
  - **`execute_code`** — Run Python/Node/Ruby/Bash via subprocess. Respects security policy, timeout (default 30s, max 300s), output capped
  - **`session_search`** — Substring search across past session transcripts with context snippets, grouped by session

  ### Improved tools

  - **`edit`** — `replace_all` mode + 5 fuzzy matching strategies: whitespace-normalized, trimmed-lines, line-ending-normalized, indentation-normalized, case-insensitive
  - **`shell`** — `timeout_ms` and `working_dir` parameters. `ExecOptions` on `ShellHandle` designed for future backends (Docker/SSH)
  - **`process`** — `wait` and `close_stdin` actions. `timeout_ms`, `offset`, `max_bytes` parameters

  ### Bug fixes

  - **`file_write`** — Fixed two bugs in new-file creation: (1) path canonicalization mismatch on macOS where `/tmp` → `/private/tmp` caused post-write validation to always fail, and (2) missing parent directory creation
  - **Shell timeout race on Linux** — Replaced `System.Timeout.timeout` wrapping `readProcess` with `Async.cancel` to avoid `waitForProcess: No child processes`

  ### Infrastructure

  - `ExecOptions` record on `ShellHandle._sh_execute` for future backend extensibility
  - `filterRegistry` added to `Tools.Registry` for toolset restriction
  - `ripgrep` added to `flake.nix` dev shell
  - `ProcessHandle` gains `_ph_wait` and `_ph_closeStdin` fields
  - `delegate_task` registered via lazy circular binding with `AgentEnv`

  ## Test plan

  - [x] 82 new tests added (1289 total), 0 failures
  - [x] hlint clean, `-Wall -Werror` clean
  - [x] All existing tests pass
  - [x] x86_64-linux CI green
  - [x] aarch64-darwin CI: flaky `SignalFlowSpec` is pre-existing, unrelated to this PR