### PR TITLE
feat: persist message source/origin to session.json + transcript.jsonl (pureclaw-dte)

### DIFF
--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -104,86 +104,99 @@ runAgentLoopWith env initialMessages = do
       receiveResult <- try @IOException (_ch_receive channel)
       case receiveResult of
         Left _ -> _lh_logInfo logger "Session ended"
-        Right msg
-          | T.null stripped -> go ctx
-          -- INVARIANT: any message beginning with '/' is handled locally and
-          -- NEVER forwarded to the provider. Unknown slash commands get an
-          -- error response rather than silently routing to the LLM.
-          | "/" `T.isPrefixOf` stripped ->
-              case parseSlashCommand stripped of
-                Just (CmdTab tabCmd) -> do
-                  -- Tab commands need callbacks (SpawnIO, PromptRenderer,
-                  -- BannerEmit, etc.) that 'executeSlashCommand' can't wire
-                  -- without a dependency cycle. Dispatch via the legacy
-                  -- bridge instead. The bridge invokes the canonical
-                  -- 'Routing.AutoSpawn' handlers so /tab* commands behave
-                  -- the same way they would under the new dispatcher.
-                  _lh_logInfo logger $ "Slash command (tab): " <> stripped
-                  dispatchLegacyTabCmd env tabCmd
-                  go ctx
-                Just (CmdBg prompt) -> do
-                  -- /bg runs the prompt in a fresh background session
-                  -- (issue #52). The single-tab loop has no tabbed-chat
-                  -- dispatcher, so we fork a self-contained background
-                  -- turn that emits its result directly to the channel
-                  -- (the ChannelOut writer is not running in this path).
-                  -- The foreground loop continues uninterrupted.
-                  _lh_logInfo logger $ "Slash command (bg): " <> stripped
-                  _ch_send channel (OutgoingMessage
-                    "\x1F504 /bg: running in the background \x2014 the result will appear here when ready.")
-                  _ <- _env_fork env (runBackgroundTurn env prompt)
-                  go ctx
-                Just cmd -> do
-                  _lh_logInfo logger $ "Slash command: " <> stripped
-                  ctx' <- executeSlashCommand env cmd ctx
-                  go ctx'
-                Nothing -> do
-                  _lh_logWarn logger $ "Unrecognized slash command: " <> stripped
-                  _ch_send channel
-                    (OutgoingMessage ("Unknown command: " <> stripped
-                      <> "\nType /status for session info, /help for available commands."))
-                  go ctx
-          | otherwise -> do
-              target <- readIORef (_env_target env)
-              case target of
-                TargetHarness name -> do
-                  harnesses <- readIORef (_env_harnesses env)
-                  case Map.lookup name harnesses of
-                    Nothing -> do
+        Right msg -> do
+          -- Capture the session origin (set-once) BEFORE any slash/harness/
+          -- /bg/provider branching, covering the empty-message branch too:
+          -- origin is about the SENDER, not the content. This is the
+          -- single-tab loop's sole inbound entry; the tabbed dispatcher
+          -- runtime is a separate path (out of scope, see design WU3).
+          --
+          -- SECURITY: _sm_source is attacker-asserted provenance and MUST
+          -- NOT feed any access-control decision.
+          sh <- readIORef (_env_session env)
+          Session.setSourceIfAbsent sh (_im_source msg)
+          dispatchMsg
+          where
+            stripped = T.strip (_im_content msg)
+            dispatchMsg
+              | T.null stripped = go ctx
+              -- INVARIANT: any message beginning with '/' is handled locally
+              -- and NEVER forwarded to the provider. Unknown slash commands
+              -- get an error response rather than silently routing to the LLM.
+              | "/" `T.isPrefixOf` stripped =
+                  case parseSlashCommand stripped of
+                    Just (CmdTab tabCmd) -> do
+                      -- Tab commands need callbacks (SpawnIO, PromptRenderer,
+                      -- BannerEmit, etc.) that 'executeSlashCommand' can't wire
+                      -- without a dependency cycle. Dispatch via the legacy
+                      -- bridge instead. The bridge invokes the canonical
+                      -- 'Routing.AutoSpawn' handlers so /tab* commands behave
+                      -- the same way they would under the new dispatcher.
+                      _lh_logInfo logger $ "Slash command (tab): " <> stripped
+                      dispatchLegacyTabCmd env tabCmd
+                      go ctx
+                    Just (CmdBg prompt) -> do
+                      -- /bg runs the prompt in a fresh background session
+                      -- (issue #52). The single-tab loop has no tabbed-chat
+                      -- dispatcher, so we fork a self-contained background
+                      -- turn that emits its result directly to the channel
+                      -- (the ChannelOut writer is not running in this path).
+                      -- The foreground loop continues uninterrupted.
+                      _lh_logInfo logger $ "Slash command (bg): " <> stripped
                       _ch_send channel (OutgoingMessage
-                        ("Harness \"" <> name <> "\" is not running. Use /harness start "
-                          <> name <> " or /target to switch targets."))
+                        "\x1F504 /bg: running in the background \x2014 the result will appear here when ready.")
+                      _ <- _env_fork env (runBackgroundTurn env prompt)
                       go ctx
-                    Just hh -> do
-                      _lh_logInfo logger $ "Routing to harness: " <> name
-                      _hh_send hh (TE.encodeUtf8 stripped)
-                      output <- _hh_receive hh
-                      let response = sanitizeHarnessOutput (TE.decodeUtf8 output)
-                      unless (T.null (T.strip response)) $
-                        _ch_send channel (OutgoingMessage (prefixHarnessOutput name response))
-                      go ctx
-                TargetProvider -> do
-                  mProvider <- readIORef (_env_provider env)
-                  case mProvider of
+                    Just cmd -> do
+                      _lh_logInfo logger $ "Slash command: " <> stripped
+                      ctx' <- executeSlashCommand env cmd ctx
+                      go ctx'
                     Nothing -> do
-                      _ch_send channel (OutgoingMessage noProviderMessage)
+                      _lh_logWarn logger $ "Unrecognized slash command: " <> stripped
+                      _ch_send channel
+                        (OutgoingMessage ("Unknown command: " <> stripped
+                          <> "\nType /status for session info, /help for available commands."))
                       go ctx
-                    Just provider -> do
-                      mModel <- readIORef (_env_model env)
-                      case mModel of
+              | otherwise = do
+                  target <- readIORef (_env_target env)
+                  case target of
+                    TargetHarness name -> do
+                      harnesses <- readIORef (_env_harnesses env)
+                      case Map.lookup name harnesses of
                         Nothing -> do
-                          _ch_send channel (OutgoingMessage noModelMessage)
+                          _ch_send channel (OutgoingMessage
+                            ("Harness \"" <> name <> "\" is not running. Use /harness start "
+                              <> name <> " or /target to switch targets."))
                           go ctx
-                        Just model -> do
-                          let userMsg = textMessage User stripped
-                              ctx' = addMessage userMsg ctx
-                          _lh_logDebug logger $
-                            "Sending " <> T.pack (show (length (contextMessages ctx'))) <> " messages"
-                          -- Wrap provider with transcript logging (session owns the transcript)
-                          th <- envTranscript env
-                          let provider' = mkTranscriptProvider th (unModelId model) provider
-                          handleCompletion provider' ctx'
-          where stripped = T.strip (_im_content msg)
+                        Just hh -> do
+                          _lh_logInfo logger $ "Routing to harness: " <> name
+                          _hh_send hh (TE.encodeUtf8 stripped)
+                          output <- _hh_receive hh
+                          let response = sanitizeHarnessOutput (TE.decodeUtf8 output)
+                          unless (T.null (T.strip response)) $
+                            _ch_send channel (OutgoingMessage (prefixHarnessOutput name response))
+                          go ctx
+                    TargetProvider -> do
+                      mProvider <- readIORef (_env_provider env)
+                      case mProvider of
+                        Nothing -> do
+                          _ch_send channel (OutgoingMessage noProviderMessage)
+                          go ctx
+                        Just provider -> do
+                          mModel <- readIORef (_env_model env)
+                          case mModel of
+                            Nothing -> do
+                              _ch_send channel (OutgoingMessage noModelMessage)
+                              go ctx
+                            Just model -> do
+                              let userMsg = textMessage User stripped
+                                  ctx' = addMessage userMsg ctx
+                              _lh_logDebug logger $
+                                "Sending " <> T.pack (show (length (contextMessages ctx'))) <> " messages"
+                              -- Wrap provider with transcript logging (session owns the transcript)
+                              th <- envTranscript env
+                              let provider' = mkTranscriptProvider th (unModelId model) provider
+                              handleCompletion provider' ctx'
 
     handleCompletion provider ctx = do
       mModel <- readIORef (_env_model env)
@@ -364,6 +377,7 @@ mkBackgroundSession env model prompt = do
         , SessionTypes._sm_archived = False
         , SessionTypes._sm_description = Just (backgroundDescription prompt)
         , SessionTypes._sm_autoSummary = Nothing
+        , SessionTypes._sm_source = Nothing
         }
   Session.mkSessionHandle (_env_broker env) (_env_logger env) sessionsDir meta
 

--- a/src/PureClaw/Agent/Loop.hs
+++ b/src/PureClaw/Agent/Loop.hs
@@ -195,7 +195,7 @@ runAgentLoopWith env initialMessages = do
                                 "Sending " <> T.pack (show (length (contextMessages ctx'))) <> " messages"
                               -- Wrap provider with transcript logging (session owns the transcript)
                               th <- envTranscript env
-                              let provider' = mkTranscriptProvider th (unModelId model) provider
+                              let provider' = mkTranscriptProvider th (unModelId model) (Just (_im_source msg)) provider
                               handleCompletion provider' ctx'
 
     handleCompletion provider ctx = do
@@ -345,7 +345,7 @@ runBackgroundSession env provider model prompt = do
   let transcript = Session._sh_transcript bgSession
       -- Recording wrapper: each provider call writes a request/response
       -- pair to the session transcript (and fans out to the broker).
-      provider'  = mkTranscriptProvider transcript (unModelId model) provider
+      provider'  = mkTranscriptProvider transcript (unModelId model) Nothing provider
   runSubAgent provider' model registry (_env_systemPrompt env)
               prompt backgroundMaxTurns
     `finally` do

--- a/src/PureClaw/Agent/SlashCommands.hs
+++ b/src/PureClaw/Agent/SlashCommands.hs
@@ -991,6 +991,14 @@ executeSlashCommand env CmdStatus ctx = do
   th <- envTranscript env
   transcriptPath <- _th_getPath th
   harnesses <- readIORef (_env_harnesses env)
+  -- Session origin (set-once provenance). 'Nothing' for legacy sessions or
+  -- sessions that have not yet received an inbound message — render those as
+  -- "unknown" so the absence reads as intentional.
+  --
+  -- SECURITY: _sm_source is attacker-asserted; it is DISPLAY ONLY and never
+  -- used for any access-control decision.
+  activeSession <- readIORef (_env_session env)
+  meta <- readIORef (Session._sh_meta activeSession)
   let modelText = maybe "(not set)" unModelId mModel
       targetLine = case target of
         TargetProvider    -> "  Target:    model: " <> modelText
@@ -1009,11 +1017,18 @@ executeSlashCommand env CmdStatus ctx = do
         else "  Harnesses: " <> T.intercalate ", "
                [n <> " (" <> _hh_name h <> ")" | (n, h) <- Map.toList harnesses]
       policyLine = "  Policy:    " <> T.pack (show (_sp_autonomy (_env_policy env)))
+      sourceLine = case SessionTypes._sm_source meta of
+        Nothing  -> "  Source:    unknown"
+        Just src -> "  Source:    " <> sourceLabel src
+      sourceLabel src = case _ms_userId src of
+        Just u  -> unUserId u <> " (" <> channelKindToText (_ms_channel src) <> ")"
+        Nothing -> "(" <> channelKindToText (_ms_channel src) <> ")"
       status = T.intercalate "\n"
         [ "Session status:"
         , targetLine
         , providerLine
         , policyLine
+        , sourceLine
         , vaultLine
         , transcriptLine
         , harnessLine
@@ -2332,6 +2347,7 @@ executeSessionCommand env sub ctx = do
                 , SessionTypes._sm_archived          = False
                 , SessionTypes._sm_description       = Nothing
                 , SessionTypes._sm_autoSummary       = Nothing
+                , SessionTypes._sm_source            = Nothing
                 }
           newHandle <- Session.mkSessionHandle
                          (_env_broker envS) (_env_logger envS) sessionsDir meta

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -599,6 +599,7 @@ runChat opts = do
                   , SessionTypes._sm_archived          = False
                   , SessionTypes._sm_description       = Nothing
                   , SessionTypes._sm_autoSummary       = Nothing
+                  , SessionTypes._sm_source            = Nothing
                   }
             -- WU3: see broker construction at the top of startWithChannel.
             mkSessionHandle (Just broker) logger sessionsDir initialMeta

--- a/src/PureClaw/Channels/CLI.hs
+++ b/src/PureClaw/Channels/CLI.hs
@@ -31,7 +31,7 @@ mkCLIChannelHandle mCompleter = do
         case mLine of
           Nothing   -> ioError (userError "EOF")  -- Ctrl-D: agent loop catches this
           Just line -> pure IncomingMessage
-            { _im_userId  = UserId "cli-user"
+            { _im_source  = mkMessageSource CkCli (Just (UserId "cli-user")) mempty
             , _im_content = T.pack line
             }
     , _ch_send = \msg -> do

--- a/src/PureClaw/Channels/Signal.hs
+++ b/src/PureClaw/Channels/Signal.hs
@@ -16,6 +16,7 @@ import Control.Concurrent.STM
 import Control.Exception
 import Data.Aeson
 import Data.Aeson.Types (parseEither)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.IORef
 import Data.Text (Text)
@@ -127,9 +128,12 @@ receiveEnvelope sc = do
   envelope <- atomically $ readTQueue (_sch_inbox sc)
   let sender = _se_source envelope
       content = maybe "" _sdm_message (_se_dataMessage envelope)
+      flds = case _se_sourceUuid envelope of
+        Just uuid -> Map.singleton "uuid" (String uuid)
+        Nothing   -> Map.empty
   writeIORef (_sch_lastSender sc) sender
   pure IncomingMessage
-    { _im_userId  = UserId sender
+    { _im_source  = mkMessageSource CkSignal (Just (UserId sender)) flds
     , _im_content = content
     }
 

--- a/src/PureClaw/Channels/Telegram.hs
+++ b/src/PureClaw/Channels/Telegram.hs
@@ -21,6 +21,7 @@ import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BL
 import Data.IORef
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -89,9 +90,10 @@ receiveUpdate tc = do
       userId = T.pack (show (_tu_id (_tm_from msg)))
       chatId = _tcht_id (_tm_chat msg)
       content = _tm_text msg
+      flds = Map.singleton "chat_id" (toJSON chatId)
   writeIORef (_tch_lastChat tc) (Just chatId)
   pure IncomingMessage
-    { _im_userId  = UserId userId
+    { _im_source  = mkMessageSource CkTelegram (Just (UserId userId)) flds
     , _im_content = content
     }
 

--- a/src/PureClaw/Core/Types.hs
+++ b/src/PureClaw/Core/Types.hs
@@ -15,6 +15,13 @@ module PureClaw.Core.Types
   , parseSessionId
     -- * Message target
   , MessageTarget (..)
+    -- * Message source / origin
+  , ChannelKind (..)
+  , MessageSource (..)
+  , mkMessageSource
+  , channelKindToText
+  , channelKindFromText
+  , maxSourceLen
     -- * Workspace
   , WorkspaceRoot (..)
     -- * Autonomy
@@ -24,10 +31,15 @@ module PureClaw.Core.Types
   , isAllowed
   ) where
 
+import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
+import Data.Char qualified as Char
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as T
 import GHC.Generics (Generic)
 
 -- | Provider identifier (e.g. "anthropic", "openai")
@@ -82,6 +94,115 @@ data MessageTarget
   = TargetProvider          -- ^ Send to the configured LLM provider + model
   | TargetHarness Text      -- ^ Send to a named running harness
   deriving stock (Show, Eq)
+
+-- | The kind of channel a message originated from. Known channels get a
+-- typed constructor; 'CkOther' is an open escape hatch for channels that
+-- do not (yet) have a dedicated tag.
+data ChannelKind
+  = CkCli
+  | CkWeb
+  | CkSignal
+  | CkTelegram
+  | CkBackground
+  | CkOther !Text
+  deriving stock (Show, Eq, Generic)
+
+-- | Render a 'ChannelKind' as a flat lowercase tag. 'CkOther' carries its
+-- own name verbatim. Mirrors the @flavourToText@ precedent.
+channelKindToText :: ChannelKind -> Text
+channelKindToText CkCli        = "cli"
+channelKindToText CkWeb        = "web"
+channelKindToText CkSignal     = "signal"
+channelKindToText CkTelegram   = "telegram"
+channelKindToText CkBackground = "background"
+channelKindToText (CkOther n)  = n
+
+-- | Parse a flat tag back into a 'ChannelKind'. Known names map to their
+-- typed constructor; everything else becomes 'CkOther'. Critically,
+-- @"signal"@ maps to 'CkSignal' (never @CkOther "signal"@), so a
+-- 'CkOther' naming a known channel cannot round-trip into existence.
+channelKindFromText :: Text -> ChannelKind
+channelKindFromText "cli"        = CkCli
+channelKindFromText "web"        = CkWeb
+channelKindFromText "signal"     = CkSignal
+channelKindFromText "telegram"   = CkTelegram
+channelKindFromText "background" = CkBackground
+channelKindFromText t            = CkOther t
+
+instance Aeson.ToJSON ChannelKind where
+  toJSON = Aeson.String . channelKindToText
+
+instance Aeson.FromJSON ChannelKind where
+  parseJSON = Aeson.withText "ChannelKind" (pure . channelKindFromText)
+
+-- | Maximum length (in characters) for any attacker-controlled string
+-- stored inside a 'MessageSource' after normalization.
+maxSourceLen :: Int
+maxSourceLen = 512
+
+-- | Where an inbound message came from. Structured and extensible: a typed
+-- 'ChannelKind', the channel's user id (when one exists), and an open
+-- field map for supplementary, channel-specific data (which may carry
+-- nested JSON).
+--
+-- Construct via 'mkMessageSource', never the raw record — the smart
+-- constructor normalizes attacker-controlled input.
+--
+-- Invariants (enforced by convention, not the type): '_ms_fields' must not
+-- duplicate '_ms_userId' and must never contain credentials/secrets.
+data MessageSource = MessageSource
+  { _ms_channel :: !ChannelKind
+  , _ms_userId  :: !(Maybe UserId)
+  , _ms_fields  :: !(Map Text Aeson.Value)
+  } deriving stock (Show, Eq, Generic)
+
+-- | Strip ASCII control characters (covers newlines, tabs, carriage
+-- returns and other control bytes) and bound the result to 'maxSourceLen'
+-- characters.
+normalizeText :: Text -> Text
+normalizeText = T.take maxSourceLen . T.filter (not . Char.isControl)
+
+-- | Recursively normalize every 'Aeson.String' leaf in a JSON value,
+-- leaving the structure otherwise intact.
+normalizeValue :: Aeson.Value -> Aeson.Value
+normalizeValue (Aeson.String t) = Aeson.String (normalizeText t)
+normalizeValue (Aeson.Array xs) = Aeson.Array (fmap normalizeValue xs)
+normalizeValue (Aeson.Object o) = Aeson.Object (fmap normalizeValue o)
+normalizeValue v                = v
+
+-- | Smart constructor for 'MessageSource'. Normalizes attacker-controlled
+-- input: strips control characters / newlines and bounds length on the
+-- user id and on every string leaf inside the field map, and folds a
+-- 'CkOther' naming a known channel (e.g. @CkOther "signal"@) down to its
+-- typed constructor.
+mkMessageSource :: ChannelKind -> Maybe UserId -> Map Text Aeson.Value -> MessageSource
+mkMessageSource ch uid fields = MessageSource
+  { _ms_channel = foldChannel ch
+  , _ms_userId  = fmap (UserId . normalizeText . unUserId) uid
+  , _ms_fields  = fmap normalizeValue fields
+  }
+  where
+    foldChannel (CkOther n) = channelKindFromText n
+    foldChannel c           = c
+
+instance Aeson.ToJSON MessageSource where
+  toJSON s = Aeson.object $
+    ["channel" .= _ms_channel s]
+      <> case _ms_userId s of
+        Just u  -> ["user_id" .= unUserId u]
+        Nothing -> []
+      <> ["fields" .= _ms_fields s | not (Map.null (_ms_fields s))]
+
+instance Aeson.FromJSON MessageSource where
+  parseJSON = Aeson.withObject "MessageSource" $ \o -> do
+    ch     <- o .:  "channel"
+    uid    <- o .:? "user_id"
+    fields <- o .:? "fields" .!= Map.empty
+    pure MessageSource
+      { _ms_channel = ch
+      , _ms_userId  = fmap UserId uid
+      , _ms_fields  = fields
+      }
 
 -- | Workspace root directory — anchors all SafePath resolution
 newtype WorkspaceRoot = WorkspaceRoot { unWorkspaceRoot :: FilePath }

--- a/src/PureClaw/Frontend/API.hs
+++ b/src/PureClaw/Frontend/API.hs
@@ -16,6 +16,7 @@ module PureClaw.Frontend.API
   , HarnessActivity (..)
   , SessionInfo (..)
   , TranscriptEntryInfo (..)
+  , toTranscriptEntryInfo
   , AgentInfo (..)
   , ProviderInfo (..)
   , TabSnapshot (..)
@@ -1102,7 +1103,7 @@ doCompletion env sid provider reqModel fallbackModel userText transcriptPath = d
       userMsg = textMessage User userText
       ctx = addMessage userMsg ctx0
       -- Wrap provider with transcript logging
-      provider' = mkTranscriptProvider th (unModelId model) provider
+      provider' = mkTranscriptProvider th (unModelId model) Nothing provider
       reg = _fe_registry env
       tools = registryDefinitions reg
       cap = _fe_maxToolIterations env

--- a/src/PureClaw/Frontend/API.hs
+++ b/src/PureClaw/Frontend/API.hs
@@ -873,6 +873,7 @@ createTab env tabKind mSeed respond = do
             , _sm_archived          = False
             , _sm_description       = Nothing
             , _sm_autoSummary       = Nothing
+            , _sm_source            = Nothing
             }
       sh <- mkSessionHandle (_fe_broker env) (_fe_logger env) (_fe_sessionsDir env) meta
       _sh_save sh

--- a/src/PureClaw/Frontend/Stream.hs
+++ b/src/PureClaw/Frontend/Stream.hs
@@ -38,6 +38,8 @@ module PureClaw.Frontend.Stream
   , errorCodeText
   , encodeServerEvent
   , decodeClientOp
+    -- * Transcript projection (exported for testing)
+  , toEntryInfo
   ) where
 
 import Control.Concurrent.Async (AsyncCancelled (..))

--- a/src/PureClaw/Handles/Channel.hs
+++ b/src/PureClaw/Handles/Channel.hs
@@ -1,6 +1,7 @@
 module PureClaw.Handles.Channel
   ( -- * Message types
     IncomingMessage (..)
+  , imUserId
   , OutgoingMessage (..)
     -- * Streaming
   , StreamChunk (..)
@@ -10,17 +11,29 @@ module PureClaw.Handles.Channel
   , mkNoOpChannelHandle
   ) where
 
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 
 import PureClaw.Core.Errors
 import PureClaw.Core.Types
 
--- | A message received from a channel user.
+-- | A message received from a channel user, tagged with the source that
+-- describes where it came from (channel + optional user id + extensible
+-- fields). The source is captured at the channel boundary via
+-- 'mkMessageSource'.
 data IncomingMessage = IncomingMessage
-  { _im_userId  :: UserId
+  { _im_source  :: MessageSource
   , _im_content :: Text
   }
   deriving stock (Show, Eq)
+
+-- | Derive the channel user id from a message's source, preserving the
+-- legacy '_im_userId' behavior. A source with no user id (@Nothing@)
+-- yields the @UserId ""@ sentinel — the same value the no-op channel
+-- produced before the 'MessageSource' migration — so dispatcher routing
+-- against the allow-list is unchanged.
+imUserId :: IncomingMessage -> UserId
+imUserId m = fromMaybe (UserId "") (_ms_userId (_im_source m))
 
 -- | A message to send to a channel user.
 newtype OutgoingMessage = OutgoingMessage
@@ -64,7 +77,7 @@ data ChannelHandle = ChannelHandle
 -- sendError are silent. readSecret returns empty text.
 mkNoOpChannelHandle :: ChannelHandle
 mkNoOpChannelHandle = ChannelHandle
-  { _ch_receive      = pure (IncomingMessage (UserId "") "")
+  { _ch_receive      = pure (IncomingMessage (mkMessageSource (CkOther "noop") Nothing mempty) "")
   , _ch_send         = \_ -> pure ()
   , _ch_sendError    = \_ -> pure ()
   , _ch_sendChunk    = \_ -> pure ()

--- a/src/PureClaw/Routing/Dispatcher.hs
+++ b/src/PureClaw/Routing/Dispatcher.hs
@@ -1074,7 +1074,7 @@ runDispatcherWith env factory =
   where
     loop e (ds, _outR) = do
       msg <- _ch_receive (_env_channel e)
-      dispatchOne e ds (_im_userId msg) (_im_content msg)
+      dispatchOne e ds (imUserId msg) (_im_content msg)
       loop e (ds, _outR)
 
 -- | The 'bracket' acquire: starts the channel-out writer, builds the

--- a/src/PureClaw/Session/Handle.hs
+++ b/src/PureClaw/Session/Handle.hs
@@ -23,6 +23,7 @@ module PureClaw.Session.Handle
   , resolveResumedTarget
     -- * Bootstrap consumption
   , markBootstrapConsumed
+  , setSourceIfAbsent
     -- * Archive flag (disk-only)
   , setArchived
   , SetArchivedError (..)
@@ -40,7 +41,7 @@ module PureClaw.Session.Handle
   ) where
 
 import Control.Exception (IOException, try)
-import Control.Monad (guard)
+import Control.Monad (guard, when)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
@@ -75,7 +76,8 @@ import System.Posix.Files (setFileMode)
 import PureClaw.Agent.AgentDef (AgentName)
 import PureClaw.Agent.Compaction (compactionMetadataKey)
 import PureClaw.Core.Types
-  ( MessageTarget (..)
+  ( MessageSource
+  , MessageTarget (..)
   , ModelId (..)
   , SessionId (..)
   , parseSessionId
@@ -275,6 +277,7 @@ noOpMeta = SessionMeta
   , _sm_archived          = False
   , _sm_description       = Nothing
   , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
   }
   where
     epoch = UTCTime (fromGregorian 1970 1 1) (secondsToDiffTime 0)
@@ -604,6 +607,25 @@ markBootstrapConsumed sh = do
   atomicModifyIORef' (_sh_meta sh) $ \m ->
     (m { _sm_bootstrapConsumed = True }, ())
   _sh_save sh
+
+-- | Record the session origin ('MessageSource') set-once: write '_sm_source'
+-- only if it is currently 'Nothing', and persist via '_sh_save' IFF the
+-- value actually changed. A second call with a different source is a no-op
+-- (the first sender wins and no redundant save occurs).
+--
+-- Same atomicity pattern as 'markBootstrapConsumed' / 'touchSessionLastActive'
+-- ('atomicModifyIORef'' on '_sh_meta'); the changed-flag avoids a wasteful
+-- re-save on the already-set path.
+--
+-- SECURITY: '_sm_source' is attacker-asserted provenance — it MUST NOT feed
+-- any access-control decision.
+setSourceIfAbsent :: SessionHandle -> MessageSource -> IO ()
+setSourceIfAbsent sh src = do
+  changed <- atomicModifyIORef' (_sh_meta sh) $ \m ->
+    case _sm_source m of
+      Just _  -> (m, False)
+      Nothing -> (m { _sm_source = Just src }, True)
+  when changed (_sh_save sh)
 
 -- ----------------------------------------------------------------------------
 -- Archive flag

--- a/src/PureClaw/Session/Types.hs
+++ b/src/PureClaw/Session/Types.hs
@@ -36,7 +36,7 @@ import Data.Time.Format (defaultTimeLocale, formatTime)
 import GHC.Generics (Generic)
 
 import PureClaw.Agent.AgentDef (AgentName, unAgentName)
-import PureClaw.Core.Types (MessageTarget (..), ModelId (..), SessionId (..))
+import PureClaw.Core.Types (MessageSource, MessageTarget (..), ModelId (..), SessionId (..))
 import PureClaw.Session.Kind
 
 -- | Validated session prefix. Used as the human-readable leading segment
@@ -163,6 +163,16 @@ data SessionMeta = SessionMeta
     -- summarization path (not yet wired up). Defaults to 'Nothing'
     -- on new sessions and after disk loads of older session.json
     -- files.
+  , _sm_source            :: Maybe MessageSource
+    -- ^ Session origin: the 'MessageSource' of the FIRST inbound
+    -- message of this session (set-once). 'Nothing' for legacy
+    -- sessions written before this field existed, and for sessions
+    -- that have not yet received an inbound message.
+    --
+    -- SECURITY: this is attacker-asserted provenance — the sender id
+    -- is unauthenticated. It MUST NOT feed any access-control or
+    -- trust decision. Routing/authz key on the dispatcher's
+    -- allow-list, never on this value.
   } deriving stock (Show, Eq, Generic)
 
 -- Hand-written JSON so we don't depend on a 'ToJSON' instance for
@@ -182,9 +192,12 @@ instance Aeson.ToJSON SessionMeta where
     , "archived"           .= _sm_archived s
     , "description"        .= _sm_description s
     , "auto_summary"       .= _sm_autoSummary s
-    ] <> case _sm_agent s of
+    ] <> (case _sm_agent s of
       Just n  -> ["agent" .= unAgentName n]
-      Nothing -> []
+      Nothing -> [])
+      <> (case _sm_source s of
+      Just src -> ["source" .= src]
+      Nothing  -> [])
 
 instance Aeson.FromJSON SessionMeta where
   parseJSON = Aeson.withObject "SessionMeta" $ \o -> do
@@ -198,6 +211,7 @@ instance Aeson.FromJSON SessionMeta where
     arch    <- o .:? "archived"     .!= False
     desc    <- o .:? "description"
     summ    <- o .:? "auto_summary"
+    src     <- o .:? "source"
     -- Parse session kind: accept both new and legacy format.
     kind    <- parseSessionKind o model agent
     pure SessionMeta
@@ -212,6 +226,7 @@ instance Aeson.FromJSON SessionMeta where
       , _sm_archived          = arch
       , _sm_description       = desc
       , _sm_autoSummary       = summ
+      , _sm_source            = src
       }
 
 -- | Parse the session kind from the JSON object. Accepts three formats:

--- a/src/PureClaw/Transcript/Provider.hs
+++ b/src/PureClaw/Transcript/Provider.hs
@@ -20,12 +20,15 @@ import PureClaw.Handles.Transcript
 import PureClaw.Providers.Class
 import PureClaw.Transcript.Types
 
--- | Internal newtype wrapping a provider with transcript logging.
+-- | Internal newtype wrapping a provider with transcript logging. The tuple
+-- carries the transcript handle, the model name (recorded as @_te_model@),
+-- the optional per-message sender (recorded into Request @_te_metadata@
+-- under @"source"@), and the wrapped provider.
 newtype TranscriptProvider = TranscriptProvider
-  { _tp_inner :: (TranscriptHandle, Text, SomeProvider) }
+  { _tp_inner :: (TranscriptHandle, Text, Maybe MessageSource, SomeProvider) }
 
 instance Provider TranscriptProvider where
-  complete (TranscriptProvider (th, source, inner)) req = do
+  complete (TranscriptProvider (th, source, msgSource, inner)) req = do
     corrId <- generateId
     reqId <- generateId
     now <- getCurrentTime
@@ -41,7 +44,7 @@ instance Provider TranscriptProvider where
           , _te_payload       = encodePayload (encodeUtf8Strict redacted)
           , _te_durationMs    = Nothing
           , _te_correlationId = corrId
-          , _te_metadata      = Map.empty
+          , _te_metadata      = sourceMeta msgSource
           }
     _th_record th reqEntry
     -- Call the inner provider
@@ -65,7 +68,7 @@ instance Provider TranscriptProvider where
     _th_record th respEntry
     pure resp
 
-  completeStream (TranscriptProvider (th, source, inner)) req callback = do
+  completeStream (TranscriptProvider (th, source, msgSource, inner)) req callback = do
     corrId <- generateId
     reqId <- generateId
     now <- getCurrentTime
@@ -81,7 +84,7 @@ instance Provider TranscriptProvider where
           , _te_payload       = encodePayload (encodeUtf8Strict redacted)
           , _te_durationMs    = Nothing
           , _te_correlationId = corrId
-          , _te_metadata      = Map.empty
+          , _te_metadata      = sourceMeta msgSource
           }
     _th_record th reqEntry
     -- Wrap the callback to capture StreamDone
@@ -112,14 +115,28 @@ instance Provider TranscriptProvider where
             _th_record th respEntry
         _ -> pure ()
 
-  listModels (TranscriptProvider (_th, _source, inner)) = listModels inner
+  listModels (TranscriptProvider (_th, _source, _msgSource, inner)) = listModels inner
+
+-- | Build the Request metadata map from an optional per-message sender.
+-- When 'Just', the sender is encoded under the @"source"@ key using the
+-- shared 'MessageSource' codec; when 'Nothing', no key is written. This is
+-- applied to Request entries ONLY — Response entries describe the reply,
+-- not the inbound sender.
+sourceMeta :: Maybe MessageSource -> Map.Map Text Aeson.Value
+sourceMeta = maybe Map.empty (Map.singleton "source" . Aeson.toJSON)
 
 -- | Wrap a 'SomeProvider' with transcript logging. Every @complete@ and
 -- @completeStream@ call records a Request entry (with redacted headers)
 -- and a Response entry (with token usage metadata).
-mkTranscriptProvider :: TranscriptHandle -> Text -> SomeProvider -> SomeProvider
-mkTranscriptProvider th source inner =
-  MkProvider (TranscriptProvider (th, source, inner))
+--
+-- The 'Maybe MessageSource' argument is the per-message sender: when 'Just',
+-- it is written into the Request entry's @_te_metadata@ under the @"source"@
+-- key (Response entries are never tagged). Pass 'Nothing' for turns with no
+-- inbound message (e.g. @\/bg@ and web completions). The sender id lives in
+-- the on-disk metadata only and is never broadcast.
+mkTranscriptProvider :: TranscriptHandle -> Text -> Maybe MessageSource -> SomeProvider -> SomeProvider
+mkTranscriptProvider th source msgSource inner =
+  MkProvider (TranscriptProvider (th, source, msgSource, inner))
 
 -- | Build metadata map from a 'CompletionResponse'.
 -- Includes model name and token usage when available.

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -29,7 +29,7 @@ import PureClaw.Routing.Types (RoutingConfig (..))
 import PureClaw.Security.Policy
 import PureClaw.Security.Vault.Age
 import PureClaw.Security.Vault.Plugin
-import PureClaw.Session.Handle (mkSessionHandle, mkNoOpSessionHandle, noOpOnFirstStreamDoneRef)
+import PureClaw.Session.Handle (SessionHandle (..), mkSessionHandle, mkNoOpSessionHandle, noOpOnFirstStreamDoneRef)
 import PureClaw.Tools.Registry
 
 import Data.Map.Strict qualified as Map
@@ -171,6 +171,7 @@ mkBgTestEnv sessionsDir p ch = do
         , SessionTypes._sm_archived = False
         , SessionTypes._sm_description = Nothing
         , SessionTypes._sm_autoSummary = Nothing
+        , SessionTypes._sm_source = Nothing
         }
   sh    <- mkSessionHandle Nothing mkNoOpLogHandle sessionsDir meta
   shRef <- newIORef sh
@@ -252,6 +253,42 @@ spec = do
           T.unpack statusMsg `shouldContain` "Messages"
           replyMsg `shouldBe` "mock> reply"
         _ -> expectationFailure "expected two messages"
+
+    -- Session origin capture (WU3): set-once provenance recorded from the
+    -- first inbound message, before slash/provider branching.
+    it "captures _sm_source on the first inbound message" $
+      withSystemTempDirectory "pc-src" $ \tmp -> do
+        let src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+        channel <- mkSourcedChannel [(src, "hello")]
+        env <- mkSourceCaptureEnv tmp (MockProvider "reply") channel
+        runAgentLoop env
+        sh <- readIORef (_env_session env)
+        meta <- readIORef (_sh_meta sh)
+        SessionTypes._sm_source meta `shouldBe` Just src
+
+    it "captures _sm_source even when the inbound message content is empty" $
+      withSystemTempDirectory "pc-src" $ \tmp -> do
+        -- An empty-content message still has a sender; origin is about the
+        -- sender, not the content, so the empty-message branch must capture.
+        let src = mkMessageSource CkTelegram (Just (UserId "99999")) mempty
+        channel <- mkSourcedChannel [(src, "")]
+        env <- mkSourceCaptureEnv tmp (MockProvider "reply") channel
+        runAgentLoop env
+        sh <- readIORef (_env_session env)
+        meta <- readIORef (_sh_meta sh)
+        SessionTypes._sm_source meta `shouldBe` Just src
+
+    it "does not overwrite _sm_source when a later message has a different sender" $
+      withSystemTempDirectory "pc-src" $ \tmp -> do
+        let first  = mkMessageSource CkSignal (Just (UserId "+15550000001")) mempty
+            second = mkMessageSource CkTelegram (Just (UserId "99999")) mempty
+        channel <- mkSourcedChannel [(first, "hello"), (second, "world")]
+        env <- mkSourceCaptureEnv tmp (MockProvider "reply") channel
+        runAgentLoop env
+        sh <- readIORef (_env_session env)
+        meta <- readIORef (_sh_meta sh)
+        -- Set-once: the session origin stays the FIRST sender.
+        SessionTypes._sm_source meta `shouldBe` Just first
 
     -- /bg — run a prompt in a fresh background session (issue #52)
     it "/bg runs a background turn and pushes the result to the channel" $
@@ -540,4 +577,54 @@ mkMockChannel messages = do
         , _ch_promptSecret = \_ -> pure ""
         }
   pure (channel, sentRef)
+
+-- | Like 'mkMockChannel' but each queued message carries its own
+-- 'MessageSource', so tests can drive the loop with messages from
+-- different senders (and with empty content). Throws EOF when drained.
+mkSourcedChannel :: [(MessageSource, Text)] -> IO ChannelHandle
+mkSourcedChannel messages = do
+  msgsRef <- newIORef messages
+  pure ChannelHandle
+    { _ch_receive = do
+        msgs <- readIORef msgsRef
+        case msgs of
+          [] -> throwIO (userError "EOF" :: IOError)
+          ((src, m):rest) -> do
+            writeIORef msgsRef rest
+            pure IncomingMessage { _im_source = src, _im_content = m }
+    , _ch_send         = \_ -> pure ()
+    , _ch_sendError    = \_ -> pure ()
+    , _ch_sendChunk    = \_ -> pure ()
+    , _ch_streaming    = True
+    , _ch_readSecret   = pure ""
+    , _ch_prompt       = \_ -> pure ""
+    , _ch_promptSecret = \_ -> pure ""
+    }
+
+-- | Build a test env backed by a REAL on-disk session handle (rooted under
+-- the given sessions dir) so origin capture via 'setSourceIfAbsent' can
+-- persist. Returns the env so tests can read '_sh_meta' afterward.
+mkSourceCaptureEnv :: Provider p => FilePath -> p -> ChannelHandle -> IO AgentEnv
+mkSourceCaptureEnv sessionsDir p ch = do
+  base <- mkTestEnv p ch
+  now  <- getCurrentTime
+  let meta = SessionTypes.SessionMeta
+        { SessionTypes._sm_id    = SessionTypes.newSessionId Nothing now
+        , SessionTypes._sm_agent = Nothing
+        , SessionTypes._sm_kind  = SessionTypes.SkProvider
+            (SessionTypes.ProviderSpec
+              (SessionTypes.inferProviderId "mock") (ModelId "mock") Nothing)
+        , SessionTypes._sm_model  = "mock"
+        , SessionTypes._sm_channel = "cli"
+        , SessionTypes._sm_createdAt = now
+        , SessionTypes._sm_lastActive = now
+        , SessionTypes._sm_bootstrapConsumed = False
+        , SessionTypes._sm_archived = False
+        , SessionTypes._sm_description = Nothing
+        , SessionTypes._sm_autoSummary = Nothing
+        , SessionTypes._sm_source = Nothing
+        }
+  sh    <- mkSessionHandle Nothing mkNoOpLogHandle sessionsDir meta
+  shRef <- newIORef sh
+  pure base { _env_session = shRef }
 

--- a/test/Agent/LoopSpec.hs
+++ b/test/Agent/LoopSpec.hs
@@ -527,7 +527,7 @@ mkMockChannel messages = do
               (m:rest) -> do
                 writeIORef msgsRef rest
                 pure IncomingMessage
-                  { _im_userId = UserId "test"
+                  { _im_source = mkMessageSource CkCli (Just (UserId "test")) mempty
                   , _im_content = m
                   }
         , _ch_send = \msg ->

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -400,6 +400,43 @@ spec = do
           T.unpack t `shouldContain` "Target:"
         Nothing -> expectationFailure "Expected status message"
 
+    it "/status renders 'unknown' Source for a legacy (Nothing) session" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      let ctx = emptyContext Nothing
+      env <- mkEnv sentRef
+      _ <- executeSlashCommand env CmdStatus ctx
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "  Source:    unknown"
+        Nothing -> expectationFailure "Expected status message"
+
+    it "/status renders Source as '<userId> (<channel>)' for a Just source with a userId" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      let ctx = emptyContext Nothing
+          src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+      env <- mkEnv sentRef
+      -- Inject a source into the active session's metadata.
+      sh <- readIORef (_env_session env)
+      modifyIORef' (_sh_meta sh) (\m -> m { _sm_source = Just src })
+      _ <- executeSlashCommand env CmdStatus ctx
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "  Source:    +15551234567 (signal)"
+        Nothing -> expectationFailure "Expected status message"
+
+    it "/status renders a CkOther channel label for a Just source" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      let ctx = emptyContext Nothing
+          src = mkMessageSource (CkOther "matrix") Nothing mempty
+      env <- mkEnv sentRef
+      sh <- readIORef (_env_session env)
+      modifyIORef' (_sh_meta sh) (\m -> m { _sm_source = Just src })
+      _ <- executeSlashCommand env CmdStatus ctx
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "  Source:    (matrix)"
+        Nothing -> expectationFailure "Expected status message"
+
     it "/compact with few messages returns NotNeeded" $ do
       sentRef <- newIORef (Nothing :: Maybe Text)
       let ctx = addMessage (textMessage User "hello") (emptyContext Nothing)

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -116,7 +116,7 @@ mkMockChannel sentRef msgsRef = mkNoOpChannelHandle
   { _ch_send         = writeIORef sentRef . Just . _om_content
   , _ch_receive      = do
       m <- popMsg msgsRef
-      pure (IncomingMessage (UserId "test") m)
+      pure (IncomingMessage (mkMessageSource CkCli (Just (UserId "test")) mempty) m)
   , _ch_prompt       = \_ -> popMsg msgsRef
   , _ch_promptSecret = \_ -> popMsg msgsRef
   }
@@ -127,7 +127,7 @@ mkMockChannelAll allSentRef msgsRef = mkNoOpChannelHandle
   { _ch_send         = \msg -> modifyIORef allSentRef (_om_content msg :)
   , _ch_receive      = do
       m <- popMsg msgsRef
-      pure (IncomingMessage (UserId "test") m)
+      pure (IncomingMessage (mkMessageSource CkCli (Just (UserId "test")) mempty) m)
   , _ch_prompt       = \_ -> popMsg msgsRef
   , _ch_promptSecret = \_ -> popMsg msgsRef
   }

--- a/test/Channels/ClassSpec.hs
+++ b/test/Channels/ClassSpec.hs
@@ -25,7 +25,8 @@ spec :: Spec
 spec = do
   describe "Channel typeclass" $ do
     it "toHandle produces a working ChannelHandle" $ do
-      let msg = IncomingMessage (UserId "u1") "hello"
+      let msg = IncomingMessage
+                  (mkMessageSource CkCli (Just (UserId "u1")) mempty) "hello"
           ch  = TestChannel msg
           h   = toHandle ch
       received <- _ch_receive h
@@ -33,7 +34,8 @@ spec = do
 
   describe "SomeChannel" $ do
     it "wraps a Channel and extracts a handle" $ do
-      let msg  = IncomingMessage (UserId "u2") "world"
+      let msg  = IncomingMessage
+                   (mkMessageSource CkCli (Just (UserId "u2")) mempty) "world"
           some = MkChannel (TestChannel msg)
           h    = someChannelHandle some
       received <- _ch_receive h

--- a/test/Channels/SignalSpec.hs
+++ b/test/Channels/SignalSpec.hs
@@ -5,6 +5,7 @@ import Control.Concurrent.STM
 import Control.Exception
 import Data.Aeson
 import Data.Either (isLeft)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Test.Hspec
@@ -40,7 +41,19 @@ spec = do
       let env = mkTestEnvelope "+9876543210" 2000 "Hi"
       atomically $ writeTQueue (_sch_inbox sc) env
       msg <- _ch_receive (toHandle sc)
-      _im_userId msg `shouldBe` UserId "+9876543210"
+      imUserId msg `shouldBe` UserId "+9876543210"
+      _ms_channel (_im_source msg) `shouldBe` CkSignal
+
+    it "records the uuid in the source fields when present" $ do
+      sc <- mkTestSignalChannel
+      let env = SignalEnvelope "+5550001111" (Just "abc-uuid") (Just 4000)
+                  (Just (SignalDataMessage "Yo" 4000))
+      atomically $ writeTQueue (_sch_inbox sc) env
+      msg <- _ch_receive (toHandle sc)
+      imUserId msg `shouldBe` UserId "+5550001111"
+      _ms_channel (_im_source msg) `shouldBe` CkSignal
+      Map.lookup "uuid" (_ms_fields (_im_source msg))
+        `shouldBe` Just (String "abc-uuid")
 
     it "handles envelope with no dataMessage" $ do
       sc <- mkTestSignalChannel

--- a/test/Channels/TelegramSpec.hs
+++ b/test/Channels/TelegramSpec.hs
@@ -6,6 +6,7 @@ import Data.Aeson
 import Data.ByteString (ByteString)
 import Data.Either (isLeft)
 import Data.IORef
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
@@ -41,7 +42,10 @@ spec = do
       let update = mkTestUpdate 1 99 "Bob" 100 "private" "Hi"
       atomically $ writeTQueue (_tch_inbox tc) update
       msg <- _ch_receive (toHandle tc)
-      _im_userId msg `shouldBe` UserId "99"
+      imUserId msg `shouldBe` UserId "99"
+      _ms_channel (_im_source msg) `shouldBe` CkTelegram
+      Map.lookup "chat_id" (_ms_fields (_im_source msg))
+        `shouldBe` Just (toJSON (100 :: Int))
 
   describe "parseTelegramUpdate" $ do
     it "parses a valid update JSON" $ do

--- a/test/Core/TypesSpec.hs
+++ b/test/Core/TypesSpec.hs
@@ -2,6 +2,10 @@ module Core.TypesSpec (spec) where
 
 import Test.Hspec
 import Test.QuickCheck
+import Data.Aeson qualified as Aeson
+import Data.Aeson (eitherDecode, encode)
+import Data.ByteString.Lazy.Char8 qualified as BL
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import PureClaw.Core.Types
@@ -64,3 +68,111 @@ spec = do
     it "CommandName has Ord for Set usage" $ do
       let s = Set.fromList [CommandName "a", CommandName "b", CommandName "a"]
       Set.size s `shouldBe` 2
+
+  describe "ChannelKind text round-trip" $ do
+    let kinds = [CkCli, CkWeb, CkSignal, CkTelegram, CkBackground, CkOther "matrix"]
+    it "round-trips all kinds including CkOther" $
+      mapM_ (\k -> channelKindFromText (channelKindToText k) `shouldBe` k) kinds
+
+    it "channelKindToText produces expected strings" $ do
+      channelKindToText CkCli `shouldBe` "cli"
+      channelKindToText CkWeb `shouldBe` "web"
+      channelKindToText CkSignal `shouldBe` "signal"
+      channelKindToText CkTelegram `shouldBe` "telegram"
+      channelKindToText CkBackground `shouldBe` "background"
+      channelKindToText (CkOther "matrix") `shouldBe` "matrix"
+
+    it "shadowing guard: \"signal\" never decodes to CkOther \"signal\"" $
+      channelKindFromText "signal" `shouldBe` CkSignal
+
+    it "unknown names decode to CkOther" $
+      channelKindFromText "matrix" `shouldBe` CkOther "matrix"
+
+    it "ChannelKind encodes as a plain JSON string" $ do
+      encode CkSignal `shouldBe` "\"signal\""
+      encode (CkOther "matrix") `shouldBe` "\"matrix\""
+
+    it "ChannelKind JSON round-trips" $
+      mapM_ (\k -> eitherDecode (encode k) `shouldBe` Right k) kinds
+
+  describe "MessageSource JSON" $ do
+    it "round-trips with empty fields and no user id" $ do
+      let src = mkMessageSource CkWeb Nothing Map.empty
+      eitherDecode (encode src) `shouldBe` Right src
+
+    it "round-trips with non-empty fields and a user id" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+15551234567"))
+                  (Map.fromList [("uuid", Aeson.String "abc-123")])
+      eitherDecode (encode src) `shouldBe` Right src
+
+    it "uses snake_case keys" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+1555"))
+                  (Map.fromList [("uuid", Aeson.String "abc")])
+          out = BL.unpack (encode src)
+      out `shouldSatisfy` ("\"channel\"" `isSubOf`)
+      out `shouldSatisfy` ("\"user_id\"" `isSubOf`)
+      out `shouldSatisfy` ("\"fields\"" `isSubOf`)
+
+    it "serializes user_id as a plain string" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+1555")) Map.empty
+          out = BL.unpack (encode src)
+      out `shouldSatisfy` ("\"+1555\"" `isSubOf`)
+
+    it "omits user_id when Nothing" $ do
+      let src = mkMessageSource CkWeb Nothing Map.empty
+          out = BL.unpack (encode src)
+      out `shouldSatisfy` (not . ("\"user_id\"" `isSubOf`))
+
+    it "omits fields when empty" $ do
+      let src = mkMessageSource CkWeb Nothing Map.empty
+          out = BL.unpack (encode src)
+      out `shouldSatisfy` (not . ("\"fields\"" `isSubOf`))
+
+    it "tolerant decode: missing user_id and fields" $ do
+      let json = "{\"channel\":\"web\"}"
+      eitherDecode json `shouldBe` Right (mkMessageSource CkWeb Nothing Map.empty)
+
+  describe "mkMessageSource normalization" $ do
+    it "strips control chars and newlines on the user id" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "a\nb\tc\rd")) Map.empty
+      _ms_userId src `shouldBe` Just (UserId "abcd")
+
+    it "strips control chars on a field string value" $ do
+      let src = mkMessageSource CkTelegram Nothing
+                  (Map.fromList [("username", Aeson.String "ev\nil\tname")])
+      Map.lookup "username" (_ms_fields src)
+        `shouldBe` Just (Aeson.String "evilname")
+
+    it "normalizes nested string values inside fields" $ do
+      let nested = Aeson.object ["inner" Aeson..= Aeson.String "x\ny"]
+          src = mkMessageSource CkTelegram Nothing (Map.fromList [("o", nested)])
+      Map.lookup "o" (_ms_fields src)
+        `shouldBe` Just (Aeson.object ["inner" Aeson..= Aeson.String "xy"])
+
+    it "bounds user id length to maxSourceLen" $ do
+      let long = T.replicate (maxSourceLen + 100) "a"
+          src = mkMessageSource CkSignal (Just (UserId long)) Map.empty
+      case _ms_userId src of
+        Just (UserId t) -> T.length t `shouldBe` maxSourceLen
+        Nothing -> expectationFailure "expected Just user id"
+
+    it "bounds field string length to maxSourceLen" $ do
+      let long = T.replicate (maxSourceLen + 100) "b"
+          src = mkMessageSource CkTelegram Nothing
+                  (Map.fromList [("k", Aeson.String long)])
+      case Map.lookup "k" (_ms_fields src) of
+        Just (Aeson.String t) -> T.length t `shouldBe` maxSourceLen
+        _ -> expectationFailure "expected Just (String ...)"
+
+    it "folds CkOther \"signal\" to CkSignal" $ do
+      let src = mkMessageSource (CkOther "signal") Nothing Map.empty
+      _ms_channel src `shouldBe` CkSignal
+
+    it "maxSourceLen is 512" $
+      maxSourceLen `shouldBe` 512
+  where
+    isSubOf :: String -> String -> Bool
+    isSubOf needle haystack = needle `elem` substrings
+      where
+        n = length needle
+        substrings = [take n (drop i haystack) | i <- [0 .. length haystack - n]]

--- a/test/Core/TypesSpec.hs
+++ b/test/Core/TypesSpec.hs
@@ -149,6 +149,12 @@ spec = do
       Map.lookup "o" (_ms_fields src)
         `shouldBe` Just (Aeson.object ["inner" Aeson..= Aeson.String "xy"])
 
+    it "normalizes string values inside a JSON array field" $ do
+      let arr = Aeson.toJSON [Aeson.String "a\nb", Aeson.String "c\td"]
+          src = mkMessageSource CkTelegram Nothing (Map.fromList [("xs", arr)])
+      Map.lookup "xs" (_ms_fields src)
+        `shouldBe` Just (Aeson.toJSON [Aeson.String "ab", Aeson.String "cd"])
+
     it "bounds user id length to maxSourceLen" $ do
       let long = T.replicate (maxSourceLen + 100) "a"
           src = mkMessageSource CkSignal (Just (UserId long)) Map.empty

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -1422,6 +1422,7 @@ writeTestSession baseDir sid archived = do
         , _sm_archived          = archived
         , _sm_description       = Nothing
         , _sm_autoSummary       = Nothing
+        , _sm_source            = Nothing
         }
       epoch = UTCTime (fromGregorian 2024 1 1) (secondsToDiffTime 0)
   LBS.writeFile (dir </> "session.json") (Aeson.encode meta)
@@ -1544,6 +1545,7 @@ writeBranchSource baseDir sid mAgentText mPrompt entries = do
         , _sm_archived          = False
         , _sm_description       = Nothing
         , _sm_autoSummary       = Nothing
+        , _sm_source            = Nothing
         }
       epochT = UTCTime (fromGregorian 2024 1 1) (secondsToDiffTime 0)
   LBS.writeFile (dir </> "session.json") (Aeson.encode meta)
@@ -1570,6 +1572,7 @@ writeHarnessBranchSource baseDir sid = do
         , _sm_archived          = False
         , _sm_description       = Nothing
         , _sm_autoSummary       = Nothing
+        , _sm_source            = Nothing
         }
       epochT = UTCTime (fromGregorian 2024 1 1) (secondsToDiffTime 0)
   LBS.writeFile (dir </> "session.json") (Aeson.encode meta)
@@ -1657,6 +1660,7 @@ writeSessionBootstrap baseDir sid mAgentText boot = do
         , _sm_archived          = False
         , _sm_description       = Nothing
         , _sm_autoSummary       = Nothing
+        , _sm_source            = Nothing
         }
       epochT = UTCTime (fromGregorian 2024 1 1) (secondsToDiffTime 0)
   LBS.writeFile (dir </> "session.json") (Aeson.encode meta)

