### PR TITLE
Change session ID scheme to timestamp-first (#69)

### DIFF
--- a/scripts/migrate-session-ids.sh
+++ b/scripts/migrate-session-ids.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# migrate-session-ids.sh — migrate existing session directories from the
+# legacy "<prefix>-<timestamp>" naming scheme to the new
+# "<timestamp>-<prefix>" scheme (GitHub issue #69).
+#
+# The timestamp segment is always "YYYYMMDD-HHMMSS-mmm" (8 digits, 6
+# digits, 3 digits, hyphen-separated). Under the OLD scheme it trails an
+# optional prefix; under the NEW scheme it leads. Prefix-less sessions
+# (just the bare timestamp) are identical in both schemes and are left
+# untouched.
+#
+# The script is idempotent: directories already in the new scheme, and
+# names it does not recognise, are skipped. Re-running it is a no-op.
+#
+# Usage:
+#   scripts/migrate-session-ids.sh [--dry-run] [SESSIONS_DIR]
+#
+#   --dry-run     Print the renames that WOULD happen; change nothing.
+#   SESSIONS_DIR  Directory holding the per-session subdirectories.
+#                 Defaults to "$HOME/.pureclaw/sessions".
+#
+# Exit status:
+#   0  success (including "nothing to do")
+#   1  usage error or a rename failed
+#   2  sessions directory does not exist
+
+set -euo pipefail
+
+# --- Argument parsing -------------------------------------------------
+
+DRY_RUN=0
+SESSIONS_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    --*)
+      echo "error: unknown option '$1'" >&2
+      exit 1
+      ;;
+    *)
+      if [ -n "$SESSIONS_DIR" ]; then
+        echo "error: unexpected extra argument '$1'" >&2
+        exit 1
+      fi
+      SESSIONS_DIR="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$SESSIONS_DIR" ]; then
+  SESSIONS_DIR="${HOME}/.pureclaw/sessions"
+fi
+
+if [ ! -d "$SESSIONS_DIR" ]; then
+  echo "sessions directory does not exist: $SESSIONS_DIR" >&2
+  exit 2
+fi
+
+# --- Migration --------------------------------------------------------
+
+# A bare timestamp: YYYYMMDD-HHMMSS-mmm (anchored).
+TS_RE='[0-9]{8}-[0-9]{6}-[0-9]{3}'
+# New scheme: <timestamp>-<prefix>  (timestamp leads, prefix follows).
+NEW_RE="^${TS_RE}-.+$"
+# Bare timestamp, no prefix (identical in both schemes).
+BARE_RE="^${TS_RE}$"
+# Old scheme: <prefix>-<timestamp>  (prefix leads, timestamp trails).
+# The prefix is captured greedily; the timestamp is the final segment.
+OLD_RE="^(.+)-(${TS_RE})$"
+
+renamed=0
+skipped=0
+
+# Iterate over immediate subdirectories only.
+for entry in "$SESSIONS_DIR"/*; do
+  [ -d "$entry" ] || continue
+  name="$(basename "$entry")"
+
+  # Already new scheme, or a bare timestamp: nothing to do.
+  if [[ "$name" =~ $NEW_RE ]] || [[ "$name" =~ $BARE_RE ]]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  # Old scheme: split prefix and trailing timestamp.
+  if [[ "$name" =~ $OLD_RE ]]; then
+    prefix="${BASH_REMATCH[1]}"
+    timestamp="${BASH_REMATCH[2]}"
+    newname="${timestamp}-${prefix}"
+    target="$SESSIONS_DIR/$newname"
+
+    if [ -e "$target" ]; then
+      echo "warn: target already exists, skipping: $name -> $newname" >&2
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "would rename: $name -> $newname"
+    else
+      mv -- "$entry" "$target"
+      echo "renamed: $name -> $newname"
+    fi
+    renamed=$((renamed + 1))
+    continue
+  fi
+
+  # Unrecognised name: leave it alone.
+  echo "warn: unrecognised session directory, skipping: $name" >&2
+  skipped=$((skipped + 1))
+done
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "dry run: $renamed would be renamed, $skipped skipped"
+else
+  echo "done: $renamed renamed, $skipped skipped"
+fi

--- a/scripts/migrate-session-ids.sh
+++ b/scripts/migrate-session-ids.sh
@@ -4,25 +4,38 @@
 # legacy "<prefix>-<timestamp>" naming scheme to the new
 # "<timestamp>-<prefix>" scheme (GitHub issue #69).
 #
+# A session is stored as a directory whose NAME equals the session's "id"
+# field in its session.json. PureClaw relies on that invariant: transcript
+# paths, the recent/archived listings, resume, archive, and last-active
+# updates all derive the on-disk path from the "id" field. So this script
+# does TWO things for every session:
+#
+#   1. Renames the directory  <prefix>-<timestamp>  ->  <timestamp>-<prefix>
+#   2. Rewrites session.json's "id" field to match the directory name.
+#
+# Step 2 also REPAIRS sessions that were renamed by an earlier, id-unaware
+# version of this script (directory already new, but "id" still old): the
+# script reconciles every session's "id" to its directory name regardless
+# of whether a rename was needed this run.
+#
 # The timestamp segment is always "YYYYMMDD-HHMMSS-mmm" (8 digits, 6
 # digits, 3 digits, hyphen-separated). Under the OLD scheme it trails an
 # optional prefix; under the NEW scheme it leads. Prefix-less sessions
-# (just the bare timestamp) are identical in both schemes and are left
-# untouched.
+# (just the bare timestamp) have the same name in both schemes and are
+# only ever touched if their "id" field needs reconciling.
 #
-# The script is idempotent: directories already in the new scheme, and
-# names it does not recognise, are skipped. Re-running it is a no-op.
+# The script is idempotent: a second run changes nothing.
 #
 # Usage:
 #   scripts/migrate-session-ids.sh [--dry-run] [SESSIONS_DIR]
 #
-#   --dry-run     Print the renames that WOULD happen; change nothing.
+#   --dry-run     Print what WOULD change; modify nothing.
 #   SESSIONS_DIR  Directory holding the per-session subdirectories.
 #                 Defaults to "$HOME/.pureclaw/sessions".
 #
 # Exit status:
 #   0  success (including "nothing to do")
-#   1  usage error or a rename failed
+#   1  usage error or an operation failed
 #   2  sessions directory does not exist
 
 set -euo pipefail
@@ -38,7 +51,7 @@ while [ $# -gt 0 ]; do
       DRY_RUN=1
       ;;
     -h|--help)
-      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     --*)
@@ -65,62 +78,119 @@ if [ ! -d "$SESSIONS_DIR" ]; then
   exit 2
 fi
 
+# jq gives us a safe JSON edit; fall back to a targeted sed otherwise.
+HAVE_JQ=0
+if command -v jq >/dev/null 2>&1; then
+  HAVE_JQ=1
+fi
+
+# --- Helpers ----------------------------------------------------------
+
+# Read the current "id" field from a session.json. Empty if absent.
+read_session_id() {
+  local meta="$1"
+  if [ "$HAVE_JQ" -eq 1 ]; then
+    jq -r '.id // empty' "$meta" 2>/dev/null || true
+  else
+    # Compact Aeson output: "id":"<value>". Tolerate optional spaces.
+    sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$meta" | head -n1
+  fi
+}
+
+# Reconcile session.json's "id" to the directory name. No-op when the
+# field already matches or there is no session.json.
+ids_updated=0
+reconcile_id() {
+  local dir="$1" wantid="$2"
+  local meta="$dir/session.json"
+  [ -f "$meta" ] || return 0
+
+  local curid
+  curid="$(read_session_id "$meta")"
+  [ "$curid" = "$wantid" ] && return 0
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "would update id: $curid -> $wantid"
+    ids_updated=$((ids_updated + 1))
+    return 0
+  fi
+
+  local tmp="$meta.migrate.tmp"
+  if [ "$HAVE_JQ" -eq 1 ]; then
+    jq --arg id "$wantid" '.id = $id' "$meta" > "$tmp"
+  else
+    sed -E "s|\"id\"[[:space:]]*:[[:space:]]*\"[^\"]*\"|\"id\":\"${wantid}\"|" "$meta" > "$tmp"
+  fi
+  mv -- "$tmp" "$meta"
+  echo "updated id: $curid -> $wantid"
+  ids_updated=$((ids_updated + 1))
+}
+
 # --- Migration --------------------------------------------------------
 
 # A bare timestamp: YYYYMMDD-HHMMSS-mmm (anchored).
 TS_RE='[0-9]{8}-[0-9]{6}-[0-9]{3}'
 # New scheme: <timestamp>-<prefix>  (timestamp leads, prefix follows).
 NEW_RE="^${TS_RE}-.+$"
-# Bare timestamp, no prefix (identical in both schemes).
+# Bare timestamp, no prefix (same name in both schemes).
 BARE_RE="^${TS_RE}$"
 # Old scheme: <prefix>-<timestamp>  (prefix leads, timestamp trails).
-# The prefix is captured greedily; the timestamp is the final segment.
 OLD_RE="^(.+)-(${TS_RE})$"
 
 renamed=0
 skipped=0
 
-# Iterate over immediate subdirectories only.
 for entry in "$SESSIONS_DIR"/*; do
   [ -d "$entry" ] || continue
   name="$(basename "$entry")"
+  meta="$entry/session.json"
 
-  # Already new scheme, or a bare timestamp: nothing to do.
+  # Decide the directory's target name.
   if [[ "$name" =~ $NEW_RE ]] || [[ "$name" =~ $BARE_RE ]]; then
-    skipped=$((skipped + 1))
-    continue
-  fi
-
-  # Old scheme: split prefix and trailing timestamp.
-  if [[ "$name" =~ $OLD_RE ]]; then
+    # Already new / bare: keep the name; we still reconcile the id below.
+    target="$name"
+  elif [[ "$name" =~ $OLD_RE ]]; then
     prefix="${BASH_REMATCH[1]}"
     timestamp="${BASH_REMATCH[2]}"
-    newname="${timestamp}-${prefix}"
-    target="$SESSIONS_DIR/$newname"
-
-    if [ -e "$target" ]; then
-      echo "warn: target already exists, skipping: $name -> $newname" >&2
+    target="${timestamp}-${prefix}"
+  else
+    # Unrecognised name: only a real session (has session.json) is worth
+    # reconciling; otherwise leave it entirely alone.
+    if [ ! -f "$meta" ]; then
+      echo "warn: unrecognised directory, skipping: $name" >&2
       skipped=$((skipped + 1))
       continue
     fi
-
-    if [ "$DRY_RUN" -eq 1 ]; then
-      echo "would rename: $name -> $newname"
-    else
-      mv -- "$entry" "$target"
-      echo "renamed: $name -> $newname"
-    fi
-    renamed=$((renamed + 1))
-    continue
+    target="$name"
   fi
 
-  # Unrecognised name: leave it alone.
-  echo "warn: unrecognised session directory, skipping: $name" >&2
-  skipped=$((skipped + 1))
+  # Rename the directory when the scheme changed.
+  if [ "$target" != "$name" ]; then
+    dest="$SESSIONS_DIR/$target"
+    if [ -e "$dest" ]; then
+      echo "warn: target already exists, skipping rename: $name -> $target" >&2
+      skipped=$((skipped + 1))
+      # Still attempt to reconcile the id of the existing dir in place.
+      reconcile_id "$entry" "$name"
+      continue
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "would rename: $name -> $target"
+    else
+      mv -- "$entry" "$dest"
+      echo "renamed: $name -> $target"
+      entry="$dest"
+      meta="$entry/session.json"
+    fi
+    renamed=$((renamed + 1))
+  fi
+
+  # Reconcile session.json's "id" to the (possibly new) directory name.
+  reconcile_id "$entry" "$target"
 done
 
 if [ "$DRY_RUN" -eq 1 ]; then
-  echo "dry run: $renamed would be renamed, $skipped skipped"
+  echo "dry run: $renamed dir(s) would be renamed, $ids_updated id(s) would be updated, $skipped skipped"
 else
-  echo "done: $renamed renamed, $skipped skipped"
+  echo "done: $renamed renamed, $ids_updated id(s) updated, $skipped skipped"
 fi

--- a/scripts/test-migrate-session-ids.sh
+++ b/scripts/test-migrate-session-ids.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# test-migrate-session-ids.sh — shell-level test for
+# scripts/migrate-session-ids.sh (GitHub issue #69).
+#
+# Builds a throwaway sessions tree in a temp dir, runs the migration, and
+# asserts on the resulting directory names and on idempotency / dry-run
+# behaviour. Exits 0 if all assertions pass, 1 otherwise.
+#
+# Run from anywhere:
+#   bash scripts/test-migrate-session-ids.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MIGRATE="$ROOT/scripts/migrate-session-ids.sh"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/pureclaw-migrate-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+SESSIONS="$TMP/sessions"
+mkdir -p "$SESSIONS"
+
+fail=0
+check() {
+  # check <description> <condition-already-evaluated:0|1>
+  if [ "$2" -eq 0 ]; then
+    echo "PASS: $1"
+  else
+    echo "FAIL: $1" >&2
+    fail=1
+  fi
+}
+
+exists()      { [ -d "$SESSIONS/$1" ] && return 0 || return 1; }
+not_exists()  { [ ! -e "$SESSIONS/$1" ] && return 0 || return 1; }
+
+# --- Fixture ----------------------------------------------------------
+# Old scheme, simple prefix.
+mkdir -p "$SESSIONS/zoe-20250325-143045-678"
+echo '{"a":1}' > "$SESSIONS/zoe-20250325-143045-678/transcript.jsonl"
+# Old scheme, hyphenated prefix.
+mkdir -p "$SESSIONS/ops-team-20250325-143045-679"
+# Bare timestamp, no prefix (identical in both schemes).
+mkdir -p "$SESSIONS/20250325-143045-680"
+# Already new scheme.
+mkdir -p "$SESSIONS/20250325-143045-681-bob"
+# Unrecognised name.
+mkdir -p "$SESSIONS/totally-random"
+# A stray file (not a directory) must be ignored.
+touch "$SESSIONS/loose-file.txt"
+
+# --- Dry run changes nothing ------------------------------------------
+out="$(bash "$MIGRATE" --dry-run "$SESSIONS")"
+echo "$out" | grep -q "would rename: zoe-20250325-143045-678 -> 20250325-143045-678-zoe"
+check "dry-run reports the simple rename" $?
+exists "zoe-20250325-143045-678"; check "dry-run does not actually rename" $?
+
+# --- Real migration ---------------------------------------------------
+bash "$MIGRATE" "$SESSIONS" >/dev/null
+
+exists "20250325-143045-678-zoe";       check "simple prefix moved to suffix" $?
+not_exists "zoe-20250325-143045-678";   check "old simple dir is gone" $?
+exists "20250325-143045-679-ops-team";  check "hyphenated prefix preserved & moved" $?
+not_exists "ops-team-20250325-143045-679"; check "old hyphenated dir is gone" $?
+exists "20250325-143045-680";           check "bare timestamp untouched" $?
+exists "20250325-143045-681-bob";       check "already-new dir untouched" $?
+exists "totally-random";                check "unrecognised dir untouched" $?
+
+# Transcript content travels with its directory.
+content="$(cat "$SESSIONS/20250325-143045-678-zoe/transcript.jsonl" 2>/dev/null || echo MISSING)"
+[ "$content" = '{"a":1}' ]; check "transcript file moved with the session dir" $?
+
+# --- Idempotency ------------------------------------------------------
+before="$(ls "$SESSIONS" | sort)"
+bash "$MIGRATE" "$SESSIONS" >/dev/null
+after="$(ls "$SESSIONS" | sort)"
+[ "$before" = "$after" ]; check "second run is a no-op (idempotent)" $?
+
+# --- Collision safety -------------------------------------------------
+# If the new name already exists, the old dir must be left in place.
+mkdir -p "$SESSIONS/alice-20250325-143045-682"
+mkdir -p "$SESSIONS/20250325-143045-682-alice"
+bash "$MIGRATE" "$SESSIONS" >/dev/null 2>&1
+exists "alice-20250325-143045-682"; check "collision leaves old dir untouched" $?
+
+# --- Missing directory exits 2 ----------------------------------------
+set +e
+bash "$MIGRATE" "$TMP/does-not-exist" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 2 ]; check "missing sessions dir exits 2" $?
+
+# --- Unknown option exits 1 -------------------------------------------
+set +e
+bash "$MIGRATE" --bogus >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 1 ]; check "unknown option exits 1" $?
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "ALL PASS"
+  exit 0
+else
+  echo "SOME TESTS FAILED" >&2
+  exit 1
+fi

--- a/scripts/test-migrate-session-ids.sh
+++ b/scripts/test-migrate-session-ids.sh
@@ -4,8 +4,9 @@
 # scripts/migrate-session-ids.sh (GitHub issue #69).
 #
 # Builds a throwaway sessions tree in a temp dir, runs the migration, and
-# asserts on the resulting directory names and on idempotency / dry-run
-# behaviour. Exits 0 if all assertions pass, 1 otherwise.
+# asserts on directory names, on the reconciled session.json "id" field
+# (the directory-name == id invariant), and on idempotency / dry-run /
+# repair behaviour. Exits 0 if all assertions pass, 1 otherwise.
 #
 # Run from anywhere:
 #   bash scripts/test-migrate-session-ids.sh
@@ -35,17 +36,36 @@ check() {
 exists()      { [ -d "$SESSIONS/$1" ] && return 0 || return 1; }
 not_exists()  { [ ! -e "$SESSIONS/$1" ] && return 0 || return 1; }
 
+# Read the "id" field from a session's session.json (jq if available).
+read_id() {
+  local meta="$SESSIONS/$1/session.json"
+  if command -v jq >/dev/null 2>&1; then
+    jq -r '.id // empty' "$meta"
+  else
+    sed -nE 's/.*"id"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$meta" | head -n1
+  fi
+}
+
+# Write a minimal session.json with the given "id".
+mk_session() {
+  local dir="$1" id="$2"
+  mkdir -p "$SESSIONS/$dir"
+  printf '{"id":"%s","model":"m","channel":"cli"}\n' "$id" \
+    > "$SESSIONS/$dir/session.json"
+}
+
 # --- Fixture ----------------------------------------------------------
-# Old scheme, simple prefix.
-mkdir -p "$SESSIONS/zoe-20250325-143045-678"
+# Old scheme, simple prefix (dir name == old id).
+mk_session "zoe-20250325-143045-678" "zoe-20250325-143045-678"
 echo '{"a":1}' > "$SESSIONS/zoe-20250325-143045-678/transcript.jsonl"
 # Old scheme, hyphenated prefix.
-mkdir -p "$SESSIONS/ops-team-20250325-143045-679"
+mk_session "ops-team-20250325-143045-679" "ops-team-20250325-143045-679"
 # Bare timestamp, no prefix (identical in both schemes).
-mkdir -p "$SESSIONS/20250325-143045-680"
-# Already new scheme.
-mkdir -p "$SESSIONS/20250325-143045-681-bob"
-# Unrecognised name.
+mk_session "20250325-143045-680" "20250325-143045-680"
+# Already-renamed by an id-unaware run: dir is NEW but "id" is STALE (old).
+# This is the exact broken state the repair pass must fix.
+mk_session "20250325-143045-681-bob" "bob-20250325-143045-681"
+# Unrecognised dir WITHOUT session.json (stray) — must be ignored.
 mkdir -p "$SESSIONS/totally-random"
 # A stray file (not a directory) must be ignored.
 touch "$SESSIONS/loose-file.txt"
@@ -54,7 +74,11 @@ touch "$SESSIONS/loose-file.txt"
 out="$(bash "$MIGRATE" --dry-run "$SESSIONS")"
 echo "$out" | grep -q "would rename: zoe-20250325-143045-678 -> 20250325-143045-678-zoe"
 check "dry-run reports the simple rename" $?
+echo "$out" | grep -q "would update id: bob-20250325-143045-681 -> 20250325-143045-681-bob"
+check "dry-run reports the stale-id repair" $?
 exists "zoe-20250325-143045-678"; check "dry-run does not actually rename" $?
+[ "$(read_id 20250325-143045-681-bob)" = "bob-20250325-143045-681" ]
+check "dry-run does not actually rewrite id" $?
 
 # --- Real migration ---------------------------------------------------
 bash "$MIGRATE" "$SESSIONS" >/dev/null
@@ -62,25 +86,39 @@ bash "$MIGRATE" "$SESSIONS" >/dev/null
 exists "20250325-143045-678-zoe";       check "simple prefix moved to suffix" $?
 not_exists "zoe-20250325-143045-678";   check "old simple dir is gone" $?
 exists "20250325-143045-679-ops-team";  check "hyphenated prefix preserved & moved" $?
-not_exists "ops-team-20250325-143045-679"; check "old hyphenated dir is gone" $?
-exists "20250325-143045-680";           check "bare timestamp untouched" $?
-exists "20250325-143045-681-bob";       check "already-new dir untouched" $?
-exists "totally-random";                check "unrecognised dir untouched" $?
+
+# The invariant: every session's dir name == its session.json "id".
+[ "$(read_id 20250325-143045-678-zoe)" = "20250325-143045-678-zoe" ]
+check "renamed dir: id field reconciled to dir name" $?
+[ "$(read_id 20250325-143045-679-ops-team)" = "20250325-143045-679-ops-team" ]
+check "hyphenated dir: id field reconciled to dir name" $?
+[ "$(read_id 20250325-143045-680)" = "20250325-143045-680" ]
+check "bare timestamp: id field unchanged & correct" $?
+# The repair case — dir was already new, id was stale.
+[ "$(read_id 20250325-143045-681-bob)" = "20250325-143045-681-bob" ]
+check "already-renamed dir: stale id repaired to dir name" $?
+exists "totally-random";                check "stray dir untouched" $?
 
 # Transcript content travels with its directory.
 content="$(cat "$SESSIONS/20250325-143045-678-zoe/transcript.jsonl" 2>/dev/null || echo MISSING)"
 [ "$content" = '{"a":1}' ]; check "transcript file moved with the session dir" $?
 
+# Other session.json fields are preserved through the id rewrite.
+model="$( (command -v jq >/dev/null 2>&1 && jq -r '.model' "$SESSIONS/20250325-143045-678-zoe/session.json") || echo "" )"
+if command -v jq >/dev/null 2>&1; then
+  [ "$model" = "m" ]; check "other session.json fields preserved" $?
+fi
+
 # --- Idempotency ------------------------------------------------------
-before="$(ls "$SESSIONS" | sort)"
+before="$(ls "$SESSIONS" | sort); $(read_id 20250325-143045-681-bob)"
 bash "$MIGRATE" "$SESSIONS" >/dev/null
-after="$(ls "$SESSIONS" | sort)"
+after="$(ls "$SESSIONS" | sort); $(read_id 20250325-143045-681-bob)"
 [ "$before" = "$after" ]; check "second run is a no-op (idempotent)" $?
 
 # --- Collision safety -------------------------------------------------
 # If the new name already exists, the old dir must be left in place.
-mkdir -p "$SESSIONS/alice-20250325-143045-682"
-mkdir -p "$SESSIONS/20250325-143045-682-alice"
+mk_session "alice-20250325-143045-682" "alice-20250325-143045-682"
+mk_session "20250325-143045-682-alice" "20250325-143045-682-alice"
 bash "$MIGRATE" "$SESSIONS" >/dev/null 2>&1
 exists "alice-20250325-143045-682"; check "collision leaves old dir untouched" $?
 

--- a/src/PureClaw/Session/Types.hs
+++ b/src/PureClaw/Session/Types.hs
@@ -97,8 +97,9 @@ instance Aeson.FromJSON SessionPrefix where
 
 -- | Pure session ID generator. Encodes a 'UTCTime' as
 -- @YYYYMMDD-HHMMSS-mmm@ (milliseconds zero-padded to three digits)
--- and prefixes it with the optional 'SessionPrefix' separated by a
--- hyphen.
+-- and appends the optional 'SessionPrefix' after it, separated by a
+-- hyphen. The timestamp leads so that lexicographic sorting of session
+-- IDs (and their on-disk directory names) is also chronological.
 newSessionId :: Maybe SessionPrefix -> UTCTime -> SessionId
 newSessionId mPrefix time =
   let hms     = formatTime defaultTimeLocale "%Y%m%d-%H%M%S" time
@@ -108,7 +109,7 @@ newSessionId mPrefix time =
       timeStr = T.pack hms <> "-" <> T.justifyRight 3 '0' (T.pack (show millis))
       full    = case mPrefix of
         Nothing -> timeStr
-        Just p  -> unSessionPrefix p <> "-" <> timeStr
+        Just p  -> timeStr <> "-" <> unSessionPrefix p
   in SessionId full
 
 -- | Map a 'SessionKind' to its corresponding 'MessageTarget'. Pure helper

--- a/test/Integration/CLISpec.hs
+++ b/test/Integration/CLISpec.hs
@@ -3,6 +3,7 @@ module Integration.CLISpec (spec) where
 
 import Control.Concurrent
 import Data.ByteString.Lazy qualified as LBS
+import Data.List qualified as List
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as TE
 import Control.Monad (forM_, when)
@@ -275,7 +276,7 @@ spec = do
       err `shouldContain` "Default agent: (none)"
 
   describe "--prefix CLI flag" $ do
-    it "creates a session whose dir starts with the given prefix" $ do
+    it "creates a session whose dir ends with the given prefix" $ do
       bin <- findPureclaw
       withSystemTempDirectory "pureclaw-prefix-test" $ \tmpDir -> do
         let pc = setStdin (byteStringInput (LBS.fromStrict (TE.encodeUtf8 "")))
@@ -297,7 +298,7 @@ spec = do
               `shouldBe` annotate (T.unpack (TE.decodeUtf8 (LBS.toStrict err))) ExitSuccess
             let sessionsDir = tmpDir </> ".pureclaw" </> "sessions"
             dirs <- listDirectory sessionsDir
-            any (\d -> take 6 d == "myrun-") dirs `shouldBe` True
+            any ("-myrun" `List.isSuffixOf`) dirs `shouldBe` True
 
     it "defaults --prefix to the agent name when --agent is set and --prefix is omitted" $ do
       bin <- findPureclaw
@@ -308,11 +309,12 @@ spec = do
            createDirectoryIfMissing True agentDir
            writeFile (agentDir </> "SOUL.md") "hi")
       annotate err exitCode `shouldBe` annotate err ExitSuccess
-      -- The new session dir name must start with the agent prefix.
+      -- The new session dir name must end with the agent prefix.
       -- We can't easily inspect tmpDir here because runPureclawWithSetup
       -- destroys it, so assert indirectly via a stderr log line we emit
-      -- at startup listing the session id.
-      err `shouldContain` "Session: zoe-"
+      -- at startup listing the session id (now timestamp-first, e.g.
+      -- "Session: 20250325-143045-678-zoe").
+      err `shouldContain` "-zoe"
 
     it "rejects --prefix ../evil with an error exit" $ do
       bin <- findPureclaw
@@ -347,7 +349,7 @@ spec = do
         ec1 `shouldBe` ExitSuccess
         let sessionsDir = tmpDir </> ".pureclaw" </> "sessions"
         dirs <- listDirectory sessionsDir
-        let mResumeId = case filter (\d -> take 5 d == "seed-") dirs of
+        let mResumeId = case filter ("-seed" `List.isSuffixOf`) dirs of
                           (d:_) -> Just d
                           _     -> Nothing
         resumeId <- maybe (fail "no seed session directory found") pure mResumeId
@@ -515,11 +517,11 @@ spec = do
         ec2 `shouldBe` ExitSuccess
         let sessionsDir = tmpDir </> ".pureclaw" </> "sessions"
         dirs <- listDirectory sessionsDir
-        let hasPrefix p d = take (length p) d == p
-        length (filter (hasPrefix "one-") dirs) `shouldBe` 1
-        length (filter (hasPrefix "two-") dirs) `shouldBe` 1
+        let hasSuffix s d = s `List.isSuffixOf` d
+        length (filter (hasSuffix "-one") dirs) `shouldBe` 1
+        length (filter (hasSuffix "-two") dirs) `shouldBe` 1
         -- Each session dir has its own transcript file (not shared)
-        case (filter (hasPrefix "one-") dirs, filter (hasPrefix "two-") dirs) of
+        case (filter (hasSuffix "-one") dirs, filter (hasSuffix "-two") dirs) of
           (oneDir:_, twoDir:_) -> do
             doesFileExist (sessionsDir </> oneDir </> "transcript.jsonl")
               `shouldReturn` True

--- a/test/Session/TypesSpec.hs
+++ b/test/Session/TypesSpec.hs
@@ -79,11 +79,11 @@ spec = do
           Right p -> p
           Left e  -> error ("test fixture: " ++ show e)
 
-    it "produces \"<prefix>-YYYYMMDD-HHMMSS-mmm\" when a prefix is supplied" $
+    it "produces \"YYYYMMDD-HHMMSS-mmm-<prefix>\" when a prefix is supplied" $
       newSessionId (Just zoePrefix) fixedTime
-        `shouldBe` parseSessionId "zoe-20250325-143045-678"
+        `shouldBe` parseSessionId "20250325-143045-678-zoe"
 
-    it "omits the prefix and leading hyphen when Nothing is supplied" $
+    it "omits the prefix and trailing hyphen when Nothing is supplied" $
       newSessionId Nothing fixedTime
         `shouldBe` parseSessionId "20250325-143045-678"
 


### PR DESCRIPTION
Closes #69.

## What

Session IDs (and their on-disk directory names) now lead with the timestamp:

- **Old:** `<prefix>-YYYYMMDD-HHMMSS-mmm` (e.g. `zoe-20250325-143045-678`)
- **New:** `YYYYMMDD-HHMMSS-mmm-<prefix>` (e.g. `20250325-143045-678-zoe`)

This makes lexicographic sorting of sessions chronological, which is the point of the issue. The no-prefix case (bare timestamp) is unchanged.

## Why it's a one-line generation change

Session IDs are opaque everywhere — directory names, the `"id"` field in `session.json`, frontend routing, and the `mkSessionId` validator (character-class only). Nothing parses the ID into agent + timestamp, so `newSessionId` in `PureClaw/Session/Types.hs` was the only generation site to change.

## Migration script

`scripts/migrate-session-ids.sh` renames existing sessions under `~/.pureclaw/sessions` from the old scheme to the new one. Crucially it does **two** things per session:

1. Renames the directory `<prefix>-<timestamp>` → `<timestamp>-<prefix>`.
2. Rewrites `session.json`'s `"id"` field to match the directory name.

Step 2 matters because the codebase relies on the invariant **directory-name == `"id"`**: transcript paths, the recent/archived listings (`hasTranscriptEntries`, `firstMessageSnippet`), resume, archive, and last-active updates all derive the on-disk path from `"id"`. An id-unaware rename leaves sessions resolving to a nonexistent path, so they get treated as empty and disappear from Recent Sessions. The reconcile pass runs on every invocation, so it also repairs data already migrated by an earlier id-unaware run.

The script is idempotent, collision-safe, supports `--dry-run`, defaults to `~/.pureclaw/sessions`, and accepts a custom directory. `scripts/test-migrate-session-ids.sh` is a shell-level test harness covering simple/hyphenated prefixes, bare timestamps, the stale-id repair case, idempotency, collisions, field preservation, and error exits.

## Tests

- TDD red/green: failing `Session/TypesSpec` fixture committed first, then the implementation.
- Updated four `Integration/CLISpec` assertions that checked the old prefix-leading directory shape.
- Full suite: **2222 examples, 0 failures** (also under `--enable-coverage`); hlint clean. Coverage-neutral (both branches of `newSessionId` were and remain covered).

## Validated against real data

Ran the corrected script over a live `~/.pureclaw/sessions` (220 sessions): 191 stale `"id"` fields repaired, **0 directory-name/id mismatches** afterward, re-run is a clean no-op, and the missing sessions reappeared in the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)