### PR TITLE
Frontend transcript polish: date+time, channel/userId, header & sidebar spacing (#67)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -104,6 +104,16 @@ function formatToolResultContent(content: unknown): string {
   return JSON.stringify(content, null, 2)
 }
 
+/** Format an ISO-8601 timestamp as `YYYY-MM-DD HH:MM:SS` in local time.
+ *  Shows the date alongside the time (issue #67) so transcripts spanning
+ *  multiple days are unambiguous. Local time matches the prior
+ *  `toLocaleTimeString` behavior. */
+export function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
 /** Convert transcript entries to the Message format ChatArea expects. */
 export function transcriptToMessages(entries: TranscriptEntry[]): Message[] {
   const messages: Message[] = []
@@ -111,7 +121,7 @@ export function transcriptToMessages(entries: TranscriptEntry[]): Message[] {
   const toolResults = buildToolResultIndex(entries)
 
   for (const e of entries) {
-    const ts = new Date(e.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    const ts = formatTimestamp(e.timestamp)
     const rawJson = e.payload
 
     if (e.direction === 'request') {
@@ -520,7 +530,7 @@ export default function App() {
   })()
 
   const messages = useMemo(() => {
-    const now = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    const now = formatTimestamp(new Date().toISOString())
     if (pendingMessage) {
       return [
         ...transcriptMessages,

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -129,6 +129,8 @@ function providerSession(id: string): SessionInfo {
     description: null,
     autoSummary: null,
     firstMessageSnippet: null,
+    channel: null,
+    channelUserId: null,
   }
 }
 

--- a/frontend/src/__tests__/formatTimestamp.test.ts
+++ b/frontend/src/__tests__/formatTimestamp.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { formatTimestamp, transcriptToMessages } from '../App'
+import type { TranscriptEntry } from '../types'
+
+describe('formatTimestamp (issue #67: show date AND time, not just time)', () => {
+  it('renders YYYY-MM-DD HH:MM:SS in local time', () => {
+    // Build a Date from LOCAL components, round-trip through ISO (UTC), and
+    // expect the local components back — deterministic in any timezone since
+    // both construction and formatting use local time.
+    const local = new Date(2024, 5, 15, 13, 5, 9) // 2024-06-15 13:05:09 local
+    expect(formatTimestamp(local.toISOString())).toBe('2024-06-15 13:05:09')
+  })
+
+  it('zero-pads month, day, hour, minute, and second', () => {
+    const local = new Date(2024, 0, 2, 3, 4, 5) // 2024-01-02 03:04:05 local
+    expect(formatTimestamp(local.toISOString())).toBe('2024-01-02 03:04:05')
+  })
+
+  it('matches the YYYY-MM-DD HH:MM:SS shape', () => {
+    expect(formatTimestamp('2024-01-01T00:00:00Z')).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+    )
+  })
+
+  it('transcriptToMessages stamps each message with the date-and-time format', () => {
+    const entries: TranscriptEntry[] = [
+      {
+        id: 'e1',
+        direction: 'request',
+        payload: 'hello',
+        timestamp: '2024-01-01T00:00:00Z',
+      } as TranscriptEntry,
+    ]
+    const msgs = transcriptToMessages(entries)
+    expect(msgs.length).toBeGreaterThan(0)
+    for (const m of msgs) {
+      expect(m.timestamp).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/)
+    }
+  })
+})

--- a/frontend/src/__tests__/sessionSubtitle.test.ts
+++ b/frontend/src/__tests__/sessionSubtitle.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { sessionSubtitle } from '../types'
+
+// Issue #67 follow-up: the transcript header subtitle should drop the model
+// (which can change over a session's lifetime) and instead show the
+// communications channel name + user id when one exists, or nothing (just the
+// agent) when there is no channel user id (e.g. `pureclaw tui`).
+describe('sessionSubtitle (channel + user id, not model)', () => {
+  it('renders "agent · channel:userId" when a channel user id exists', () => {
+    expect(
+      sessionSubtitle({ agent: 'assistant', channel: 'signal', channelUserId: '+15551234567' }),
+    ).toBe('assistant · signal:+15551234567')
+  })
+
+  it('renders just the agent when there is no channel user id (e.g. tui)', () => {
+    expect(sessionSubtitle({ agent: 'assistant', channel: null, channelUserId: null })).toBe(
+      'assistant',
+    )
+  })
+
+  it('renders just "channel:userId" when there is no agent', () => {
+    expect(sessionSubtitle({ agent: null, channel: 'telegram', channelUserId: '42' })).toBe(
+      'telegram:42',
+    )
+  })
+
+  it('ignores the model entirely (model present but no channel id → agent only)', () => {
+    expect(
+      sessionSubtitle({ agent: 'assistant', model: 'claude-sonnet-4-20250514' } as never),
+    ).toBe('assistant')
+  })
+
+  it('returns an empty string when nothing is available', () => {
+    expect(sessionSubtitle({ agent: null, channel: null, channelUserId: null })).toBe('')
+  })
+})

--- a/frontend/src/components/ChatArea.tsx
+++ b/frontend/src/components/ChatArea.tsx
@@ -1058,13 +1058,20 @@ export function ChatArea({
             ? sessionSubtitle(selectedSession)
             : selectedAgent.description ?? ''
           if (!subtitle) return null
+          // Keep the separator and subtitle in a SINGLE flex child so the
+          // header's gap applies once between the title and the subtitle
+          // (not twice, around a standalone separator). The middot is
+          // followed by a normal space, matching the spacing of the dots
+          // inside the subtitle itself.
           return (
-            <>
-              <span style={{ color: 'var(--border)' }}>&middot;</span>
-              <span className="text-xs truncate" style={{ color: 'var(--text-muted)' }}>
-                {subtitle}
-              </span>
-            </>
+            <span
+              data-testid="header-subtitle"
+              className="text-xs truncate min-w-0"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              <span style={{ color: 'var(--border)' }}>&middot;</span>{' '}
+              {subtitle}
+            </span>
           )
         })()}
         {messages.length > 0 && (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -139,7 +139,19 @@ function ArchivedSection({
   if (sessions.length === 0) return null
 
   return (
-    <div className="shrink-0 flex flex-col" style={{ borderTop: '1px solid var(--border)', maxHeight: '50%' }}>
+    <div
+      data-testid="archived-section"
+      className="shrink-0 flex flex-col"
+      style={{
+        borderTop: '1px solid var(--border)',
+        maxHeight: '50%',
+        // When collapsed, pin the section to the status-line height so its
+        // 1px top border lines up exactly with the status line's top border
+        // (border-box includes the border). Released when expanded so the
+        // session list can grow.
+        ...(expanded ? {} : { height: 'var(--bottombar-height)', justifyContent: 'center' }),
+      }}
+    >
       <div
         className="px-3 py-1.5 flex items-center justify-between cursor-pointer shrink-0"
         style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -106,14 +106,19 @@ function SessionRow({
         {onUnarchive && <UnarchiveButton onUnarchive={() => onUnarchive(session.id)} />}
         <span className="pill token-count">{age}</span>
       </div>
-      {(session.agent || session.model) && (
-        <div
-          className="text-xs ml-0 mt-0.5"
-          style={{ color: 'var(--text-faint)', lineHeight: 'var(--leading-tight)' }}
-        >
-          {sessionSubtitle(session)}
-        </div>
-      )}
+      {(() => {
+        const subtitle = sessionSubtitle(session)
+        if (!subtitle) return null
+        return (
+          <div
+            className="text-xs ml-0 mt-0.5 truncate"
+            style={{ color: 'var(--text-faint)', lineHeight: 'var(--leading-tight)' }}
+            title={subtitle}
+          >
+            {subtitle}
+          </div>
+        )
+      })()}
     </div>
   )
 }

--- a/frontend/src/components/__tests__/ArchivedSessions.test.tsx
+++ b/frontend/src/components/__tests__/ArchivedSessions.test.tsx
@@ -14,6 +14,8 @@ function makeSessions(...overrides: Partial<SessionInfo>[]): SessionInfo[] {
     description: o.description ?? null,
     autoSummary: o.autoSummary ?? null,
     firstMessageSnippet: o.firstMessageSnippet ?? null,
+    channel: o.channel ?? null,
+    channelUserId: o.channelUserId ?? null,
   }))
 }
 

--- a/frontend/src/components/__tests__/ArchivedSessions.test.tsx
+++ b/frontend/src/components/__tests__/ArchivedSessions.test.tsx
@@ -63,6 +63,20 @@ describe('ArchivedSessions', () => {
     expect(screen.getByText('old session')).toBeInTheDocument()
   })
 
+  it('collapsed section is pinned to the bottom-bar height so its top border aligns with the status line (#67)', () => {
+    const archivedSessions = makeSessions({ description: 'old session' })
+    render(
+      <Sidebar {...defaultProps} archivedSessions={archivedSessions} />,
+    )
+    const section = screen.getByTestId('archived-section')
+    // Collapsed: fixed to --bottombar-height (border-box) so its 1px top
+    // border lines up exactly with the status line's top border.
+    expect(section.style.height).toBe('var(--bottombar-height)')
+    // Expanded: the height constraint is released so the list can grow.
+    fireEvent.click(screen.getByText(/Archived/))
+    expect(section.style.height).toBe('')
+  })
+
   it('shows expand/collapse icons', () => {
     const archivedSessions = makeSessions({ description: 'test' })
     const { container } = render(

--- a/frontend/src/components/__tests__/ChatArea.test.tsx
+++ b/frontend/src/components/__tests__/ChatArea.test.tsx
@@ -574,6 +574,23 @@ describe('ChatArea branch button (D9, D10)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Header subtitle spacing (#67): the separator + subtitle form a single flex
+// child so the title↔subtitle gap is one standard gap, not two.
+// ---------------------------------------------------------------------------
+describe('ChatArea header subtitle spacing', () => {
+  it('groups the middot separator and subtitle into one element', () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn() as unknown as HTMLElement['scrollIntoView']
+    const agent = { ...makeAgent(), description: 'signal:+15551234567' }
+    const { getByTestId } = render(<ChatArea selectedAgent={agent} messages={[]} />)
+    const subtitle = getByTestId('header-subtitle')
+    // Separator and subtitle text live in the SAME element (one flex child →
+    // one gap between the title and the subtitle), with the middot followed by
+    // a normal space — matching the spacing of the dots inside the subtitle.
+    expect(subtitle.textContent).toBe('· signal:+15551234567')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // D12a / D12b — read-only branch prefix above the composer
 // ---------------------------------------------------------------------------
 describe('ChatArea branch-draft prefix (D12a, D12b)', () => {

--- a/frontend/src/components/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/__tests__/Sidebar.test.tsx
@@ -72,6 +72,42 @@ describe('Sidebar lifecycle transitions', () => {
     expect(onArchiveTab).toHaveBeenCalledWith(0)
   })
 
+  it('truncates the channel:userId subtitle to one line and shows the full text on hover', () => {
+    const subtitle = 'assistant · signal:+15551234567890'
+    render(
+      <Sidebar
+        {...defaultProps}
+        sessions={makeSessions({
+          id: 'sess-sig',
+          agent: 'assistant',
+          channel: 'signal',
+          channelUserId: '+15551234567890',
+        })}
+      />,
+    )
+    const el = screen.getByText(subtitle)
+    // Single-line clipping (Tailwind `truncate` = overflow-hidden + nowrap + ellipsis)
+    expect(el.className).toContain('truncate')
+    // Full, untruncated value available on hover
+    expect(el.getAttribute('title')).toBe(subtitle)
+  })
+
+  it('shows the subtitle for a session that has only a channel user id (no agent/model)', () => {
+    render(
+      <Sidebar
+        {...defaultProps}
+        sessions={makeSessions({
+          id: 'sess-tui',
+          agent: null,
+          model: '',
+          channel: 'telegram',
+          channelUserId: '42',
+        })}
+      />,
+    )
+    expect(screen.getByText('telegram:42')).toBeTruthy()
+  })
+
   it('clicking an archived session selects it without unarchiving', () => {
     const onSelectSession = vi.fn()
     const archivedSessions = makeSessions({ id: 'arch-1', description: 'old session' })

--- a/frontend/src/components/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/__tests__/Sidebar.test.tsx
@@ -24,6 +24,8 @@ function makeSessions(...overrides: Partial<SessionInfo>[]): SessionInfo[] {
     description: o.description ?? null,
     autoSummary: o.autoSummary ?? null,
     firstMessageSnippet: o.firstMessageSnippet ?? null,
+    channel: o.channel ?? null,
+    channelUserId: o.channelUserId ?? null,
   }))
 }
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -352,5 +352,7 @@ export async function createSession(agent?: string, customPrompt?: string): Prom
     description: null,
     autoSummary: null,
     firstMessageSnippet: null,
+    channel: null,
+    channelUserId: null,
   }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -27,6 +27,12 @@ export interface SessionInfo {
   description: string | null
   autoSummary: string | null
   firstMessageSnippet: string | null
+  /** Communications channel name of the session origin (e.g. "signal",
+   *  "telegram", "cli"), or null when no source was recorded. */
+  channel: string | null
+  /** Channel user id of the session origin, or null when the channel
+   *  carries no user id (e.g. `pureclaw tui`). */
+  channelUserId: string | null
 }
 
 /** Cascade used to pick the display title for a session.
@@ -49,12 +55,15 @@ export function shortenModel(model: string): string {
   return m ? m[1]! : model
 }
 
-/** Agent + short model formatted as "agent · sonnet-4" (with the
- *  middle dot). Skips either piece if it's missing. */
-export function sessionSubtitle(s: { agent?: string | null; model?: string | null }): string {
+/** Agent + communications channel formatted as "agent · channel:userId"
+ *  (with the middle dot). The model is deliberately omitted — it can change
+ *  over a session's lifetime. The channel piece is shown only when the
+ *  origin carries a channel user id; sessions with no channel user id
+ *  (e.g. `pureclaw tui`) show just the agent. Skips either piece if missing. */
+export function sessionSubtitle(s: { agent?: string | null; channel?: string | null; channelUserId?: string | null }): string {
   const parts: string[] = []
   if (s.agent) parts.push(s.agent)
-  if (s.model) parts.push(shortenModel(s.model))
+  if (s.channelUserId) parts.push(`${s.channel ?? ''}:${s.channelUserId}`)
   return parts.join(' · ')
 }
 

--- a/src/PureClaw/Frontend/API.hs
+++ b/src/PureClaw/Frontend/API.hs
@@ -15,6 +15,7 @@ module PureClaw.Frontend.API
   , HarnessInfo (..)
   , HarnessActivity (..)
   , SessionInfo (..)
+  , toSessionInfo
   , TranscriptEntryInfo (..)
   , toTranscriptEntryInfo
   , AgentInfo (..)
@@ -59,7 +60,7 @@ import PureClaw.Agent.AgentDef
   , unAgentName
   )
 import PureClaw.Agent.Context
-import PureClaw.Core.Types (ModelId (..), SessionId (..), ToolCallId, unModelId, unSessionId)
+import PureClaw.Core.Types (MessageSource (..), ModelId (..), SessionId (..), ToolCallId, UserId (..), channelKindToText, unModelId, unSessionId)
 import PureClaw.Frontend.Activity.Types (HarnessActivity (..))
 import PureClaw.Frontend.BroadcastingTranscript (mkBroadcastingFileTranscriptHandle)
 import PureClaw.Frontend.StreamBroker
@@ -281,6 +282,13 @@ data SessionInfo = SessionInfo
   , _si_firstMessageSnippet  :: Maybe Text
     -- ^ Cheap fallback: a trimmed prefix of the first user message
     -- in the transcript. Computed on demand in 'handleRecentSessions'.
+  , _si_channel              :: Maybe Text
+    -- ^ Communications channel name of the session origin (e.g. "signal",
+    -- "telegram", "cli"), derived from the first inbound message's
+    -- 'MessageSource'. 'Nothing' when the session has no recorded source.
+  , _si_channelUserId        :: Maybe Text
+    -- ^ Channel user id of the session origin (phone / UUID / Telegram id).
+    -- 'Nothing' when the channel carries no user id (e.g. @pureclaw tui@).
   }
   deriving stock (Show, Eq)
 
@@ -295,6 +303,8 @@ instance ToJSON SessionInfo where
     , "description"         .= _si_description si
     , "autoSummary"         .= _si_autoSummary si
     , "firstMessageSnippet" .= _si_firstMessageSnippet si
+    , "channel"             .= _si_channel si
+    , "channelUserId"       .= _si_channelUserId si
     ]
 
 -- | WAI application handling @\/api\/*@ routes.
@@ -551,6 +561,8 @@ toSessionInfo m snippet = SessionInfo
   , _si_description         = _sm_description m
   , _si_autoSummary         = _sm_autoSummary m
   , _si_firstMessageSnippet = snippet
+  , _si_channel             = channelKindToText . _ms_channel <$> _sm_source m
+  , _si_channelUserId       = _sm_source m >>= fmap unUserId . _ms_userId
   }
 
 -- | Cheap fallback for display: read just the first line of the

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -24,7 +24,7 @@ import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 
 import PureClaw.Agent.AgentDef (mkAgentName, unAgentName)
-import PureClaw.Core.Types (ModelId (..), SessionId (..), ToolCallId (..))
+import PureClaw.Core.Types (ChannelKind (..), ModelId (..), SessionId (..), ToolCallId (..), UserId (..), mkMessageSource)
 import PureClaw.Frontend.API
 import PureClaw.Handles.Log (mkNoOpLogHandle)
 import PureClaw.Providers.Class
@@ -645,6 +645,47 @@ spec = do
         (st, respBody) <- getJSON env ["api", "sessions", "archived"]
         st `shouldBe` HTTP.status200
         respBody `shouldBe` Aeson.encode ([] :: [Aeson.Value])
+
+  -- -----------------------------------------------------------------------
+  -- #67 follow-up: SessionInfo exposes channel name + channel user id
+  -- (so the transcript header can show channel:userId instead of the model)
+  -- -----------------------------------------------------------------------
+
+  describe "toSessionInfo (channel + user id — #67)" $ do
+    let epoch = UTCTime (fromGregorian 2024 1 1) (secondsToDiffTime 0)
+        baseMeta src = SessionMeta
+          { _sm_id                = SessionId "s1"
+          , _sm_agent             = Nothing
+          , _sm_kind              = SkProvider (ProviderSpec (inferProviderId "claude-sonnet-4-20250514") (ModelId "claude-sonnet-4-20250514") Nothing)
+          , _sm_model             = "claude-sonnet-4-20250514"
+          , _sm_channel           = "web"
+          , _sm_createdAt         = epoch
+          , _sm_lastActive        = epoch
+          , _sm_bootstrapConsumed = True
+          , _sm_archived          = False
+          , _sm_description       = Nothing
+          , _sm_autoSummary       = Nothing
+          , _sm_source            = src
+          }
+    it "exposes channel name and user id from the session source" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+          si  = toSessionInfo (baseMeta (Just src)) Nothing
+      _si_channel si `shouldBe` Just "signal"
+      _si_channelUserId si `shouldBe` Just "+15551234567"
+    it "yields no channel user id when the source has no user id (e.g. tui/cli)" $ do
+      let src = mkMessageSource CkCli Nothing mempty
+          si  = toSessionInfo (baseMeta (Just src)) Nothing
+      _si_channel si `shouldBe` Just "cli"
+      _si_channelUserId si `shouldBe` Nothing
+    it "yields no channel or user id when there is no source" $ do
+      let si = toSessionInfo (baseMeta Nothing) Nothing
+      _si_channel si `shouldBe` Nothing
+      _si_channelUserId si `shouldBe` Nothing
+    it "serializes channel and channelUserId into the SessionInfo JSON" $ do
+      let src = mkMessageSource CkSignal (Just (UserId "+15551234567")) mempty
+          v   = Aeson.toJSON (toSessionInfo (baseMeta (Just src)) Nothing)
+      lookupKey v "channel" `shouldBe` Just (Aeson.String "signal")
+      lookupKey v "channelUserId" `shouldBe` Just (Aeson.String "+15551234567")
 
   -- -----------------------------------------------------------------------
   -- WU-8: POST /api/sessions/{id}/archive and /unarchive idempotence


### PR DESCRIPTION
Fixes #67 — *Frontend session transcripts should show date and time, not just time* — plus a series of related polish items in the transcript header and sidebar surfaced while in the area.

## Changes

| Commit | Change |
|---|---|
| `994c3bf` | **Date + time in transcripts.** Transcript entries and the pending message were stamped time-only (`toLocaleTimeString`). Added a `formatTimestamp` helper rendering `YYYY-MM-DD HH:MM:SS` in local time, used at both formatting sites. |
| `ada38a1` | **Channel + user id (not model) in the session subtitle.** The model can change over a session's lifetime, so the header/sidebar subtitle now shows the communications channel name and user id of the session origin (e.g. `assistant · signal:+1555…`), or just the agent when there's no channel user id (e.g. `pureclaw tui`). Backend `SessionInfo` gains `channel` / `channelUserId`, derived from the session's `MessageSource` origin (`_sm_source`). |
| `0772f5e` | **Truncate the sidebar subtitle** to one line with the full value on hover (`title`). Also gates the subtitle on its actual rendered text rather than the stale `agent \|\| model` condition. |
| `0612e3e` | **Tighten the header title↔subtitle spacing.** The `·` separator was a standalone flex child, getting the header gap on both sides; grouped the separator + subtitle into one flex child so a single standard gap applies. |
| `e371e6d` | **Align the collapsed Archived section's top border with the status line.** Pinned the collapsed section to `--bottombar-height` (border-box) so its 1px top border lines up exactly with the BottomBar's. |

## Decisions (confirmed with reviewer)
- Timestamp format: ISO-ish `YYYY-MM-DD HH:MM:SS`, local time (preserves prior behavior).
- Subtitle format: `agent · channel:userId`; applies to both the transcript header and the sidebar.

## Testing
- **Backend:** full suite **2226 examples, 0 failures**; coverage gate (`cabal test --enable-coverage`) **PASS**. +4 `toSessionInfo` tests.
- **Frontend:** full suite **184 passed**, `tsc --noEmit` clean. +10 tests (timestamp format, sessionSubtitle, sidebar truncation/gate, header grouping, archived border alignment), all written TDD red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)