--- a/test/Frontend/BroadcastingTranscriptSpec.hs
+++ b/test/Frontend/BroadcastingTranscriptSpec.hs
@@ -102,6 +102,7 @@ mkMeta sid = SessionMeta
   , _sm_archived          = False
   , _sm_description       = Nothing
   , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
   }
 
 -- | LogHandle that captures warn messages into an IORef so D34 can assert

--- a/test/Frontend/BroadcastingTranscriptSpec.hs
+++ b/test/Frontend/BroadcastingTranscriptSpec.hs
@@ -25,7 +25,21 @@ import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
-import PureClaw.Core.Types (ModelId (..), ProviderId (..), SessionId (..), parseSessionId)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text.Encoding qualified as TE
+import PureClaw.Core.Types
+  ( ChannelKind (..)
+  , MessageSource
+  , ModelId (..)
+  , ProviderId (..)
+  , SessionId (..)
+  , UserId (..)
+  , mkMessageSource
+  , parseSessionId
+  )
+import PureClaw.Frontend.API (toTranscriptEntryInfo)
+import PureClaw.Frontend.Stream (toEntryInfo)
 import PureClaw.Handles.Log (LogHandle (..), mkNoOpLogHandle)
 import PureClaw.Handles.Transcript
   ( TranscriptHandle (..)
@@ -296,7 +310,7 @@ spec = do
         let path = tmp </> "transcript.jsonl"
         th <- mkBroadcastingFileTranscriptHandle (Just broker) sid1 mkNoOpLogHandle path
         let inner = MkProvider (LeakyProvider leakyResp) :: SomeProvider
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped leakyReq
         _th_flush th
         _th_close th
@@ -359,7 +373,7 @@ spec = do
         let path = tmp </> "transcript.jsonl"
         th <- mkBroadcastingFileTranscriptHandle (Just broker) sid1 mkNoOpLogHandle path
         let inner = MkProvider (LeakyProvider leakyResp) :: SomeProvider
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped leakyReq
         _th_flush th
         _th_close th
@@ -395,7 +409,7 @@ spec = do
         let path = tmp </> "transcript.jsonl"
         th <- mkBroadcastingFileTranscriptHandle (Just broker) sid1 mkNoOpLogHandle path
         let inner = MkProvider (LeakyProvider leakyResp) :: SomeProvider
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped leakyReq
         _th_flush th
         _th_close th
@@ -412,6 +426,39 @@ spec = do
         -- redactor pipeline). The decorator is /not/ a path that
         -- bypasses redaction.
         all (`elem` diskSet) brokerSet `shouldBe` True
