### PR TITLE
feat: add /bg command — run a prompt in a fresh background session (#52)

### DIFF
--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -2,6 +2,8 @@ module PureClaw.Agent.Loop
   ( -- * Agent loop
     runAgentLoop
   , runAgentLoopWith
+    -- * Background tasks (/bg, issue #52)
+  , runBackgroundTurn
     -- * Re-exports from Handles.Harness (for backward compatibility)
   , sanitizeHarnessOutput
   ) where
@@ -28,6 +30,7 @@ import PureClaw.Handles.Log
 import PureClaw.MCP (mcpRegistry)
 import PureClaw.Providers.Class
 import PureClaw.Routing.LegacyDispatch (dispatchLegacyTabCmd)
+import PureClaw.Tools.Delegate (runSubAgent)
 import PureClaw.Tools.Registry
 import PureClaw.Transcript.Provider
 
@@ -110,6 +113,18 @@ runAgentLoopWith env initialMessages = do
                   -- the same way they would under the new dispatcher.
                   _lh_logInfo logger $ "Slash command (tab): " <> stripped
                   dispatchLegacyTabCmd env tabCmd
+                  go ctx
+                Just (CmdBg prompt) -> do
+                  -- /bg runs the prompt in a fresh background session
+                  -- (issue #52). The single-tab loop has no tabbed-chat
+                  -- dispatcher, so we fork a self-contained background
+                  -- turn that emits its result directly to the channel
+                  -- (the ChannelOut writer is not running in this path).
+                  -- The foreground loop continues uninterrupted.
+                  _lh_logInfo logger $ "Slash command (bg): " <> stripped
+                  _ch_send channel (OutgoingMessage
+                    "\x1F504 /bg: running in the background \x2014 the result will appear here when ready.")
+                  _ <- _env_fork env (runBackgroundTurn env prompt)
                   go ctx
                 Just cmd -> do
                   _lh_logInfo logger $ "Slash command: " <> stripped
@@ -246,6 +261,64 @@ runAgentLoopWith env initialMessages = do
 
     partsToText :: [ToolResultPart] -> Text
     partsToText parts = T.intercalate "\n" [t | TRPText t <- parts]
+
+-- | Maximum turns for a @\/bg@ background task (provider + tool-call cycles).
+backgroundMaxTurns :: Int
+backgroundMaxTurns = 20
+
+-- | Run a @\/bg@ prompt in a fresh background session and push the result
+-- directly to the channel (issue #52).
+--
+-- Self-contained by design: it builds a brand-new 'Context' (no
+-- foreground-history leakage), uses the process default provider/model
+-- and the effective tool registry (built-ins + connected MCP servers),
+-- runs the prompt to completion via 'runSubAgent' (non-streaming, so it
+-- does not interleave with the foreground), and emits a single
+-- @[bg done] …@ message via '_ch_send'. This intentionally does NOT go
+-- through '_env_channelOutQ' — the single-tab CLI loop does not run the
+-- 'PureClaw.Routing.ChannelOut' writer, so a queued event would never be
+-- delivered.
+--
+-- Provider/model-absent and provider-failure cases each emit a short,
+-- redacted @[bg] …@ message rather than throwing (the caller forks this
+-- with '_env_fork' and does not observe its result).
+runBackgroundTurn :: AgentEnv -> Text -> IO ()
+runBackgroundTurn env prompt = do
+  let channel = _env_channel env
+  mProvider <- readIORef (_env_provider env)
+  case mProvider of
+    Nothing ->
+      _ch_send channel (OutgoingMessage "[bg] Cannot run: no provider configured.")
+    Just provider -> do
+      mModel <- readIORef (_env_model env)
+      case mModel of
+        Nothing ->
+          _ch_send channel (OutgoingMessage "[bg] Cannot run: no model configured.")
+        Just model -> do
+          registry <- backgroundRegistry env
+          result <- try @SomeException $
+            runSubAgent provider model registry (_env_systemPrompt env)
+                        prompt backgroundMaxTurns
+          case result of
+            Left e -> do
+              _lh_logError (_env_logger env) $
+                "Background task error: " <> T.pack (show e)
+              _ch_send channel (OutgoingMessage
+                "[bg] Something went wrong running the background task.")
+            Right text ->
+              let body = if T.null (T.strip text) then "(no response)" else text
+              in _ch_send channel (OutgoingMessage ("[bg done] " <> body))
+
+-- | The effective tool registry for a background turn: built-in tools
+-- merged with any connected MCP server tools. Mirrors the @effectiveRegistry@
+-- helper inside 'runAgentLoopWith'.
+backgroundRegistry :: AgentEnv -> IO ToolRegistry
+backgroundRegistry env = do
+  servers <- readIORef (_env_mcpServers env)
+  let base = _env_registry env
+  pure $ if Map.null servers
+           then base
+           else mergeRegistries base (mcpRegistry (Map.elems servers))
 
 -- | Message shown when user sends a chat message but no provider is configured.
 noProviderMessage :: Text

--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -15,10 +15,14 @@ import Data.Foldable (for_)
 import Data.Maybe
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Time (getCurrentTime)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
 
 import Data.Map.Strict qualified as Map
 import Data.Text.Encoding qualified as TE
 
+import PureClaw.Agent.AgentDef qualified as AgentDef
 import PureClaw.Agent.Context
 import PureClaw.Core.Types
 import PureClaw.Agent.Env
@@ -27,9 +31,12 @@ import PureClaw.Core.Errors
 import PureClaw.Handles.Channel
 import PureClaw.Handles.Harness
 import PureClaw.Handles.Log
+import PureClaw.Handles.Transcript qualified as Transcript
 import PureClaw.MCP (mcpRegistry)
 import PureClaw.Providers.Class
 import PureClaw.Routing.LegacyDispatch (dispatchLegacyTabCmd)
+import PureClaw.Session.Handle qualified as Session
+import PureClaw.Session.Types qualified as SessionTypes
 import PureClaw.Tools.Delegate (runSubAgent)
 import PureClaw.Tools.Registry
 import PureClaw.Transcript.Provider
@@ -269,15 +276,24 @@ backgroundMaxTurns = 20
 -- | Run a @\/bg@ prompt in a fresh background session and push the result
 -- directly to the channel (issue #52).
 --
--- Self-contained by design: it builds a brand-new 'Context' (no
--- foreground-history leakage), uses the process default provider/model
--- and the effective tool registry (built-ins + connected MCP servers),
--- runs the prompt to completion via 'runSubAgent' (non-streaming, so it
--- does not interleave with the foreground), and emits a single
--- @[bg done] …@ message via '_ch_send'. This intentionally does NOT go
--- through '_env_channelOutQ' — the single-tab CLI loop does not run the
--- 'PureClaw.Routing.ChannelOut' writer, so a queued event would never be
--- delivered.
+-- The background turn runs in its OWN session — a brand-new
+-- 'PureClaw.Session.Handle.SessionHandle' created under the same sessions
+-- directory as the foreground session and wired to the same
+-- 'PureClaw.Frontend.StreamBroker.StreamBroker'. The provider is wrapped
+-- with 'mkTranscriptProvider' so every request/response is recorded to the
+-- session's @transcript.jsonl@ (and broadcast to the broker). This is what
+-- makes the background conversation appear in the frontend UI like any
+-- other conversation: the frontend enumerates session directories on disk
+-- and subscribes to broker events. The fresh session also means the
+-- background turn does NOT leak into the foreground conversation history.
+--
+-- It uses the process default provider/model and the effective tool
+-- registry (built-ins + connected MCP servers), runs to completion via
+-- 'runSubAgent' (non-streaming, so it does not interleave with the
+-- foreground), and emits a single @[bg done] …@ message via '_ch_send'.
+-- This intentionally does NOT go through '_env_channelOutQ' — the
+-- single-tab CLI loop does not run the 'PureClaw.Routing.ChannelOut'
+-- writer, so a queued event would never be delivered.
 --
 -- Provider/model-absent and provider-failure cases each emit a short,
 -- redacted @[bg] …@ message rather than throwing (the caller forks this
@@ -286,28 +302,93 @@ runBackgroundTurn :: AgentEnv -> Text -> IO ()
 runBackgroundTurn env prompt = do
   let channel = _env_channel env
   mProvider <- readIORef (_env_provider env)
-  case mProvider of
-    Nothing ->
+  mModel    <- readIORef (_env_model env)
+  case (mProvider, mModel) of
+    (Nothing, _) ->
       _ch_send channel (OutgoingMessage "[bg] Cannot run: no provider configured.")
-    Just provider -> do
-      mModel <- readIORef (_env_model env)
-      case mModel of
-        Nothing ->
-          _ch_send channel (OutgoingMessage "[bg] Cannot run: no model configured.")
-        Just model -> do
-          registry <- backgroundRegistry env
-          result <- try @SomeException $
-            runSubAgent provider model registry (_env_systemPrompt env)
-                        prompt backgroundMaxTurns
-          case result of
-            Left e -> do
-              _lh_logError (_env_logger env) $
-                "Background task error: " <> T.pack (show e)
-              _ch_send channel (OutgoingMessage
-                "[bg] Something went wrong running the background task.")
-            Right text ->
-              let body = if T.null (T.strip text) then "(no response)" else text
-              in _ch_send channel (OutgoingMessage ("[bg done] " <> body))
+    (_, Nothing) ->
+      _ch_send channel (OutgoingMessage "[bg] Cannot run: no model configured.")
+    (Just provider, Just model) -> do
+      outcome <- try @SomeException (runBackgroundSession env provider model prompt)
+      case outcome of
+        Left e -> do
+          _lh_logError (_env_logger env) $
+            "Background task error: " <> T.pack (show e)
+          _ch_send channel (OutgoingMessage
+            "[bg] Something went wrong running the background task.")
+        Right text ->
+          let body = if T.null (T.strip text) then "(no response)" else text
+          in _ch_send channel (OutgoingMessage ("[bg done] " <> body))
+
+-- | Create the fresh background session, run the prompt against a
+-- transcript-recording provider, persist + close the session, and return
+-- the final assistant text. Any exception propagates to 'runBackgroundTurn'
+-- (which reports a redacted failure); the session is saved + closed
+-- regardless via 'finally'.
+runBackgroundSession :: AgentEnv -> SomeProvider -> ModelId -> Text -> IO Text
+runBackgroundSession env provider model prompt = do
+  registry  <- backgroundRegistry env
+  bgSession <- mkBackgroundSession env model prompt
+  let transcript = Session._sh_transcript bgSession
+      -- Recording wrapper: each provider call writes a request/response
+      -- pair to the session transcript (and fans out to the broker).
+      provider'  = mkTranscriptProvider transcript (unModelId model) provider
+  runSubAgent provider' model registry (_env_systemPrompt env)
+              prompt backgroundMaxTurns
+    `finally` do
+      ignoreExc (Session._sh_save bgSession)
+      ignoreExc (Transcript._th_close transcript)
+
+-- | Build a fresh on-disk session for a @\/bg@ turn, rooted under the same
+-- sessions directory as the foreground session (so the frontend — which
+-- scans that directory — discovers it) and wired to '_env_broker' (so its
+-- transcript writes broadcast live).
+mkBackgroundSession :: AgentEnv -> ModelId -> Text -> IO Session.SessionHandle
+mkBackgroundSession env model prompt = do
+  now         <- getCurrentTime
+  sessionsDir <- backgroundSessionsDir env
+  createDirectoryIfMissing True sessionsDir
+  let modelTxt = unModelId model
+      mAgent   = AgentDef._ad_name <$> _env_agentDef env
+      meta = SessionTypes.SessionMeta
+        { SessionTypes._sm_id    = SessionTypes.newSessionId Nothing now
+        , SessionTypes._sm_agent = mAgent
+        , SessionTypes._sm_kind  = SessionTypes.SkProvider
+            (SessionTypes.ProviderSpec
+              (SessionTypes.inferProviderId modelTxt) model mAgent)
+        , SessionTypes._sm_model   = modelTxt
+        , SessionTypes._sm_channel = "bg"
+        , SessionTypes._sm_createdAt  = now
+        , SessionTypes._sm_lastActive = now
+        , SessionTypes._sm_bootstrapConsumed = False
+        , SessionTypes._sm_archived = False
+        , SessionTypes._sm_description = Just (backgroundDescription prompt)
+        , SessionTypes._sm_autoSummary = Nothing
+        }
+  Session.mkSessionHandle (_env_broker env) (_env_logger env) sessionsDir meta
+
+-- | The sessions directory a @\/bg@ session should be created under: the
+-- parent of the foreground session's directory (which is exactly the
+-- directory the frontend enumerates). Falls back to 'getSessionsDir' when
+-- the foreground session has no on-disk directory (e.g. a no-op handle).
+backgroundSessionsDir :: AgentEnv -> IO FilePath
+backgroundSessionsDir env = do
+  sh <- readIORef (_env_session env)
+  let dir = Session._sh_dir sh
+  if null dir then getSessionsDir else pure (takeDirectory dir)
+
+-- | A short sidebar label for a @\/bg@ session.
+backgroundDescription :: Text -> Text
+backgroundDescription prompt = "/bg: " <> T.take 80 (T.strip prompt)
+
+-- | Run an IO action and swallow its exception. Used to make the
+-- background session's save/close best-effort so a flush failure does not
+-- mask the turn's own result. Although this catches 'SomeException', it is
+-- only ever invoked inside 'finally's finalizer (which runs with async
+-- exceptions masked), so in practice it swallows synchronous IO failures
+-- from save/close — not an asynchronous 'AsyncCancelled'.
+ignoreExc :: IO () -> IO ()
+ignoreExc m = m `catch` \(_ :: SomeException) -> pure ()
 
 -- | The effective tool registry for a background turn: built-in tools
 -- merged with any connected MCP server tools. Mirrors the @effectiveRegistry@

--- a/src/PureClaw/Agent/SlashCommands.hs
+++ b/src/PureClaw/Agent/SlashCommands.hs
@@ -294,6 +294,7 @@ data SlashCommand
   | CmdMsg Text Text                  -- ^ Send a message to a specific target (name, message)
   | CmdMcp McpSubCommand              -- ^ MCP server management commands
   | CmdTab TabSlashCommand            -- ^ Tabbed Chat @\/tab*@ / @\/tabs@ family (WU2; handlers in WU9)
+  | CmdBg !Text                       -- ^ Run a prompt in a fresh background session (issue #52)
   deriving stock (Show, Eq)
 
 -- ---------------------------------------------------------------------------
@@ -306,7 +307,7 @@ data SlashCommand
 -- To add a command, add a 'CommandSpec' here — parsing and help update
 -- automatically.
 allCommandSpecs :: [CommandSpec]
-allCommandSpecs = sessionCommandSpecs ++ sessionFamilyCommandSpecs ++ providerCommandSpecs ++ channelCommandSpecs ++ vaultCommandSpecs ++ transcriptCommandSpecs ++ harnessCommandSpecs ++ agentCommandSpecs ++ mcpCommandSpecs ++ msgCommandSpecs ++ tabFamilyCommandSpecs
+allCommandSpecs = sessionCommandSpecs ++ sessionFamilyCommandSpecs ++ providerCommandSpecs ++ channelCommandSpecs ++ vaultCommandSpecs ++ transcriptCommandSpecs ++ harnessCommandSpecs ++ agentCommandSpecs ++ mcpCommandSpecs ++ msgCommandSpecs ++ bgCommandSpecs ++ tabFamilyCommandSpecs
 
 -- | The @\/tab@ command family + @\/tabs@ alias (Tabbed Chat #51).
 --
@@ -577,6 +578,25 @@ msgArgP t =
           in if T.null target || T.null (T.strip body)
              then Nothing
              else Just (CmdMsg target (T.strip body))
+     else Nothing
+
+bgCommandSpecs :: [CommandSpec]
+bgCommandSpecs =
+  [ CommandSpec "/bg <prompt>" "Run a prompt in a fresh background session" GroupSession bgArgP
+  ]
+
+-- | Parse "/bg <prompt>". The remainder after @\/bg @ is the prompt,
+-- stripped of surrounding whitespace; an empty prompt is rejected.
+-- Mirrors 'msgArgP' for the keyword/whitespace handling.
+bgArgP :: Text -> Maybe SlashCommand
+bgArgP t =
+  let pfx   = "/bg"
+      lower = T.toLower t
+  in if (pfx <> " ") `T.isPrefixOf` lower
+     then let rest = T.strip (T.drop (T.length pfx) t)
+          in if T.null rest
+             then Nothing
+             else Just (CmdBg rest)
      else Nothing
 
 -- ---------------------------------------------------------------------------
@@ -1203,6 +1223,20 @@ executeSlashCommand env (CmdTab _) ctx = do
   _ch_send (_env_channel env)
     (OutgoingMessage
        "Tab commands require the tabbed-chat dispatcher \
+       \(PureClaw.Routing.Dispatcher.runDispatcher).")
+  pure ctx
+
+-- | Legacy single-tab fallback for @\/bg@. The real background-session
+-- handling lives in the tabbed-chat dispatcher (issue #52, WU3); under
+-- the single-tab 'PureClaw.Agent.Loop.runAgentLoop' path there is no
+-- dispatcher to spawn a fresh session, so we emit an explanatory
+-- message and leave the context unchanged. This arm is
+-- correctness-mandatory: @-Wincomplete-patterns@ is off in this
+-- project, so omitting it compiles clean and then crashes at runtime.
+executeSlashCommand env (CmdBg _) ctx = do
+  _ch_send (_env_channel env)
+    (OutgoingMessage
+       "Background tasks (/bg) require the tabbed-chat dispatcher \
        \(PureClaw.Routing.Dispatcher.runDispatcher).")
   pure ctx
 

--- a/src/PureClaw/Handles/Tab.hs
+++ b/src/PureClaw/Handles/Tab.hs
@@ -467,6 +467,9 @@ toPublicTabError e = PublicTabError $ case e of
 data AiSpawnArgs = AiSpawnArgs
   { _ai_requestedName :: !Text
     -- ^ Caller-supplied friendly label before 'sanitizeTabName' (H11).
+  , _ai_background    :: !Bool
+    -- ^ True when spawned by @\/bg@; its completed turn is pushed to the
+    -- channel.
   }
   deriving stock (Eq, Show)
 

--- a/src/PureClaw/Routing/AutoSpawn.hs
+++ b/src/PureClaw/Routing/AutoSpawn.hs
@@ -65,6 +65,7 @@ module PureClaw.Routing.AutoSpawn
   , handleSwitch
   , handleDefault
   , handleNew
+  , handleBg
   , handleClose
   , handleFocus
   , handleRename
@@ -226,6 +227,47 @@ handleDefault env spawnIO emit argsRef text = do
       rememberArgs argsRef newIdx kind []
       writeIORef (_env_focus env) (Just newIdx)
       enqueuePayloadOn env emit newIdx text
+
+
+-- ---------------------------------------------------------------------------
+-- handleBg — /bg <prompt> (issue #52)
+-- ---------------------------------------------------------------------------
+
+-- | Handle @\/bg \<prompt\>@: spawn a fresh AI tab that runs the prompt
+-- in the background and pushes its final response to the channel on
+-- completion (the completion push itself lives in 'PureClaw.Tab.Ai',
+-- gated on the tab's '_ats_background' flag — see issue #52 WU2).
+--
+-- Unlike 'handleDefault' \/ 'handleNew', @\/bg@:
+--
+--   * uses a FIXED AI 'TabKind' ('TkSession' ('SkProvider'
+--     'placeholderProviderSpec')) rather than '_rc_defaultKind' — @\/bg@
+--     is AI-prompt semantics by design, and the recorded kind makes the
+--     X1 crash-retry path (which respins via the normal factory) replay
+--     a valid AI tab; and
+--   * deliberately does NOT write '_env_focus' — a background spawn must
+--     never steal the user's focus.
+--
+-- The background flag itself is injected by the dispatcher's bg-aware
+-- 'SpawnIO' (see 'PureClaw.Routing.Dispatcher.ratelimitedSpawnBg'); this
+-- handler stays decoupled from 'PureClaw.Tab.Ai'.
+handleBg
+  :: AgentEnv
+  -> SpawnIO
+  -> BannerEmit
+  -> IORef (Map Int SpawnArgs)
+  -> Text
+  -> IO ()
+handleBg env spawnIO emit argsRef prompt = do
+  let kind = TkSession (SkProvider placeholderProviderSpec)
+  r <- spawnIO kind []
+  case r of
+    Left e ->
+      emit ("/bg: " <> unPublicTabError (toPublicTabError e))
+    Right newIdx -> do
+      rememberArgs argsRef newIdx kind []
+      enqueuePayloadOn env emit newIdx prompt
+      emit ("/bg: running in tab /" <> tShowIdx newIdx)
 
 
 -- ---------------------------------------------------------------------------

--- a/src/PureClaw/Routing/Dispatcher.hs
+++ b/src/PureClaw/Routing/Dispatcher.hs
@@ -190,7 +190,8 @@ defaultTabFactory env kind idx args =
 -- (WU1-stubbed) factory bottoms.
 parseArgsForKind :: TabKind -> [Text] -> Either AiSpawnArgs (Either HarnessSpawnArgs BackendSpawnArgs)
 parseArgsForKind kind xs = case kind of
-  TkSession (SkProvider _) -> Left  AiSpawnArgs      { _ai_requestedName      = T.unwords xs }
+  TkSession (SkProvider _) -> Left  AiSpawnArgs      { _ai_requestedName      = T.unwords xs
+                                                     , _ai_background         = False }
   TkSession (SkHarness _)  -> Right (Left HarnessSpawnArgs { _harness_requestedName = T.unwords xs })
   TkRawShell _             -> Right (Right BackendSpawnArgs
                                 { _backend_requestedName = T.unwords xs

--- a/src/PureClaw/Routing/Dispatcher.hs
+++ b/src/PureClaw/Routing/Dispatcher.hs
@@ -683,6 +683,48 @@ ratelimitedSpawn env ds uid kind args = do
     else spawnTabWith env (_ds_factory ds) kind args
 
 
+-- | The @\/bg@ spawn callback (issue #52). Like 'ratelimitedSpawn' it
+-- consumes one S7 token first, but it INTENTIONALLY bypasses
+-- '_ds_factory' (the synthetic test factory): @\/bg@ must inject
+-- @'_ai_background' = True@ into the spawned AI tab so the tab loop's
+-- completion-push fires (see 'PureClaw.Tab.Ai'). It therefore wires a
+-- bg-aware factory that calls the real 'PureClaw.Tab.Ai.mkTabAi'
+-- directly — which is why WU3's tests exercise the real factory (the
+-- integration test) rather than a synthetic one.
+--
+-- The @kind@ \/ @args@ handed in by 'AutoSpawn.handleBg' are ignored:
+-- the spawned tab kind is the fixed AI kind below and the prompt is
+-- enqueued separately by 'AutoSpawn.handleBg' after the spawn.
+ratelimitedSpawnBg
+  :: AgentEnv
+  -> DispatcherState
+  -> UserId
+  -> TabKind
+  -> [Text]
+  -> IO (Either TabError TabIndex)
+ratelimitedSpawnBg env ds uid _kind _args = do
+  now <- getCurrentTime
+  ok  <- tryConsumeSpawnToken (_ds_rateLimiter ds) uid now
+  if not ok
+    then pure (Left (TabConcurrencyLimit 0))
+    else spawnTabWith env bgFactory aiKind []
+  where
+    aiKind = TkSession (SkProvider ProviderSpec
+      { _ps_provider = ProviderId "anthropic"
+      , _ps_model    = ModelId "placeholder"
+      , _ps_agent    = Nothing
+      })
+    -- NB: the requested name must be NON-empty — 'mkTabAi' runs it
+    -- through 'sanitizeTabName', which rejects an empty/blank name with
+    -- 'NameRedactedToEmpty' (the spawn would otherwise fail with no tab
+    -- created). "bg" is the user-facing label for background tabs.
+    bgFactory _k idx _a =
+      TabAi.mkTabAi env idx AiSpawnArgs
+        { _ai_requestedName = "bg"
+        , _ai_background    = True
+        }
+
+
 -- | Dispatch a slash command. The @\/tab*@ family is routed to the
 -- AutoSpawn handlers; every other slash command is delivered to the
 -- focused AI tab via '_tabHandle_enqueueSlash' (WU10 — I5 wiring).
@@ -712,6 +754,13 @@ dispatchSlash env ds uid cmd = case cmd of
   -- be wrong-channel-of-output for a UX greeting). Delegated to
   -- 'Onboarding.handleStart' which emits via @_ch_send@ directly.
   CmdStart      -> Onboarding.handleStart env
+  -- /bg (issue #52): spawn a fresh background AI tab and enqueue the
+  -- prompt without stealing focus. EXPLICIT arm — the catch-all below
+  -- would otherwise silently route /bg to the focused tab, and the
+  -- build will NOT warn (-Wincomplete-patterns is off project-wide).
+  CmdBg prompt  ->
+    AutoSpawn.handleBg env (ratelimitedSpawnBg env ds uid)
+      (emitDispatcherBanner env) (_ds_spawnArgs ds) prompt
   _             -> routeToFocused env ds uid cmd
 
 -- | Route a non-@\/tab*@ slash command to the focused tab via

--- a/src/PureClaw/Tab/Ai.hs
+++ b/src/PureClaw/Tab/Ai.hs
@@ -529,6 +529,17 @@ runOneTurn env idx state provider model ctx = do
       let assistantText = responseText response
       unless (T.null (T.strip assistantText)) $
         appendTranscript env assistantText
+      -- Background-tab completion push (WU2 — /bg). A tab spawned by
+      -- @/bg@ runs without stealing focus; when its turn finishes while
+      -- the tab is NOT focused we surface the final response to the
+      -- channel as a @[bg /N done]@ banner. A focused bg tab streams
+      -- live above, so we skip the push to avoid duplicate output. Only
+      -- @/bg@ tabs push — ordinary non-focused tabs do not.
+      when (_ats_background state && not focusedNow) $ do
+        let body = if T.null (T.strip assistantText)
+                     then "(no response)"
+                     else assistantText
+        emitBgCompletion env idx body
       -- Tool-call continuation: full tool-call cycling is part of
       -- the WU10 refactor that ports Agent.Loop's logic wholesale.
       -- For WU6 we log the presence of tool calls so the gap is
@@ -619,6 +630,15 @@ emitBanner :: AgentEnv -> Text -> IO ()
 emitBanner env txt =
   atomically $ writeTBQueue (_env_channelOutQ env)
                  (SrcDispatcher, BannerLine txt)
+
+-- | Push a background-tab completion banner to the channel (WU2 — @\/bg@).
+-- Emitted via 'SrcDispatcher' so it bypasses focus gating and always
+-- reaches the current channel. The leading @[bg \/N done] @ text is the
+-- confirmed user-facing wording.
+emitBgCompletion :: AgentEnv -> TabIndex -> Text -> IO ()
+emitBgCompletion env idx body =
+  emitBanner env
+    ("[bg /" <> T.pack (show (unTabIndex idx)) <> " done] " <> body)
 
 -- | The error banner shown when a provider call fails.
 errorBanner :: TabIndex -> Text

--- a/src/PureClaw/Tab/Ai.hs
+++ b/src/PureClaw/Tab/Ai.hs
@@ -182,6 +182,11 @@ data AiTabState = AiTabState
     -- ^ Per-tab monotonically-increasing counter for 'StreamId'
     -- allocation. Wrap-around is not a practical concern (2^64 ≈
     -- 18 quintillion streams).
+  , _ats_background :: !Bool
+    -- ^ True when this tab was spawned by @\/bg@. When set, a completed
+    -- turn run while the tab is NOT focused pushes its final response to
+    -- the channel as a @[bg \/N done]@ banner. Sourced from
+    -- 'PureClaw.Handles.Tab._ai_background' at spawn; never mutated.
   }
 
 
@@ -203,7 +208,7 @@ mkTabAi env idx args =
     Left nameErr -> pure (Left (TabInvalidName nameErr))
     Right nameTxt -> do
       let rc = _env_routingConfig env
-      state <- allocState env rc
+      state <- allocState env rc (_ai_background args)
       now <- getCurrentTime
       writeIORef (_ats_statusRef state) (Idle now)
       -- Fork the loop. The fork seam returns a 'TabRunner' that the
@@ -217,8 +222,8 @@ mkTabAi env idx args =
 -- 'AgentEnv' so the per-tab provider\/model\/target track the
 -- process-level defaults at spawn time and can drift independently
 -- afterwards.
-allocState :: AgentEnv -> RoutingConfig -> IO AiTabState
-allocState env rc = do
+allocState :: AgentEnv -> RoutingConfig -> Bool -> IO AiTabState
+allocState env rc background = do
   inputQ       <- newTBQueueIO (fromIntegral (_rc_inputQueueBound rc))
   curProv      <- readIORef (_env_provider env)
   provRef      <- newIORef curProv
@@ -243,6 +248,7 @@ allocState env rc = do
     , _ats_closed    = closedRef
     , _ats_statusRef = statRef
     , _ats_streamCtr = streamCtrRef
+    , _ats_background = background
     }
 
 -- | Build the public 'TabHandle' record from the per-tab state.

--- a/src/PureClaw/Tools/Delegate.hs
+++ b/src/PureClaw/Tools/Delegate.hs
@@ -1,6 +1,8 @@
 module PureClaw.Tools.Delegate
   ( -- * Tool registration
     delegateTaskTool
+    -- * Reusable sub-agent engine
+  , runSubAgent
   ) where
 
 import Control.Exception

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -14,7 +14,6 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
-import PureClaw.Session.Handle (mkSessionHandle)
 import PureClaw.Session.Types qualified as SessionTypes
 
 import PureClaw.Agent.Env
@@ -30,7 +29,7 @@ import PureClaw.Routing.Types (RoutingConfig (..))
 import PureClaw.Security.Policy
 import PureClaw.Security.Vault.Age
 import PureClaw.Security.Vault.Plugin
-import PureClaw.Session.Handle (mkNoOpSessionHandle, noOpOnFirstStreamDoneRef)
+import PureClaw.Session.Handle (mkSessionHandle, mkNoOpSessionHandle, noOpOnFirstStreamDoneRef)
 import PureClaw.Tools.Registry
 
 import Data.Map.Strict qualified as Map

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -2,12 +2,20 @@ module Agent.LoopSpec (spec) where
 
 import Control.Concurrent.STM (newTBQueueIO, newTVarIO)
 import Control.Exception
+import Control.Monad (forM)
 import Data.Aeson (object, (.=))
 import Data.IntMap.Strict qualified as IntMap
 import Data.IORef
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Time (getCurrentTime)
+import System.Directory (doesFileExist, listDirectory)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
+
+import PureClaw.Session.Handle (mkSessionHandle)
+import PureClaw.Session.Types qualified as SessionTypes
 
 import PureClaw.Agent.Env
 import PureClaw.Agent.Loop
@@ -142,6 +150,33 @@ mkTestEnv p ch = do
     , _env_broker          = Nothing
     }
 
+-- | Like 'mkTestEnv' but with a REAL foreground session rooted under the
+-- given sessions directory, so a @\/bg@ background turn (which derives the
+-- sessions dir from the foreground session) writes its transcript under
+-- @tmp@ rather than the real @~/.pureclaw/sessions@.
+mkBgTestEnv :: Provider p => FilePath -> p -> ChannelHandle -> IO AgentEnv
+mkBgTestEnv sessionsDir p ch = do
+  base <- mkTestEnv p ch
+  now  <- getCurrentTime
+  let meta = SessionTypes.SessionMeta
+        { SessionTypes._sm_id    = SessionTypes.newSessionId Nothing now
+        , SessionTypes._sm_agent = Nothing
+        , SessionTypes._sm_kind  = SessionTypes.SkProvider
+            (SessionTypes.ProviderSpec
+              (SessionTypes.inferProviderId "mock") (ModelId "mock") Nothing)
+        , SessionTypes._sm_model  = "mock"
+        , SessionTypes._sm_channel = "cli"
+        , SessionTypes._sm_createdAt = now
+        , SessionTypes._sm_lastActive = now
+        , SessionTypes._sm_bootstrapConsumed = False
+        , SessionTypes._sm_archived = False
+        , SessionTypes._sm_description = Nothing
+        , SessionTypes._sm_autoSummary = Nothing
+        }
+  sh    <- mkSessionHandle Nothing mkNoOpLogHandle sessionsDir meta
+  shRef <- newIORef sh
+  pure base { _env_session = shRef }
+
 spec :: Spec
 spec = do
   describe "runAgentLoop" $ do
@@ -220,42 +255,63 @@ spec = do
         _ -> expectationFailure "expected two messages"
 
     -- /bg — run a prompt in a fresh background session (issue #52)
-    it "/bg runs a background turn and pushes the result to the channel" $ do
-      (channel, sentRef) <- mkMockChannel []
-      env <- mkTestEnv (MockProvider "bg result") channel
-      runBackgroundTurn env "summarize the repo"
-      sent <- readIORef sentRef
-      sent `shouldBe` ["[bg done] bg result"]
+    it "/bg runs a background turn and pushes the result to the channel" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, sentRef) <- mkMockChannel []
+        env <- mkBgTestEnv tmp (MockProvider "bg result") channel
+        runBackgroundTurn env "summarize the repo"
+        sent <- readIORef sentRef
+        sent `shouldBe` ["[bg done] bg result"]
 
-    it "/bg background turn maps a blank response to (no response)" $ do
-      (channel, sentRef) <- mkMockChannel []
-      env <- mkTestEnv (MockProvider "") channel
-      runBackgroundTurn env "do nothing"
-      sent <- readIORef sentRef
-      sent `shouldBe` ["[bg done] (no response)"]
+    it "/bg records the conversation to its own session transcript (frontend-visible)" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, _sentRef) <- mkMockChannel []
+        env <- mkBgTestEnv tmp (MockProvider "bg result") channel
+        runBackgroundTurn env "summarize the repo"
+        -- A fresh session directory with a NON-EMPTY transcript.jsonl must
+        -- exist under the sessions dir (this is what the frontend scans).
+        -- The foreground test session has no turns, so its transcript is
+        -- empty; exactly one non-empty transcript (the /bg session) is added.
+        dirs <- listDirectory tmp
+        contents <- forM dirs $ \d -> do
+          let f = tmp </> d </> "transcript.jsonl"
+          ex <- doesFileExist f
+          if ex then readFile f else pure ""
+        length (filter (not . null) contents) `shouldBe` 1
 
-    it "/bg background turn with no provider reports it cannot run" $ do
-      (channel, sentRef) <- mkMockChannel []
-      env <- mkTestEnv (MockProvider "ignored") channel
-      writeIORef (_env_provider env) Nothing
-      runBackgroundTurn env "do thing"
-      sent <- readIORef sentRef
-      sent `shouldBe` ["[bg] Cannot run: no provider configured."]
+    it "/bg background turn maps a blank response to (no response)" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, sentRef) <- mkMockChannel []
+        env <- mkBgTestEnv tmp (MockProvider "") channel
+        runBackgroundTurn env "do nothing"
+        sent <- readIORef sentRef
+        sent `shouldBe` ["[bg done] (no response)"]
 
-    it "/bg background turn surfaces provider failure without leaking details" $ do
-      (channel, sentRef) <- mkMockChannel []
-      env <- mkTestEnv FailingProvider channel
-      runBackgroundTurn env "do thing"
-      sent <- readIORef sentRef
-      sent `shouldBe` ["[bg] Something went wrong running the background task."]
+    it "/bg background turn with no provider reports it cannot run" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, sentRef) <- mkMockChannel []
+        env <- mkBgTestEnv tmp (MockProvider "ignored") channel
+        writeIORef (_env_provider env) Nothing
+        runBackgroundTurn env "do thing"
+        sent <- readIORef sentRef
+        sent `shouldBe` ["[bg] Cannot run: no provider configured."]
 
-    it "/bg in the loop acknowledges in the foreground (not the dispatcher fallback)" $ do
-      (channel, sentRef) <- mkMockChannel ["/bg do a thing"]
-      env <- mkTestEnv (MockProvider "bg result") channel
-      runAgentLoop env
-      sent <- readIORef sentRef
-      any (T.isInfixOf "/bg: running") sent `shouldBe` True
-      any (T.isInfixOf "tabbed-chat dispatcher") sent `shouldBe` False
+    it "/bg background turn surfaces provider failure without leaking details" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, sentRef) <- mkMockChannel []
+        env <- mkBgTestEnv tmp FailingProvider channel
+        runBackgroundTurn env "do thing"
+        sent <- readIORef sentRef
+        sent `shouldBe` ["[bg] Something went wrong running the background task."]
+
+    it "/bg in the loop acknowledges in the foreground (not the dispatcher fallback)" $
+      withSystemTempDirectory "pc-bg" $ \tmp -> do
+        (channel, sentRef) <- mkMockChannel ["/bg do a thing"]
+        env <- mkBgTestEnv tmp (MockProvider "bg result") channel
+        runAgentLoop env
+        sent <- readIORef sentRef
+        any (T.isInfixOf "/bg: running") sent `shouldBe` True
+        any (T.isInfixOf "tabbed-chat dispatcher") sent `shouldBe` False
 
     -- Invariant: slash-prefixed messages NEVER reach the provider
     it "unknown slash command never calls provider" $ do

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -219,6 +219,44 @@ spec = do
           replyMsg `shouldBe` "mock> reply"
         _ -> expectationFailure "expected two messages"
 
+    -- /bg — run a prompt in a fresh background session (issue #52)
+    it "/bg runs a background turn and pushes the result to the channel" $ do
+      (channel, sentRef) <- mkMockChannel []
+      env <- mkTestEnv (MockProvider "bg result") channel
+      runBackgroundTurn env "summarize the repo"
+      sent <- readIORef sentRef
+      sent `shouldBe` ["[bg done] bg result"]
+
+    it "/bg background turn maps a blank response to (no response)" $ do
+      (channel, sentRef) <- mkMockChannel []
+      env <- mkTestEnv (MockProvider "") channel
+      runBackgroundTurn env "do nothing"
+      sent <- readIORef sentRef
+      sent `shouldBe` ["[bg done] (no response)"]
+
+    it "/bg background turn with no provider reports it cannot run" $ do
+      (channel, sentRef) <- mkMockChannel []
+      env <- mkTestEnv (MockProvider "ignored") channel
+      writeIORef (_env_provider env) Nothing
+      runBackgroundTurn env "do thing"
+      sent <- readIORef sentRef
+      sent `shouldBe` ["[bg] Cannot run: no provider configured."]
+
+    it "/bg background turn surfaces provider failure without leaking details" $ do
+      (channel, sentRef) <- mkMockChannel []
+      env <- mkTestEnv FailingProvider channel
+      runBackgroundTurn env "do thing"
+      sent <- readIORef sentRef
+      sent `shouldBe` ["[bg] Something went wrong running the background task."]
+
+    it "/bg in the loop acknowledges in the foreground (not the dispatcher fallback)" $ do
+      (channel, sentRef) <- mkMockChannel ["/bg do a thing"]
+      env <- mkTestEnv (MockProvider "bg result") channel
+      runAgentLoop env
+      sent <- readIORef sentRef
+      any (T.isInfixOf "/bg: running") sent `shouldBe` True
+      any (T.isInfixOf "tabbed-chat dispatcher") sent `shouldBe` False
+
     -- Invariant: slash-prefixed messages NEVER reach the provider
     it "unknown slash command never calls provider" $ do
       callRef <- newIORef (0 :: Int)

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -300,6 +300,28 @@ spec = do
       parseSlashCommand "/msg cc-0 List All TODO Items"
         `shouldBe` Just (CmdMsg "cc-0" "List All TODO Items")
 
+    -- ---------------------------------------------------------------
+    -- /bg <prompt> — run a prompt in a fresh background session
+    -- (issue #52). The legacy parser must recognise it so it reaches
+    -- the CmdBg arm of executeSlashCommand; the real handling lives in
+    -- the tabbed-chat dispatcher (WU3).
+    -- ---------------------------------------------------------------
+
+    it "parses /bg with a prompt" $ do
+      parseSlashCommand "/bg x" `shouldBe` Just (CmdBg "x")
+
+    it "parses /bg case-insensitively for the command keyword" $ do
+      parseSlashCommand "/BG x" `shouldBe` Just (CmdBg "x")
+
+    it "returns Nothing for bare /bg (prompt required)" $ do
+      parseSlashCommand "/bg" `shouldBe` Nothing
+
+    it "returns Nothing for /bg with only whitespace" $ do
+      parseSlashCommand "/bg   " `shouldBe` Nothing
+
+    it "strips surrounding whitespace from the /bg prompt" $ do
+      parseSlashCommand "/bg   do thing  " `shouldBe` Just (CmdBg "do thing")
+
   describe "executeSlashCommand" $ do
     let mkEnv sentRef = do
           vaultRef    <- newIORef Nothing
@@ -1692,6 +1714,9 @@ spec = do
           -- (see CmdHelp in executeSlashCommand for why).
           let nonTab = filter ((/= GroupTab) . _cs_group) allCommandSpecs
           mapM_ (\s -> T.unpack t `shouldContain` T.unpack (_cs_syntax s)) nonTab
+          -- Pin /bg explicitly (issue #52) so a future regrouping of the
+          -- help auto-render can't silently drop it.
+          T.unpack t `shouldContain` "/bg"
 
     it "/help output contains group headings" $ do
       sentRef <- newIORef (Nothing :: Maybe Text)
@@ -1779,6 +1804,52 @@ spec = do
             }
           ctx = addMessage (textMessage User "hello") (emptyContext Nothing)
       ctx' <- executeSlashCommand env CmdHelp ctx
+      ctx' `shouldBe` ctx
+
+  describe "executeSlashCommand — /bg fallback" $ do
+    it "emits the dispatcher-requirement message and leaves context unchanged" $ do
+      sentRef     <- newIORef (Nothing :: Maybe Text)
+      vaultRef    <- newIORef Nothing
+      providerRef <- newIORef (Just (MkProvider (MockProvider "summary")))
+      modelRef    <- newIORef (Just (ModelId "test"))
+      harnessRef    <- newIORef Map.empty
+      targetRef     <- newIORef TargetProvider
+      windowIdxRef  <- newIORef 0
+      sessionRef <- newIORef =<< mkNoOpSessionHandle
+      mcpRef     <- newIORef Map.empty
+      let env = AgentEnv
+            { _env_provider     = providerRef
+            , _env_model        = modelRef
+            , _env_channel      = mkNoOpChannelHandle
+                { _ch_send = writeIORef sentRef . Just . _om_content }
+            , _env_logger       = mkNoOpLogHandle
+            , _env_systemPrompt = Nothing
+            , _env_registry     = emptyRegistry
+            , _env_vault        = vaultRef
+            , _env_pluginHandle = mkMockPluginHandle [] (\_ -> Left (AgeError "mock"))
+            , _env_policy       = defaultPolicy
+            , _env_harnesses    = harnessRef
+            , _env_target       = targetRef
+            , _env_nextWindowIdx = windowIdxRef
+            , _env_agentDef      = Nothing
+            , _env_session       = sessionRef
+            , _env_onFirstStreamDone = noOpOnFirstStreamDoneRef
+            , _env_mcpServers   = mcpRef
+            , _env_tabs          = error "WU3 stub: _env_tabs not exercised in this test"
+            , _env_focus         = error "WU3 stub: _env_focus not exercised in this test"
+            , _env_activeCount   = error "WU3 stub: _env_activeCount not exercised in this test"
+            , _env_runners       = error "WU3 stub: _env_runners not exercised in this test"
+            , _env_channelOutQ   = error "WU3 stub: _env_channelOutQ not exercised in this test"
+            , _env_routingConfig = defaultRoutingConfig
+            , _env_fork          = defaultEnvFork
+            , _env_broker          = Nothing
+            }
+          ctx = addMessage (textMessage User "hello") (emptyContext Nothing)
+      ctx' <- executeSlashCommand env (CmdBg "x") ctx
+      sent <- readIORef sentRef
+      case sent of
+        Nothing -> expectationFailure "Expected /bg fallback output"
+        Just t  -> T.unpack t `shouldContain` "dispatcher"
       ctx' `shouldBe` ctx
 
   describe "SlashCommand" $ do

--- a/test/Handles/TabSpec.hs
+++ b/test/Handles/TabSpec.hs
@@ -223,7 +223,8 @@ spec = do
       r <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                 Just i -> i
                                 Nothing -> error "0 is valid")
-             Tab.AiSpawnArgs { Tab._ai_requestedName = "h4" }
+             Tab.AiSpawnArgs { Tab._ai_requestedName = "h4"
+                             , Tab._ai_background = False }
       case r of
         Right h -> do
           -- The bound is _rc_inputQueueBound (default 64); burst
@@ -263,7 +264,8 @@ spec = do
       Right h <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                       Just i -> i
                                       Nothing -> error "0 is valid")
-                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h6" }
+                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h6"
+                                   , Tab._ai_background = False }
       Tab._tabHandle_close h Tab.CloseGraceful
       Tab._tabHandle_close h Tab.CloseGraceful  -- repeat — no throw
       Tab._tabHandle_close h Tab.CloseForce     -- still no throw
@@ -275,7 +277,8 @@ spec = do
       Right h <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                       Just i -> i
                                       Nothing -> error "0 is valid")
-                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h7" }
+                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h7"
+                                   , Tab._ai_background = False }
       -- shouldReturn confirms close completed without raising.
       Tab._tabHandle_close h Tab.CloseGraceful `shouldReturn` ()
       Tab._tabHandle_close h Tab.CloseForce    `shouldReturn` ()
@@ -290,7 +293,8 @@ spec = do
       Right h <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                       Just i -> i
                                       Nothing -> error "0 is valid")
-                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h8" }
+                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h8"
+                                   , Tab._ai_background = False }
       Tab._tabHandle_close h Tab.CloseGraceful
       pure ()
 
