### PR TITLE
fix: bump session lastActive on gateway completions

### DIFF
--- a/src/PureClaw/Frontend/API.hs
+++ b/src/PureClaw/Frontend/API.hs
@@ -87,6 +87,7 @@ import PureClaw.Session.Handle
   , resolveBranchSeed
   , setArchived
   , setDescription
+  , touchSessionLastActive
   )
 import PureClaw.Session.Types
 import PureClaw.Handles.Transcript
@@ -1121,6 +1122,13 @@ doCompletion env sid provider reqModel fallbackModel userText transcriptPath = d
               (runCompletionLoop env provider' model tools reg cap ctx)
   _th_flush th
   _th_close th
+  -- Bump the session's on-disk _sm_lastActive so the sidebar "age" pill
+  -- reflects this completion. The gateway records through a raw
+  -- broadcasting transcript handle, which bypasses the touchLastActive
+  -- wrapper that live SessionHandles get, so we update the metadata
+  -- explicitly here and re-broadcast the lists snapshot to subscribers.
+  touchSessionLastActive (_fe_sessionsDir env) sid
+  broadcastLists env
   pure result
 
 -- | Section-character limit used when rendering a per-session agent's

--- a/src/PureClaw/Session/Handle.hs
+++ b/src/PureClaw/Session/Handle.hs
@@ -29,6 +29,8 @@ module PureClaw.Session.Handle
     -- * Description (disk-only)
   , setDescription
   , SetDescriptionError (..)
+    -- * Last-active (disk-only)
+  , touchSessionLastActive
     -- * Resume context reload
   , loadRecentMessages
     -- * Frozen system prompt (read from transcript)
@@ -646,6 +648,26 @@ setDescription baseDir sid mDesc =
   let normalized = mDesc >>= \t -> let s = T.strip t in if T.null s then Nothing else Just s
   in  updateSessionMeta baseDir sid (\m -> m { _sm_description = normalized })
         SetDescriptionSessionMissing SetDescriptionParseFailed
+
+-- | Best-effort bump of @_sm_lastActive@ to the current time, operating
+-- directly on the on-disk @session.json@ under @\<baseDir\>/\<sid\>/@ — no
+-- live 'SessionHandle' required.
+--
+-- The frontend gateway records transcript entries through a raw
+-- broadcasting handle (see @doCompletion@), not the
+-- 'touchLastActive'-wrapped 'SessionHandle' transcript, so the automatic
+-- bump never fires on that path. Without this call a provider session's
+-- @_sm_lastActive@ stays pinned at @_sm_createdAt@ and the sidebar's "age"
+-- pill shows the session's start time instead of its most recent activity.
+--
+-- Silent on a missing or corrupt @session.json@: keeping the sidebar pill
+-- fresh must never fail a completion the user already received.
+touchSessionLastActive :: FilePath -> SessionId -> IO ()
+touchSessionLastActive baseDir sid = do
+  now <- getCurrentTime
+  _ <- updateSessionMeta baseDir sid (\m -> m { _sm_lastActive = now })
+         () (const ())
+  pure ()
 
 -- | Shared read-modify-write helper for the disk-only meta mutators.
 -- Reads @session.json@, applies @f@, and writes back via tmp-file +

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -877,6 +877,23 @@ spec = do
         recorded <- peekRecorded fakeProv
         length recorded `shouldBe` 2
 
+    -- The sidebar's "age" pill reads _sm_lastActive. The gateway records
+    -- transcript entries through a raw broadcasting handle (not a
+    -- SessionHandle), so the touchLastActive bump never fires here — a
+    -- completed /send must still advance _sm_lastActive past _sm_createdAt
+    -- on disk, otherwise every session's pill is frozen at its start time.
+    it "bumps _sm_lastActive on disk after a completion" $ do
+      withSystemTempDirectory "pureclaw-send-lastactive" $ \tmpDir -> do
+        let agentsDir = tmpDir </> "agents"
+        writeSessionBootstrap tmpDir "sess-la" Nothing True
+        metaBefore <- readSessionMeta tmpDir "sess-la"
+        env <- mkSendEnv tmpDir agentsDir Nothing
+        _ <- sendOnce env "sess-la" "hello"
+        metaAfter <- readSessionMeta tmpDir "sess-la"
+        -- createdAt is untouched; lastActive advances past it.
+        _sm_createdAt metaAfter `shouldBe` _sm_createdAt metaBefore
+        (_sm_lastActive metaAfter > _sm_createdAt metaAfter) `shouldBe` True
+
   -- -----------------------------------------------------------------------
   -- WU4: frozen system prompt + per-session agent rendering (§9.1)
   -- -----------------------------------------------------------------------

--- a/test/Session/HandleSpec.hs
+++ b/test/Session/HandleSpec.hs
@@ -58,6 +58,7 @@ import PureClaw.Session.Handle
   , resolveSessionRef
   , resumeSession
   , setArchived
+  , touchSessionLastActive
   , setDescription
   , validateRuntime
   )
@@ -441,6 +442,25 @@ spec = do
     it "returns SetDescriptionSessionMissing for an unknown session" $ withTmp $ \base -> do
       result <- setDescription base (parseSessionId "nope-2") (Just "x")
       result `shouldBe` Left SetDescriptionSessionMissing
+
+  describe "touchSessionLastActive" $ do
+    it "advances _sm_lastActive past _sm_createdAt, leaving other fields intact" $ withTmp $ \base -> do
+      let meta = mkMeta "touch-1" t0
+      sh <- mkSessionHandle Nothing mkNoOpLogHandle base meta
+      _th_close (_sh_transcript sh)
+      touchSessionLastActive base (parseSessionId "touch-1")
+      Right onDisk <- Aeson.eitherDecodeFileStrict' (base </> "touch-1" </> "session.json")
+        :: IO (Either String SessionMeta)
+      -- createdAt is untouched; lastActive moves forward.
+      _sm_createdAt onDisk `shouldBe` t0
+      (_sm_lastActive onDisk > _sm_createdAt onDisk) `shouldBe` True
+      _sm_id onDisk `shouldBe` _sm_id meta
+      _sm_archived onDisk `shouldBe` _sm_archived meta
+
+    it "is a silent no-op for an unknown session" $ withTmp $ \base -> do
+      -- Must not throw even though there is no session.json to update.
+      touchSessionLastActive base (parseSessionId "nope-touch")
+      doesFileExist (base </> "nope-touch" </> "session.json") `shouldReturn` False
 
   describe "loadRecentMessages" $ do
     it "returns all messages when fewer than maxCount exist" $ withTmp $ \base -> do


### PR DESCRIPTION
The sidebar's session "age" pill reads _sm_lastActive, but the frontend gateway never updated it. doCompletion records transcript entries through a raw broadcasting handle opened directly from the transcript path, which bypasses the touchLastActive wrapper that live SessionHandles get. As a result _sm_lastActive stayed pinned at _sm_createdAt and every web session's pill showed its start time instead of its most recent activity.

Add a disk-only Session.Handle.touchSessionLastActive helper (best-effort, silent on missing/corrupt session.json) and call it from doCompletion after recording, then re-broadcast the lists snapshot so subscribers see the refreshed pill/ordering live.

Tests (TDD): a /send APISpec test asserting lastActive advances past createdAt on disk, plus HandleSpec unit tests for the helper's success and unknown-session no-op paths.