+
+  -- -------------------------------------------------------------------------
+  -- WU4 — the per-message sender id lives in _te_metadata only and is
+  -- DROPPED by both broadcast projections. These tests pin the privacy
+  -- invariant: the sender id must not appear in the WS @entry@ event
+  -- (toEntryInfo) nor the HTTP GET /transcript response
+  -- (toTranscriptEntryInfo / its ToJSON).
+  -- -------------------------------------------------------------------------
+  describe "WU4 source omitted from broadcast projections" $ do
+    let senderId = "+15551234567" :: Text
+        taggedEntry =
+          (mkEntry "src")
+            { _te_metadata =
+                Map.singleton "source"
+                  (Aeson.toJSON (sourceWith senderId))
+            }
+
+    it "WS projection (toEntryInfo) omits the sender id" $ do
+      let info = toEntryInfo taggedEntry
+          encoded = TE.decodeUtf8Lenient
+                      (LBS.toStrict (Aeson.encode info))
+      (senderId `T.isInfixOf` encoded) `shouldBe` False
+
+    it "HTTP projection (toTranscriptEntryInfo) omits the sender id" $ do
+      let info = toTranscriptEntryInfo taggedEntry
+          encoded = TE.decodeUtf8Lenient
+                      (LBS.toStrict (Aeson.encode info))
+      (senderId `T.isInfixOf` encoded) `shouldBe` False
+
+-- | A 'MessageSource' carrying the given user id, used to plant a
+-- recognizable sender id inside @_te_metadata@.
+sourceWith :: Text -> MessageSource
+sourceWith uid = mkMessageSource CkSignal (Just (UserId uid)) mempty
 
 -- ---------------------------------------------------------------------------
 -- Local helpers