@@ -301,7 +305,8 @@ spec = do
       Right h <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                       Just i -> i
                                       Nothing -> error "0 is valid")
-                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h9" }
+                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h9"
+                                   , Tab._ai_background = False }
       -- Force close: same as Graceful but the no-op session would
       -- have its _sh_save skipped. With the no-op session we cannot
       -- observe the skip from outside; the assertion is no-throw +
@@ -321,7 +326,8 @@ spec = do
       Right h <- TabAi.mkTabAi env (case Tab.mkTabIndex 0 of
                                       Just i -> i
                                       Nothing -> error "0 is valid")
-                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h10" }
+                   Tab.AiSpawnArgs { Tab._ai_requestedName = "h10"
+                                   , Tab._ai_background = False }
       Tab._tabHandle_close h Tab.CloseGraceful
       pure ()
     -- H11: every code path that constructs a TabHandle's @_tabHandle_name@
@@ -409,7 +415,8 @@ spec = do
         notImpl (ErrorCall msg) = "not implemented" `List.isInfixOf` msg
 
     it "mkTabAi stub: throws ErrorCall containing 'not implemented'" $ do
-      let args = Tab.AiSpawnArgs { Tab._ai_requestedName = "ai" }
+      let args = Tab.AiSpawnArgs { Tab._ai_requestedName = "ai"
+                                 , Tab._ai_background = False }
       Tab.mkTabAi idx args `shouldThrow` notImpl
 
     it "mkTabHarness stub: throws ErrorCall containing 'not implemented'" $ do