--- a/test/Frontend/StreamGoldensSpec.hs
+++ b/test/Frontend/StreamGoldensSpec.hs
@@ -111,6 +111,7 @@ sampleSessionMeta = SessionMeta
   , _sm_archived          = False
   , _sm_description       = Nothing
   , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
   }
 
 -- | Client→server focus op (no since).

--- a/test/Frontend/StreamIntegrationSpec.hs
+++ b/test/Frontend/StreamIntegrationSpec.hs
@@ -168,6 +168,7 @@ mkMeta sidText = SessionMeta
   , _sm_archived          = False
   , _sm_description       = Nothing
   , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
   }
 
 -- | Drain the hello + initial lists snapshot from a freshly opened

--- a/test/Handles/ChannelSpec.hs
+++ b/test/Handles/ChannelSpec.hs
@@ -11,7 +11,7 @@ spec = do
   describe "mkNoOpChannelHandle" $ do
     it "receive returns an empty message" $ do
       msg <- _ch_receive mkNoOpChannelHandle
-      _im_userId msg `shouldBe` UserId ""
+      imUserId msg `shouldBe` UserId ""
       _im_content msg `shouldBe` ""
 
     it "send succeeds silently" $ do
@@ -31,9 +31,22 @@ spec = do
 
   describe "IncomingMessage" $ do
     it "has Show and Eq instances" $ do