--- a/test/Routing/AutoSpawnSpec.hs
+++ b/test/Routing/AutoSpawnSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 -- |
 -- Module      : Routing.AutoSpawnSpec
@@ -770,9 +771,9 @@ spec = do
       saAfter <- readIORef argsRf
       case Map.lookup 2 saAfter of
         Just sa -> PureClaw.Routing.AutoSpawn._sa_kind sa `shouldSatisfy`
-                     (\k -> case k of
-                              KindAi -> True
-                              _      -> False)
+                     (\case
+                        KindAi -> True
+                        _      -> False)
         Nothing -> expectationFailure "expected spawn args recorded at /2"
 
     it ("handleBg (Left): emits a redacted '/bg: ...' banner, enqueues "

--- a/test/Routing/AutoSpawnSpec.hs
+++ b/test/Routing/AutoSpawnSpec.hs
@@ -739,3 +739,56 @@ spec = do
       drained <- drainQueue (_env_channelOutQ env)
       banners drained `shouldSatisfy`
         any ("/0:" `T.isInfixOf`)
+
+  describe "handleBg — /bg background spawn (WU3)" $ do
+
+    it ("handleBg (Right idx): records the AI spawn kind, enqueues the "
+        <> "prompt on the new tab, emits '/bg: running in tab /N', and "
+        <> "leaves _env_focus UNCHANGED") $ do
+      env <- mkAutoSpawnEnv
+      -- Pre-set focus to a known value; it must survive untouched.
+      writeIORef (_env_focus env) (Just (ti 3))
+      -- A synthetic bg tab the SpawnIO will register at index 2.
+      st <- mkSyntheticTab (ti 2) KindAi "bg-2" (Idle t0)
+      bannersRf <- newIORef ([] :: [Text])
+      argsRf    <- newIORef (Map.empty :: Map Int PureClaw.Routing.AutoSpawn.SpawnArgs)
+      let emit t = atomicModifyIORef' bannersRf (\xs -> (xs <> [t], ()))
+          spawnIO _kind _args = do
+            _ <- insertTab (_env_tabs env) (ti 2) (_st_handle st)
+            pure (Right (ti 2))
+      PureClaw.Routing.AutoSpawn.handleBg env spawnIO emit argsRf "summarize the repo"
+      -- Focus unchanged.
+      f <- readIORef (_env_focus env)
+      f `shouldBe` Just (ti 3)
+      -- Prompt enqueued on the new tab.
+      sent <- readIORef (_st_sentRf st)
+      sent `shouldBe` ["summarize the repo"]
+      -- Banner emitted.
+      bs <- readIORef bannersRf
+      bs `shouldSatisfy` any ("/bg: running in tab /2" `T.isInfixOf`)
+      -- Spawn args recorded with the AI kind (so X1 retry respins an AI tab).
+      saAfter <- readIORef argsRf
+      case Map.lookup 2 saAfter of
+        Just sa -> PureClaw.Routing.AutoSpawn._sa_kind sa `shouldSatisfy`
+                     (\k -> case k of
+                              KindAi -> True
+                              _      -> False)
+        Nothing -> expectationFailure "expected spawn args recorded at /2"
+
+    it ("handleBg (Left): emits a redacted '/bg: ...' banner, enqueues "
+        <> "nothing, and leaves _env_focus UNCHANGED") $ do
+      env <- mkAutoSpawnEnv
+      writeIORef (_env_focus env) (Nothing :: Maybe TabIndex)
+      bannersRf <- newIORef ([] :: [Text])
+      argsRf    <- newIORef (Map.empty :: Map Int PureClaw.Routing.AutoSpawn.SpawnArgs)
+      let emit t = atomicModifyIORef' bannersRf (\xs -> (xs <> [t], ()))
+          spawnIO _kind _args = pure (Left (TabLimitExceeded 9))
+      PureClaw.Routing.AutoSpawn.handleBg env spawnIO emit argsRf "do a thing"
+      f <- readIORef (_env_focus env)
+      f `shouldBe` Nothing
+      tabs <- readIORef (_env_tabs env)
+      IntMap.size tabs `shouldBe` 0
+      saAfter <- readIORef argsRf
+      Map.keys saAfter `shouldBe` []
+      bs <- readIORef bannersRf
+      bs `shouldSatisfy` any ("/bg: " `T.isInfixOf`)

--- a/test/Routing/DispatcherSpec.hs
+++ b/test/Routing/DispatcherSpec.hs
@@ -237,7 +237,8 @@ aiFactoryAdapter :: AgentEnv -> TabFactory
 aiFactoryAdapter env kind idx args =
   case kind of
     KindAi -> TabAi.mkTabAi env idx
-                AiSpawnArgs { _ai_requestedName = T.unwords args }
+                AiSpawnArgs { _ai_requestedName = T.unwords args
+                            , _ai_background = False }
     _      -> error
         ("aiFactoryAdapter: this test adapter only supports KindAi; \
          \got " <> show kind)

--- a/test/Routing/DispatcherSpec.hs
+++ b/test/Routing/DispatcherSpec.hs
@@ -24,6 +24,7 @@
 -- throw-from-factory test-local factory.
 module Routing.DispatcherSpec (spec) where
 
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
   ( TBQueue
   , atomically
@@ -75,7 +76,12 @@ import PureClaw.Handles.Tab
   , pattern KindTmux
   )
 import PureClaw.MCP (McpServer)
-import PureClaw.Providers.Class (SomeProvider)
+import PureClaw.Providers.Class
+  ( CompletionResponse (..)
+  , ContentBlock (..)
+  , SomeProvider (MkProvider)
+  )
+import PureClaw.Routing.ChannelOut (startChannelOut)
 import PureClaw.Routing.Config (defaultRoutingConfig)
 import PureClaw.Routing.Dispatcher
   ( TabFactory
@@ -115,6 +121,10 @@ import Test.Fake.ChannelHandle
   , fakeChannelHandle
   , feedIncoming
   , newFakeChannel
+  )
+import Test.Fake.Provider
+  ( newFakeProvider
+  , queueResponse
   )
 
 
@@ -1123,6 +1133,114 @@ spec = do
       let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
       banners `shouldSatisfy`
         any (\t -> "nonexistent-session" `T.isInfixOf` t)
+
+  describe "/bg — dispatcher + AutoSpawn wiring (WU3)" $ do
+
+    it ("dispatchOne '/bg do a thing' spawns exactly one tab, leaves "
+        <> "_env_focus UNCHANGED, and emits '/bg: running in tab /N'") $ do
+      fch <- newFakeChannel
+      env <- mkDispatcherEnv (fakeChannelHandle fch)
+      -- Pre-set a known focus; /bg must not steal it.
+      writeIORef (_env_focus env) (Just (ti 3))
+      -- The bg path bypasses _ds_factory and uses the real TabAi.mkTabAi,
+      -- so the synthetic factory here is never consulted for /bg.
+      ds <- newDispatcherState env defaultTabFactoryNoop
+      dispatchOne env ds (UserId "u") "/bg do a thing"
+      tabs <- readIORef (_env_tabs env)
+      IntMap.size tabs `shouldBe` 1
+      f <- readIORef (_env_focus env)
+      f `shouldBe` Just (ti 3)
+      drained <- drainQueue (_env_channelOutQ env)
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+      banners `shouldSatisfy` any ("/bg: running in tab /0" `T.isInfixOf`)
+      closeAllTabs env
+
+    it ("S7: /bg with the spawn-rate bucket exhausted emits a redacted "
+        <> "'/bg: ...' banner and spawns NO tab") $ do
+      fch <- newFakeChannel
+      env <- mkDispatcherEnv (fakeChannelHandle fch)
+      ds <- newDispatcherState env defaultTabFactoryNoop
+      -- Burn the whole bucket (_rc_spawnRateLimit = 10) with /help
+      -- dispatches (each consumes one S7 token via routeToFocused).
+      mapM_ (\_ -> dispatchOne env ds (UserId "u") "/help")
+            [(1 :: Int) .. 10]
+      _ <- drainQueue (_env_channelOutQ env)
+      dispatchOne env ds (UserId "u") "/bg over the limit"
+      tabs <- readIORef (_env_tabs env)
+      IntMap.size tabs `shouldBe` 0
+      drained <- drainQueue (_env_channelOutQ env)
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+      banners `shouldSatisfy` any ("/bg: " `T.isInfixOf`)
+      closeAllTabs env
+
+    it ("S6: /bg with the registry at _rc_maxTabs emits a redacted "
+        <> "'/bg: ...' banner (TabLimitExceeded) and spawns NO new tab") $ do
+      fch <- newFakeChannel
+      env0 <- mkDispatcherEnv (fakeChannelHandle fch)
+      let env = env0
+            { _env_routingConfig = (_env_routingConfig env0)
+                { _rc_maxTabs = 1 }
+            }
+      st0 <- mkSyntheticTab (ti 0) KindAi (Idle t0)
+      _   <- insertTab (_env_tabs env) (ti 0) (_st_handle st0)
+      ds <- newDispatcherState env defaultTabFactoryNoop
+      dispatchOne env ds (UserId "u") "/bg cannot fit"
+      tabs <- readIORef (_env_tabs env)
+      IntMap.size tabs `shouldBe` 1  -- only the pre-existing tab
+      drained <- drainQueue (_env_channelOutQ env)
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+      banners `shouldSatisfy` any ("/bg: " `T.isInfixOf`)
+      closeAllTabs env
+
+    it ("INTEGRATION: a /bg through the REAL TabAi.mkTabAi factory + a "
+        <> "MockProvider ultimately delivers the '[bg /N done] <text>' "
+        <> "banner across _env_channelOutQ -> ChannelOut -> _ch_send") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content = [TextBlock "integration bg text"]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      fch <- newFakeChannel
+      env <- mkDispatcherEnv (fakeChannelHandle fch)
+      writeIORef (_env_provider env) (Just (MkProvider fp))
+      writeIORef (_env_model env) (Just (ModelId "test-model"))
+      -- Boot the channel-out writer so SrcDispatcher banners cross to
+      -- the underlying ChannelHandle (_ch_send).
+      coRunner <- startChannelOut env
+      ds <- newDispatcherState env defaultTabFactoryNoop
+      dispatchOne env ds (UserId "u") "/bg summarize"
+      -- The bg tab runs the provider turn asynchronously; poll the fake
+      -- channel's send sink until the [bg ...] banner arrives.
+      let pollFor :: Int -> IO [Text]
+          pollFor 0 = pure []
+          pollFor n = do
+            evs <- drainEvents fch
+            let sends = [t | (_, FceSend (OutgoingMessage t)) <- evs]
+                bgs   = filter ("[bg " `T.isPrefixOf`) sends
+            if null bgs
+              then threadDelay 20000 >> pollFor (n - 1)
+              else pure bgs
+      bgBanners <- pollFor 25  -- up to ~500ms
+      bgBanners `shouldBe` ["[bg /0 done] integration bg text"]
+      _trun_cancel coRunner
+      closeAllTabs env
+
+    it ("/bg with a slash-command prompt ('/bg /new') spawns + enqueues "
+        <> "without crashing and still emits '/bg: running in tab /N'") $ do
+      fch <- newFakeChannel
+      env <- mkDispatcherEnv (fakeChannelHandle fch)
+      ds <- newDispatcherState env defaultTabFactoryNoop
+      dispatchOne env ds (UserId "u") "/bg /new"
+      tabs <- readIORef (_env_tabs env)
+      IntMap.size tabs `shouldBe` 1
+      drained <- drainQueue (_env_channelOutQ env)
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+      banners `shouldSatisfy` any ("/bg: running in tab /0" `T.isInfixOf`)
+      -- No [bg /N done] push: the prompt runs as a slash command in the
+      -- bg tab, so no provider turn fires.
+      banners `shouldSatisfy` not . any ("[bg " `T.isPrefixOf`)
+      closeAllTabs env
 
 
 -- | A factory that intentionally errors when invoked — used as a

--- a/test/Routing/ParseSpec.hs
+++ b/test/Routing/ParseSpec.hs
@@ -268,6 +268,20 @@ spec = do
       parse "/agent list" `shouldBe`
         Right (RT.ParsedSlashCmd (Slash.CmdAgent Slash.AgentList))
 
+    it "BG1: parseInput \"/bg summarize the repo\" yields ParsedSlashCmd (CmdBg \"summarize the repo\")" $
+      parse "/bg summarize the repo" `shouldBe`
+        Right (RT.ParsedSlashCmd (Slash.CmdBg "summarize the repo"))
+
+    it "BG2: parseInput \"/bg\" (bare) is malformed (prompt required)" $
+      parse "/bg" `shouldBe` Left RT.ParseErrorMalformed
+
+    it "BG3: parseInput \"/bg   \" (whitespace-only prompt) is malformed" $
+      parse "/bg   " `shouldBe` Left RT.ParseErrorMalformed
+
+    it "BG4: parseInput \"/bg   do thing  \" strips surrounding whitespace from the prompt" $
+      parse "/bg   do thing  " `shouldBe`
+        Right (RT.ParsedSlashCmd (Slash.CmdBg "do thing"))
+
     it "P18: LLM-free invariant — property test: switch | inject | slash-cmd inputs never invoke Provider.complete (uses T1 fake provider)" $
       withMaxSuccess 200 prop_P18_llm_free
 

--- a/test/Routing/RegistrySpec.hs
+++ b/test/Routing/RegistrySpec.hs
@@ -303,7 +303,8 @@ spec = do
         <> "per-tab TBQueue; the loop is the sole context writer.") $ do
       env <- mkE3TestEnv
       r <- TabAi.mkTabAi env idx0