-      let msg = IncomingMessage (UserId "user1") "hello"
+      let msg = IncomingMessage
+            (mkMessageSource CkCli (Just (UserId "user1")) mempty) "hello"
       show msg `shouldContain` "user1"
       msg `shouldBe` msg
+
+    it "imUserId derives the user id from a source with Just userId" $ do
+      let msg = IncomingMessage
+            (mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty) "hi"
+      imUserId msg `shouldBe` UserId "+15551234567"
+      _ms_channel (_im_source msg) `shouldBe` CkSignal
+
+    it "imUserId yields the UserId \"\" sentinel for a Nothing source" $ do
+      let msg = IncomingMessage
+            (mkMessageSource (CkOther "noop") Nothing mempty) "hi"
+      imUserId msg `shouldBe` UserId ""
+      _ms_userId (_im_source msg) `shouldBe` Nothing
 
   describe "OutgoingMessage" $ do
     it "has Show and Eq instances" $ do

--- a/test/Integration/CLISpec.hs
+++ b/test/Integration/CLISpec.hs
@@ -392,6 +392,7 @@ spec = do
               , _sm_archived          = False
               , _sm_description       = Nothing
               , _sm_autoSummary       = Nothing
+              , _sm_source            = Nothing
               }
             mkTxEntry eid dir payload = TranscriptEntry
               { _te_id            = eid
@@ -454,6 +455,7 @@ spec = do
               , _sm_archived          = False
               , _sm_description       = Nothing
               , _sm_autoSummary       = Nothing
+              , _sm_source            = Nothing
               }
         createDirectoryIfMissing True sessionsDir
         sh <- mkSessionHandle Nothing mkNoOpLogHandle sessionsDir meta