-             Tab.AiSpawnArgs { Tab._ai_requestedName = "e5" }
+             Tab.AiSpawnArgs { Tab._ai_requestedName = "e5"
+                             , Tab._ai_background = False }
       case r of
         Right h -> do
           -- The handle's enqueueSlash returns Right () — the dispatcher's

--- a/test/Tab/AiSpec.hs
+++ b/test/Tab/AiSpec.hs
@@ -34,6 +34,7 @@ import Data.IORef
   , readIORef
   , writeIORef
   )
+import Data.Aeson qualified as Aeson
 import Data.IntMap.Strict qualified as IntMap
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -160,7 +161,20 @@ yieldAwhile = threadDelay 30000  -- 30ms
 -- | Spawn an AI tab and return its handle (Right) or fail the test.
 spawnAiTab :: AgentEnv -> Int -> Text -> IO TabHandle
 spawnAiTab env n name = do
-  r <- mkTabAi env (ti n) AiSpawnArgs { _ai_requestedName = name }
+  r <- mkTabAi env (ti n)
+         AiSpawnArgs { _ai_requestedName = name, _ai_background = False }
+  case r of
+    Right h -> pure h
+    Left e  -> do
+      expectationFailure ("expected Right TabHandle; got Left " <> show e)
+      error "unreachable"
+
+-- | Spawn a /bg-style AI tab (the '_ai_background' flag set) and return
+-- its handle (Right) or fail the test.
+spawnBgAiTab :: AgentEnv -> Int -> Text -> IO TabHandle
+spawnBgAiTab env n name = do
+  r <- mkTabAi env (ti n)
+         AiSpawnArgs { _ai_requestedName = name, _ai_background = True }
   case r of
     Right h -> pure h
     Left e  -> do
@@ -598,7 +612,8 @@ spec = do
         <> " (e.g. ANSI escapes) is surfaced as Left TabInvalidName") $ do
       env <- mkAiTestEnv Nothing
       r <- mkTabAi env (ti 0)
-             AiSpawnArgs { _ai_requestedName = "\ESC[31mboom" }
+             AiSpawnArgs { _ai_requestedName = "\ESC[31mboom"
+                         , _ai_background = False }
       case r of
         Left _ -> pure ()  -- Left TabInvalidName branch reached
         Right h -> do
@@ -650,6 +665,141 @@ spec = do
       _ <- _tabHandle_send h "hi"
       yieldAwhile
       _ <- drainOut env
+      _tabHandle_close h CloseGraceful
+
+  describe "WU2 — /bg background-tab completion push" $ do
+
+    it ("BG1: a background tab whose turn completes while NOT focused"
+        <> " pushes exactly one SrcDispatcher BannerLine equal to"
+        <> " \"[bg /N done] \" <> responseText") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content = [TextBlock "bg result text"]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      env <- mkAiTestEnv (Just fp)
+      -- Focus is Nothing by default → the bg tab (index 2) is not focused.
+      h <- spawnBgAiTab env 2 "bg"
+      _ <- _tabHandle_send h "summarize"
+      yieldAwhile
+      drained <- drainOut env
+      let bgBanners = [t | (SrcDispatcher, BannerLine t) <- drained
+                         , "[bg " `T.isPrefixOf` t]
+      bgBanners `shouldBe` ["[bg /2 done] bg result text"]
+      _tabHandle_close h CloseGraceful
+
+    it ("BG2: a background tab that IS focused streams normally"
+        <> " (StreamStart/ChunkOf/StreamEnd present) and pushes NO bg"
+        <> " banner") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content = [TextBlock "focused stream"]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      env <- mkAiTestEnv (Just fp)
+      h <- spawnBgAiTab env 0 "bg-focused"
+      writeIORef (_env_focus env) (Just (ti 0))
+      _ <- _tabHandle_send h "go"
+      yieldAwhile
+      drained <- drainOut env
+      let streamStarts = [() | (SrcTab _, StreamStart{}) <- drained]
+          streamEnds   = [() | (SrcTab _, StreamEnd{})   <- drained]
+          bgBanners    = [t | (SrcDispatcher, BannerLine t) <- drained
+                            , "[bg " `T.isPrefixOf` t]
+      length streamStarts `shouldSatisfy` (>= 1)
+      length streamEnds   `shouldSatisfy` (>= 1)
+      bgBanners `shouldBe` []
+      _tabHandle_close h CloseGraceful
+
+    it ("BG3: a non-background tab (not focused) never pushes a bg"
+        <> " banner") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content = [TextBlock "ordinary"]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      env <- mkAiTestEnv (Just fp)
+      h <- spawnAiTab env 1 "ordinary"
+      -- Focus stays Nothing.
+      _ <- _tabHandle_send h "hi"
+      yieldAwhile
+      drained <- drainOut env
+      let bgBanners = [t | (SrcDispatcher, BannerLine t) <- drained
+                         , "[bg " `T.isPrefixOf` t]
+      bgBanners `shouldBe` []
+      _tabHandle_close h CloseGraceful
+
+    it ("BG4: a background, not-focused tab whose provider returns a"
+        <> " blank response pushes banner body \"(no response)\"") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content = [TextBlock "   "]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      env <- mkAiTestEnv (Just fp)
+      h <- spawnBgAiTab env 5 "bg-blank"
+      _ <- _tabHandle_send h "go"
+      yieldAwhile
+      drained <- drainOut env
+      let bgBanners = [t | (SrcDispatcher, BannerLine t) <- drained
+                         , "[bg " `T.isPrefixOf` t]
+      bgBanners `shouldBe` ["[bg /5 done] (no response)"]
+      _tabHandle_close h CloseGraceful
+
+    it ("BG5: a background, not-focused tab whose provider returns a"
+        <> " tool-call-only response pushes banner body \"(no"
+        <> " response)\" (responseText is empty for tool-only content)") $ do
+      fp <- newFakeProvider
+      queueResponse fp CompletionResponse
+        { _crsp_content =
+            [ ToolUseBlock
+                { _tub_id    = ToolCallId "call-1"
+                , _tub_name  = "do_thing"
+                , _tub_input = Aeson.Null
+                }
+            ]
+        , _crsp_model   = ModelId "test-model"
+        , _crsp_usage   = Nothing
+        }
+      env <- mkAiTestEnv (Just fp)
+      h <- spawnBgAiTab env 7 "bg-tool"
+      _ <- _tabHandle_send h "go"
+      yieldAwhile
+      drained <- drainOut env
+      let bgBanners = [t | (SrcDispatcher, BannerLine t) <- drained
+                         , "[bg " `T.isPrefixOf` t]
+      bgBanners `shouldBe` ["[bg /7 done] (no response)"]
+      _tabHandle_close h CloseGraceful
+
+    it ("BG6: a background, not-focused tab whose provider errors emits"
+        <> " the existing errorBanner and NO bg banner") $ do
+      env <- mkBrokenProviderEnv
+      h <- spawnBgAiTab env 4 "bg-broken"
+      _ <- _tabHandle_send h "go"
+      yieldAwhile
+      drained <- drainOut env
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+          bgBanners = filter ("[bg " `T.isPrefixOf`) banners
+      banners `shouldSatisfy`
+        any (\t -> "/4" `T.isInfixOf` t && "provider error" `T.isInfixOf` t)
+      bgBanners `shouldBe` []
+      _tabHandle_close h CloseGraceful
+
+    it ("BG7: a background, not-focused tab with no provider configured"
+        <> " emits the existing no-provider banner and NO bg banner") $ do
+      env <- mkAiTestEnv Nothing
+      h <- spawnBgAiTab env 6 "bg-noprov"
+      _ <- _tabHandle_send h "go"
+      yieldAwhile
+      drained <- drainOut env
+      let banners = [t | (SrcDispatcher, BannerLine t) <- drained]
+          bgBanners = filter ("[bg " `T.isPrefixOf`) banners
+      banners `shouldSatisfy` any ("no provider" `T.isInfixOf`)
+      bgBanners `shouldBe` []
       _tabHandle_close h CloseGraceful
 
 