--- a/test/Integration/SignalFlowSpec.hs
+++ b/test/Integration/SignalFlowSpec.hs
@@ -3,11 +3,15 @@ module Integration.SignalFlowSpec (spec) where
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Concurrent.STM
-import Data.Aeson (object, (.=))
+import Data.Aeson (Value (..), object, (.=))
 import Data.IntMap.Strict qualified as IntMap
 import Data.IORef
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Time (UTCTime (..), fromGregorian, secondsToDiffTime)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -19,13 +23,16 @@ import PureClaw.Channels.Signal.Transport
 import PureClaw.Core.Types
 import PureClaw.Handles.Channel
 import PureClaw.Handles.Log
+import PureClaw.Handles.Transcript (TranscriptHandle (..))
 import PureClaw.Providers.Class
 import PureClaw.Routing.Config (defaultRoutingConfig)
 import PureClaw.Routing.Types (RoutingConfig (..))
 import PureClaw.Security.Policy
 import PureClaw.Security.Vault.Age
 import PureClaw.Security.Vault.Plugin
-import PureClaw.Session.Handle (mkNoOpSessionHandle, noOpOnFirstStreamDoneRef)
+import PureClaw.Session.Handle (mkNoOpSessionHandle, mkSessionHandle, noOpOnFirstStreamDoneRef)
+import PureClaw.Session.Handle qualified as Session
+import PureClaw.Session.Types
 import PureClaw.Tools.Registry
 
 import Data.Map.Strict qualified as Map
@@ -216,6 +223,73 @@ spec = do
       -- Should get intermediate text + final response
       length sent `shouldSatisfy` (>= 1)
 
+    -- End-to-end dual-storage proof (WU5): a Signal DM carrying BOTH a phone
+    -- number AND a uuid must land in BOTH session.json (via _sm_source /
+    -- setSourceIfAbsent, set-once on first inbound) AND transcript.jsonl (via
+    -- mkTranscriptProvider's per-message source metadata on the Request entry).
+    -- Uses a REAL on-disk session handle (not the noOp one) and a non-streaming
+    -- provider so the transcript `complete` Request path is exercised.
+    it "persists a Signal DM's phone AND uuid into both session.json and transcript.jsonl" $
+      withSystemTempDirectory "pureclaw-signal-flow-spec" $ \baseDir -> do
+        sc <- mkTestSignalChannelForFlow
+        sentRef <- newIORef ([] :: [Text])
+        let handle = (toHandle sc)
+              { _ch_send = \msg -> modifyIORef sentRef (<> [_om_content msg]) }
+
+        -- A real on-disk session handle with a fresh _sm_source = Nothing.
+        let sid  = "sess-srctest"
+            meta = mkSrcTestMeta sid
+        sh <- mkSessionHandle Nothing mkNoOpLogHandle baseDir meta
+
+        -- Build the test env, then OVERRIDE its (noOp) session with the real one
+        -- so the agent loop's transcript writes (and set-once source capture)
+        -- target the on-disk session.
+        baseEnv <- mkTestEnv (EchoProvider "Echo: ") handle
+        writeIORef (_env_session baseEnv) sh
+
+        agentThread <- async $ runAgentLoop baseEnv
+
+        -- A Signal DM carrying BOTH a phone (source) and a uuid (sourceUuid).
+        let envelope = SignalEnvelope
+              { _se_source    = "+15551234567"
+              , _se_sourceUuid = Just "uuid-abc-123"
+              , _se_timestamp = Just 1000
+              , _se_dataMessage = Just SignalDataMessage
+                  { _sdm_message   = "Hello"
+                  , _sdm_timestamp = 1000
+                  }
+              }
+        atomically $ writeTQueue (_sch_inbox sc) envelope
+        waitForResponses sentRef 1
+
+        cancelWith agentThread (userError "EOF")
+        _ <- waitCatch agentThread
+
+        -- Flush the transcript so transcript.jsonl is on disk before reading.
+        _th_flush (Session._sh_transcript sh)
+
+        -- session.json: phone AND uuid persisted via _sm_source.
+        sessionJson <- TIO.readFile (baseDir </> T.unpack sid </> "session.json")
+        T.unpack sessionJson `shouldContain` "+15551234567"
+        T.unpack sessionJson `shouldContain` "uuid-abc-123"
+        -- Robust structural check on the in-memory meta: _sm_source carries the
+        -- phone as the user id and the uuid in the fields map.
+        persisted <- readIORef (Session._sh_meta sh)
+        (_ms_userId =<< _sm_source persisted)
+          `shouldBe` Just (UserId "+15551234567")
+        case _sm_source persisted of
+          Just src ->
+            Map.lookup "uuid" (_ms_fields src)
+              `shouldBe` Just (String "uuid-abc-123")
+          Nothing -> expectationFailure "expected _sm_source to be Just"
+
+        -- transcript.jsonl: phone AND uuid recorded on the Request entry's
+        -- metadata.source (the substring check is sufficient — both only appear
+        -- because mkTranscriptProvider wrote _im_source into the Request metadata).
+        transcriptJsonl <- TIO.readFile (baseDir </> T.unpack sid </> "transcript.jsonl")
+        T.unpack transcriptJsonl `shouldContain` "+15551234567"
+        T.unpack transcriptJsonl `shouldContain` "uuid-abc-123"
+
 -- | A mock provider that returns a tool call on first request, then text.
 data ToolCallThenTextProvider = ToolCallThenTextProvider
 
@@ -239,6 +313,30 @@ instance Provider ToolCallThenTextProvider where
     where
       isResult (ToolResultBlock {}) = True
       isResult _ = False
+
+-- | A fresh provider-backed 'SessionMeta' with @_sm_source = Nothing@, mirroring
+-- the @mkMeta@ helper shape in @test/Session/HandleSpec.hs@. Used by the
+-- dual-storage end-to-end test so the agent loop captures the Signal source
+-- set-once into a real on-disk @session.json@.
+mkSrcTestMeta :: Text -> SessionMeta
+mkSrcTestMeta sid = SessionMeta
+  { _sm_id                = parseSessionId sid
+  , _sm_agent             = Nothing
+  , _sm_kind              = SkProvider (ProviderSpec (inferProviderId "mock") (ModelId "mock") Nothing)
+  , _sm_model             = "mock"
+  , _sm_channel           = "signal"
+  , _sm_createdAt         = srcTestEpoch
+  , _sm_lastActive        = srcTestEpoch
+  , _sm_bootstrapConsumed = False
+  , _sm_archived          = False
+  , _sm_description       = Nothing
+  , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
+  }
+
+-- | Fixed timestamp for 'mkSrcTestMeta' (2025-01-01T00:00:00Z).
+srcTestEpoch :: UTCTime
+srcTestEpoch = UTCTime (fromGregorian 2025 1 1) (secondsToDiffTime 0)
 
 -- | Create a test SignalChannel with mock transport.
 mkTestSignalChannelForFlow :: IO SignalChannel

--- a/test/Routing/DispatcherSpec.hs
+++ b/test/Routing/DispatcherSpec.hs
@@ -44,6 +44,7 @@ import Data.IntMap.Strict qualified as IntMap
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (UTCTime (..), addUTCTime, fromGregorian, secondsToDiffTime)
@@ -388,7 +389,8 @@ spec = do
                   then do
                     -- inject one valid message
                     feedIncoming fch
-                      (IncomingMessage (UserId "u") "hello")
+                      (IncomingMessage
+                        (mkMessageSource CkCli (Just (UserId "u")) mempty) "hello")
                     -- read it through the underlying queue
                     _ch_receive (fakeChannelHandle fch)
                   else throwIO (ErrorCall "EOF")
@@ -638,7 +640,8 @@ spec = do
                 if n == 0
                   then do
                     feedIncoming fch
-                      (IncomingMessage (UserId "allowed") "/0")
+                      (IncomingMessage
+                        (mkMessageSource CkCli (Just (UserId "allowed")) mempty) "/0")
                     _ch_receive (fakeChannelHandle fch)
                   else throwIO (ErrorCall "EOF")
             }
@@ -661,6 +664,21 @@ spec = do
       -- perspective because the dispatcher only consumes _ch_receive.
       _ <- pure env
       pure ()
+
+    it ("an IncomingMessage whose source carries no userId (imUserId == "
+        <> "UserId \"\") is NOT authorized against a populated allow-list") $ do
+      -- Behavioral-equivalence guard for the MessageSource migration: the
+      -- noOp / sourceless path derives the empty UserId "" sentinel via
+      -- imUserId, and that sentinel must never match a non-empty allow-list.
+      let sourceless = IncomingMessage
+            (mkMessageSource (CkOther "noop") Nothing mempty) "hello"
+          populated  = AllowList (Set.fromList [UserId "alice", UserId "bob"])
+      -- The derived sender is the empty sentinel...
+      imUserId sourceless `shouldBe` UserId ""
+      -- ...and the empty sentinel is rejected by a populated allow-list.
+      isAllowed populated (imUserId sourceless) `shouldBe` False
+      -- Sanity: a real member IS allowed (so the list isn't vacuously empty).
+      isAllowed populated (UserId "alice") `shouldBe` True
 
 
   describe "P18 — LLM-free invariant property (dispatcher-side)" $ do

--- a/test/Session/HandleSpec.hs
+++ b/test/Session/HandleSpec.hs
@@ -27,9 +27,12 @@ import Test.Hspec
 import PureClaw.Agent.AgentDef (mkAgentName, unAgentName)
 import PureClaw.Agent.Compaction (compactionMetadataKey)
 import PureClaw.Core.Types
-  ( MessageTarget (..)
+  ( ChannelKind (..)
+  , MessageTarget (..)
   , ModelId (..)
   , SessionId (..)
+  , UserId (..)
+  , mkMessageSource
   , parseSessionId
   )
 import PureClaw.Handles.Harness (HarnessHandle, mkNoOpHarnessHandle)
@@ -58,6 +61,7 @@ import PureClaw.Session.Handle
   , resolveSessionRef
   , resumeSession
   , setArchived
+  , setSourceIfAbsent
   , touchSessionLastActive
   , setDescription
   , validateRuntime
@@ -95,6 +99,7 @@ mkMeta sid t = SessionMeta
   , _sm_archived          = False
   , _sm_description       = Nothing
   , _sm_autoSummary       = Nothing
+  , _sm_source            = Nothing
   }
 
 -- Convenience: get the low 9 perm bits of a path.
@@ -368,6 +373,46 @@ spec = do
       loaded <- readIORef (_sh_meta sh')
       _sm_bootstrapConsumed loaded `shouldBe` True
       _th_close (_sh_transcript sh')
+
+  describe "setSourceIfAbsent" $ do
+    it "sets _sm_source when currently Nothing and persists to session.json" $ withTmp $ \base -> do
+      let meta = mkMeta "src-1" t0
+          src  = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+      sh <- mkSessionHandle Nothing mkNoOpLogHandle base meta
+      _sm_source <$> readIORef (_sh_meta sh) `shouldReturn` Nothing
+      setSourceIfAbsent sh src
+      -- IORef reflects the change.
+      updated <- readIORef (_sh_meta sh)
+      _sm_source updated `shouldBe` Just src
+      -- Persisted to disk.
+      Right onDisk <- Aeson.eitherDecodeFileStrict' (_sh_dir sh </> "session.json")
+        :: IO (Either String SessionMeta)
+      _sm_source onDisk `shouldBe` Just src
+      _th_close (_sh_transcript sh)
+
+    it "leaves _sm_source unchanged and does NOT save when already Just" $ do
+      -- Build a SessionHandle whose _sh_save increments a counter, so we can
+      -- assert the "iff changed" optimization: the second call must not save.
+      saveCount <- newIORef (0 :: Int)
+      let firstSrc  = mkMessageSource CkSignal (Just (UserId "+15550000001")) mempty
+          secondSrc = mkMessageSource CkTelegram (Just (UserId "99999")) mempty
+      metaRef <- newIORef ((mkMeta "src-2" t0) { _sm_source = Nothing })
+      noOp <- mkNoOpSessionHandle
+      let sh = SessionHandle
+            { _sh_meta       = metaRef
+            , _sh_transcript = _sh_transcript noOp
+            , _sh_dir        = ""
+            , _sh_save       = modifyIORef' saveCount (+ 1)
+            }
+      -- First set: Nothing -> Just, must save once.
+      setSourceIfAbsent sh firstSrc
+      readIORef saveCount `shouldReturn` 1
+      _sm_source <$> readIORef metaRef `shouldReturn` Just firstSrc
+      -- Second set with a DIFFERENT source: already Just, must NOT save and
+      -- must NOT overwrite.
+      setSourceIfAbsent sh secondSrc
+      readIORef saveCount `shouldReturn` 1
+      _sm_source <$> readIORef metaRef `shouldReturn` Just firstSrc
 
   describe "setArchived" $ do
     it "writes the archive flag back to session.json without touching anything else" $ withTmp $ \base -> do

--- a/test/Session/TypesSpec.hs
+++ b/test/Session/TypesSpec.hs
@@ -105,6 +105,7 @@ spec = do
           , _sm_archived          = False
           , _sm_description       = Nothing
           , _sm_autoSummary       = Nothing
+          , _sm_source            = Nothing
           }
 
     it "round-trips a fully-populated SessionMeta" $
@@ -126,6 +127,45 @@ spec = do
     it "round-trips bootstrap_consumed = True" $ do
       let s = sample { _sm_bootstrapConsumed = True }
       Aeson.decode (Aeson.encode s) `shouldBe` Just s
+
+    it "round-trips a SessionMeta with a Just _sm_source" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+          s   = sample { _sm_source = Just src }
+      Aeson.decode (Aeson.encode s) `shouldBe` Just s
+
+    it "round-trips a SessionMeta with a CkOther source channel" $ do
+      let src = mkMessageSource (CkOther "matrix") (Just (UserId "@bob:matrix.org")) mempty
+          s   = sample { _sm_source = Just src }
+      Aeson.decode (Aeson.encode s) `shouldBe` Just s
+
+    it "decodes legacy JSON without a \"source\" key as _sm_source == Nothing" $ do
+      -- Encode a sample that HAS no source, decode it back, and confirm the
+      -- field is Nothing — i.e. omission round-trips to Nothing, the same
+      -- shape a legacy session.json (written before _sm_source existed)
+      -- produces.
+      let s = sample { _sm_source = Nothing }
+      case Aeson.decode (Aeson.encode s) :: Maybe SessionMeta of
+        Just m  -> _sm_source m `shouldBe` Nothing
+        Nothing -> expectationFailure "decode of source-less SessionMeta failed"
+
+    it "ToJSON OMITS the \"source\" key when _sm_source is Nothing" $ do
+      let s = sample { _sm_source = Nothing }
+          obj = Aeson.decode (Aeson.encode s) :: Maybe Aeson.Object
+      case obj of
+        Just o -> case Aeson.parseMaybe (Aeson..: "source") o :: Maybe Aeson.Value of
+          Nothing -> pure ()
+          Just _  -> expectationFailure "'source' key should be absent when _sm_source is Nothing"
+        Nothing -> expectationFailure "Failed to decode SessionMeta as Object"
+
+    it "ToJSON EMITS the \"source\" key when _sm_source is Just" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+          s   = sample { _sm_source = Just src }
+          obj = Aeson.decode (Aeson.encode s) :: Maybe Aeson.Object
+      case obj of
+        Just o -> case Aeson.parseMaybe (Aeson..: "source") o :: Maybe Aeson.Value of
+          Just _  -> pure ()
+          Nothing -> expectationFailure "'source' key should be present when _sm_source is Just"
+        Nothing -> expectationFailure "Failed to decode SessionMeta as Object"
 
     it "defaultTarget SkProvider == TargetProvider" $
       defaultTarget (SkProvider (ProviderSpec (ProviderId "anthropic") (ModelId "m") Nothing)) `shouldBe` TargetProvider
@@ -215,6 +255,7 @@ spec = do
             , _sm_archived          = False
             , _sm_description       = Nothing
             , _sm_autoSummary       = Nothing
+            , _sm_source            = Nothing
             }
       case Aeson.decode (Aeson.encode meta) :: Maybe SessionMeta of
         Nothing -> expectationFailure "round-trip decode failed"
@@ -237,6 +278,7 @@ spec = do
             , _sm_archived          = False
             , _sm_description       = Nothing
             , _sm_autoSummary       = Nothing
+            , _sm_source            = Nothing
             }
           encoded = Aeson.encode meta
           obj = Aeson.decode encoded :: Maybe Aeson.Object