### PR DESCRIPTION
## Summary

Adds a `/bg <prompt>` slash command (patterned after Hermes' `/background`). `/bg` spawns a **fresh AI session** using the default provider/model, runs the prompt **in the background without stealing focus**, and **pushes the completed result to the current channel** as `[bg /N done] …`.

Closes #52.

## Behavior

- `/bg summarize the repo` → spawns a new AI tab at the lowest free slot with the default provider/model (inherited from `AgentEnv` at spawn), enqueues the prompt, and emits `/bg: running in tab /N`.
- The current tab keeps focus; you continue working uninterrupted.
- When the background turn finishes **and you are not focused on that tab**, its full response is pushed to your current channel as `[bg /N done] …` (via `SrcDispatcher`, which bypasses focus gating). If you *are* focused on the tab, it streams live with no duplicate push.
- Only `/bg` (no `/background` / `/btw` aliases).

## Design notes

- **Background flag lives with the tab** (`AiTabState._ats_background`, sourced from `AiSpawnArgs._ai_background`) rather than in `AgentEnv` — it travels with the tab (immune to tmux-style index renumbering) and avoids touching 39 `AgentEnv` construction sites.
- **Completion push fires only when `background && not focused`** — so only `/bg` tabs push, focused tabs stream normally, and there is no double-output.
- **`handleBg` never writes `_env_focus`** (no focus steal). The bg-aware factory is injected by the dispatcher via the `SpawnIO` callback, keeping `AutoSpawn` decoupled from `Tab.Ai`.
- `/bg` spawns a **fixed AI kind** (not `_rc_defaultKind`) so the factory and kind agree even under a non-AI default config; the bg tab is named `bg` (empty names are rejected by `sanitizeTabName`).

## Edge cases handled

- Empty / whitespace-only prompt → rejected (`ParseErrorMalformed`).
- Blank or tool-call-only response → `[bg /N done] (no response)`.
- Provider error / no-provider → existing `SrcDispatcher` banners surface (reach non-focused users); no bg-framed duplicate.
- S6 (max-tabs) and S7 (spawn-rate) refusals → redacted `/bg: …` banner, no tab spawned.
- `/bg /new` (prompt that is itself a slash command) → runs as a slash command in the bg tab (no provider turn / no push); spawn + banner still happen.

## Known limitations (v1)

- Each `/bg` consumes a tab slot until manually `/tab close`d; repeated `/bg` can exhaust the 36-tab cap.
- S9 concurrent-active cap is dormant project-wide; `/bg` is throttled only by S6/S7.

## Testing

- TDD throughout (red committed separately from green per work unit).
- 3 work units, each adversarially reviewed; final cross-unit review PASS.
- Full suite: **2167 examples, 0 failures**. Coverage build green; `.coverage-thresholds.json` unchanged (no new waivers) — new arms in the pre-waived `Tab.Ai`/`Dispatcher`/`AutoSpawn` modules are covered by new tests through the real factory, including a dispatcher-boot integration test that proves the async push reaches the channel.
- `-Wall -Werror` clean; hlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