--- a/test/Test/Fake/ChannelHandle.hs
+++ b/test/Test/Fake/ChannelHandle.hs
@@ -97,7 +97,9 @@ feedIncoming fch im = atomically (writeTQueue (_fch_incoming fch) im)
 -- | Convenience: inject an incoming message from a given user with the
 -- supplied text.
 feedIncomingFromUser :: FakeChannel -> UserId -> Text -> IO ()
-feedIncomingFromUser fch uid t = feedIncoming fch (IncomingMessage uid t)
+feedIncomingFromUser fch uid t =
+  feedIncoming fch
+    (IncomingMessage (mkMessageSource (CkOther "test") (Just uid) mempty) t)
 
 -- | Atomically drain all recorded events (oldest-first) and clear the log.
 drainEvents :: FakeChannel -> IO [(UTCTime, FakeChannelEvent)]

--- a/test/Transcript/ProviderSpec.hs
+++ b/test/Transcript/ProviderSpec.hs
@@ -60,6 +60,12 @@ testRespNoUsage = CompletionResponse
   , _crsp_usage   = Nothing
   }
 
+-- | A concrete message source used by the source-tagging tests. The user
+-- id is a recognizable phone number so omit-broadcast assertions elsewhere
+-- can grep for it.
+testSource :: MessageSource
+testSource = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+
 -- | Safe access to list elements by index, failing with a clear message.
 entryAt :: [TranscriptEntry] -> Int -> IO TranscriptEntry
 entryAt entries i
@@ -81,7 +87,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         resp <- complete wrapped testReq
         resp `shouldBe` testResp
         _th_close th
@@ -95,7 +101,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -111,7 +117,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -126,7 +132,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "my-source" inner
+            wrapped = mkTranscriptProvider th "my-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -177,7 +183,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -203,7 +209,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -218,7 +224,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testRespNoUsage)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -236,7 +242,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (CannedProvider testResp)
-            wrapped = mkTranscriptProvider th "test-source" inner
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
         _ <- complete wrapped testReq
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -254,7 +260,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (StreamingMockProvider testResp)
-            wrapped = mkTranscriptProvider th "stream-source" inner
+            wrapped = mkTranscriptProvider th "stream-source" Nothing inner
         eventsRef <- newIORef ([] :: [StreamEvent])
         completeStream wrapped testReq (\ev -> modifyIORef' eventsRef (++ [ev]))
         _th_flush th
@@ -271,7 +277,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (StreamingMockProvider testResp)
-            wrapped = mkTranscriptProvider th "stream-source" inner
+            wrapped = mkTranscriptProvider th "stream-source" Nothing inner
         eventsRef <- newIORef ([] :: [StreamEvent])
         completeStream wrapped testReq (\ev -> modifyIORef' eventsRef (++ [ev]))
         events <- readIORef eventsRef
@@ -284,7 +290,7 @@ spec = do
         let path = tmpDir </> "transcript.jsonl"
         th <- mkFileTranscriptHandle mkNoOpLogHandle path
         let inner = MkProvider (StreamingMockProvider testResp)
-            wrapped = mkTranscriptProvider th "stream-source" inner
+            wrapped = mkTranscriptProvider th "stream-source" Nothing inner
         completeStream wrapped testReq (\_ -> pure ())
         _th_flush th
         entries <- _th_query th emptyFilter
@@ -292,6 +298,93 @@ spec = do
         let meta = _te_metadata respEntry
         Map.lookup "input_tokens" meta `shouldBe` Just (Aeson.Number 42)
         Map.lookup "output_tokens" meta `shouldBe` Just (Aeson.Number 17)
+        _th_close th
+
+  ---------------------------------------------------------------------------
+  -- WU4: per-message sender written to Request metadata under "source".
+  --   - present on Request via complete AND completeStream
+  --   - Nothing ⇒ no "source" key
+  --   - Response entries are NEVER tagged
+  ---------------------------------------------------------------------------
+  describe "WU4 source metadata" $ do
+    it "tags the Request entry with source via complete" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (CannedProvider testResp)
+            wrapped = mkTranscriptProvider th "test-source" (Just testSource) inner
+        _ <- complete wrapped testReq
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        reqEntry <- entryAt entries 0
+        Map.lookup "source" (_te_metadata reqEntry)
+          `shouldBe` Just (Aeson.toJSON testSource)
+        _th_close th
+
+    it "tags the Request entry with source via completeStream" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (StreamingMockProvider testResp)
+            wrapped = mkTranscriptProvider th "stream-source" (Just testSource) inner
+        completeStream wrapped testReq (\_ -> pure ())
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        reqEntry <- entryAt entries 0
+        Map.lookup "source" (_te_metadata reqEntry)
+          `shouldBe` Just (Aeson.toJSON testSource)
+        _th_close th
+
+    it "omits the source key on Request when Nothing (complete)" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (CannedProvider testResp)
+            wrapped = mkTranscriptProvider th "test-source" Nothing inner
+        _ <- complete wrapped testReq
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        reqEntry <- entryAt entries 0
+        Map.lookup "source" (_te_metadata reqEntry) `shouldBe` Nothing
+        _th_close th
+
+    it "omits the source key on Request when Nothing (completeStream)" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (StreamingMockProvider testResp)
+            wrapped = mkTranscriptProvider th "stream-source" Nothing inner
+        completeStream wrapped testReq (\_ -> pure ())
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        reqEntry <- entryAt entries 0
+        Map.lookup "source" (_te_metadata reqEntry) `shouldBe` Nothing
+        _th_close th
+
+    it "never tags the Response entry with source (complete)" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (CannedProvider testResp)
+            wrapped = mkTranscriptProvider th "test-source" (Just testSource) inner
+        _ <- complete wrapped testReq
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        respEntry <- entryAt entries 1
+        Map.lookup "source" (_te_metadata respEntry) `shouldBe` Nothing
+        _th_close th
+
+    it "never tags the Response entry with source (completeStream)" $ do
+      withSystemTempDirectory "transcript-provider-test" $ \tmpDir -> do
+        let path = tmpDir </> "transcript.jsonl"
+        th <- mkFileTranscriptHandle mkNoOpLogHandle path
+        let inner = MkProvider (StreamingMockProvider testResp)
+            wrapped = mkTranscriptProvider th "stream-source" (Just testSource) inner
+        completeStream wrapped testReq (\_ -> pure ())
+        _th_flush th
+        entries <- _th_query th emptyFilter
+        respEntry <- entryAt entries 1
+        Map.lookup "source" (_te_metadata respEntry) `shouldBe` Nothing
         _th_close th
 
 -- Helper to convert strict ByteString to lazy


### PR DESCRIPTION
## Summary

Records **where each message came from**. Adds a structured, extensible `MessageSource` (typed channel kind + optional user id + open key/value fields) captured at the channel boundary, persisted **both** at session level (`session.json`) and per-message (`transcript.jsonl`), surfaced in `/status`, and **never broadcast**.

Implements beads **pureclaw-dte** via the full metaswarm pipeline: design re-confirmation (Architect + CTO) → Plan Review Gate (3/3 PASS) → orchestrated execution (4-phase loop per WU) → final comprehensive review (PASS).

## Work units

| WU | Commit | What landed |
|----|--------|-------------|
| WU1 | `a994480` | `MessageSource`/`ChannelKind` in `Core.Types` + hand-written JSON codec + `mkMessageSource` normalization + shadowing guard |
| WU2 | `8ef56fb` | `_im_source` replaces `_im_userId` on `IncomingMessage`; `imUserId` accessor preserves the `UserId ""` sentinel; channels populate via `mkMessageSource`; dispatcher keys on `imUserId` |
| WU3 | `4ad4056` | `_sm_source` on `SessionMeta` (emit-when-Just, tolerant legacy decode); `setSourceIfAbsent` set-once helper; Loop captures origin once/message (incl. empty); `/status` Source line |
| WU4 | `bd2826d` | `mkTranscriptProvider` gains a `Maybe MessageSource` param → `_te_metadata."source"` on Request entries (both `complete` + `completeStream`); foreground=Just, /bg + web=Nothing |
| WU5 | `0a014fe` | End-to-end Signal DM integration test (phone + uuid in **both** files on disk) + coverage-gap closure |

## Design & invariants

- **Dual storage:** `_sm_source` = session origin (set-once, first sender); `transcript.jsonl` `metadata.source` = per-message truth. They legitimately diverge on a resumed session with a new sender.
- **Trust boundary (load-bearing):** `MessageSource` is *attacker-asserted provenance* and is **never** used for authz/routing — dispatch still keys on `imUserId` against the allow-list. Verified by a DispatcherSpec test asserting an empty `UserId` never matches a populated allow-list.
- **Privacy (load-bearing):** the sender id is written to `_te_metadata` (disk, server-side only). Both broadcast projections (`toEntryInfo`, `toTranscriptEntryInfo`) drop the metadata map, so it is **never broadcast** — asserted by WS + HTTP omit tests.
- **Normalization:** `mkMessageSource` strips control chars and bounds length (`maxSourceLen=512`) on the user id and every JSON string leaf in fields (incl. nested), and folds `CkOther "signal"` → `CkSignal`.
- **Backward compatible:** legacy `session.json` (no `source`) and legacy `transcript.jsonl` (no `metadata.source`) decode cleanly; new writes are readable by old readers.

## Testing

- `nix develop . --command cabal test` → **2222 examples, 0 failures, 9 pending**
- `-Wall -Werror` clean · hlint No hints · pty firewall OK
- `cabal test --enable-coverage` passes (95% target; no new modules → no new staged waivers; all new executable code exercised)
- Each WU passed an independent fresh adversarial review; the final cross-unit review confirmed both invariants end-to-end (one passing via production-code falsification).

## Follow-up

`pureclaw-6nr` — `SessionMeta._sm_source` could leak via the `AkSessionCreated` wholesale broadcast *if* the deferred frontend session-origin capture is ever wired. Safe today (publisher keeps `_sm_source = Nothing`); tracked before that follow-up lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)