### PR TITLE
fix(tabs): bound provider-worker teardown — fixes 6h CI hang

### DIFF
--- a/test/Tabs/WiringSpec.hs
+++ b/test/Tabs/WiringSpec.hs
@@ -1,6 +1,7 @@
 module Tabs.WiringSpec (spec) where
 
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception (throwIO)
 import Control.Monad qualified as M
@@ -212,8 +213,27 @@ trackingFork ref body = do
   pure runner
 
 -- | Cancel every tracked runner (idempotent; safe on already-finished asyncs).
+--
+-- A provider worker can be parked on an STM input queue whose only writer
+-- became unreachable when 'runTabbedLoop' returned on EOF. 'Async.cancel' of
+-- such a worker cannot reap it: its 'throwTo' races the RTS's
+-- @BlockedIndefinitelyOnSTM@ detector, which is slow (~40s) on macOS and never
+-- fires on Linux — the latter manifested as a 6-hour CI hang. So the cancels
+-- run concurrently under a single bound; a worker that does not reap in time is
+-- harmless (no reachable writer can feed it) and the RTS collects it. Without
+-- the bound, teardown — and thus the whole suite — could block forever.
 cancelAll :: IORef [TabRunner] -> IO ()
-cancelAll ref = readIORef ref >>= mapM_ _trun_cancel
+cancelAll ref = do
+  runners <- readIORef ref
+  M.void (timeout teardownBudgetMicros (Async.mapConcurrently_ _trun_cancel runners))
+
+-- | Upper bound on how long 'cancelAll' waits for all tracked runners to reap.
+-- Reachable runners (the relay writer, a live worker) cancel in microseconds, so
+-- this budget only bites for an orphaned worker that cannot be reaped at all —
+-- where waiting longer never helps. Kept small to keep teardown cheap; generous
+-- enough that a reachable worker mid-write always reaps well within it.
+teardownBudgetMicros :: Int
+teardownBudgetMicros = 500 * 1000
 
 -- ---------------------------------------------------------------------------
 -- Tabbed AgentEnv builder: real on-disk session + the 7 tab fields from
@@ -603,6 +623,31 @@ spec = do
         -- The action was read-and-cleared: the ref is now empty (no re-fire).
         cleared <- isNothing <$> readIORef (_env_onFirstStreamDone env)
         cleared `shouldBe` True
+
+    it "tears down provider-session runners promptly — no cancel hang (pureclaw-ctd)" $
+      withSystemTempDirectory "pc-wiring-teardown" $ \tmp -> do
+        -- Regression: a provider turn auto-starts a runtime whose worker parks
+        -- on an STM input queue. When 'runTabbedLoop' returns on EOF, that
+        -- queue's only writer (held by the loop-local session store) becomes
+        -- unreachable, so 'Async.cancel' of the worker cannot reap it — its
+        -- 'throwTo' races the RTS's BlockedIndefinitelyOnSTM detector, which is
+        -- slow (~40s) on macOS and NEVER fires on Linux (a 6-hour CI hang).
+        -- Teardown must therefore be bounded: it completes regardless.
+        let msgs =
+              [ mkInbound "conv-a" "alice" "/new"
+              , mkInbound "conv-a" "alice" "say hi"
+              ]
+        th <- mkTabbedEnvWith tmp msgs (Just (MkProvider ReplyProvider))
+                              (Just (ModelId "mock"))
+        let env = _th_env th
+        fired <- newEmptyMVar
+        writeIORef (_env_onFirstStreamDone env) (Just (putMVar fired ()))
+        _ <- timeout (5 * 1000000) (runTabbedLoop env)
+        -- Wait until the worker has run its turn and parked on its input queue
+        -- (the exact state in which the orphaned-queue cancel hang manifests).
+        _ <- timeout (5 * 1000000) (takeMVar fired)
+        tornDown <- timeout (5 * 1000000) (cancelAll (_th_runners th))
+        tornDown `shouldBe` Just ()
 
     it "/status reflects the active session transcript: messages + token totals (pureclaw-25k)" $
       withSystemTempDirectory "pc-wiring-status" $ \tmp -> do


### PR DESCRIPTION
## Problem

CI **hung for 6 hours** on Linux (GitHub's job limit) and **failed** on macOS (`BlockedIndefinitelyOnMVar`) on the tabs-as-view work (#80, now merged). It is **not** aggregate test slowness — the suite runs in ~90s up to the freeze. It is a single deadlock in `test/Tabs/WiringSpec.hs`.

## Root cause

A provider-driven `runTabbedLoop` test auto-starts a runtime whose worker parks on `readTBQueue inputQ`. When `runTabbedLoop` returns on EOF, the queue's only writer (`_rt_send`, held by a loop-local session store) becomes **unreachable**. The test's `cancelAll` then calls `Async.cancel` on that orphaned worker — but `cancel` (`throwTo` + `waitCatch`) can't reap a thread parked on an unreachable STM queue (and intermittently inside uninterruptible `safe`-FFI transcript writes). The only thing that frees it is the RTS `BlockedIndefinitelyOnSTM` detector, which fires after a ~40–48s major-GC cycle on macOS and **never on Linux** → 6-hour hang.

Traced with per-phase timing (the 48s was entirely in `cancelAll`) and `GHC.Conc.listThreads`/`threadStatus` (worker `BlockedOnForeignCall`, surviving a 3s cancel). **Production is unaffected**: `runTabbedLoop` never returns mid-life there — its `withAsync` block unwinds into process exit — so workers are never orphaned.

## Fix

`cancelAll` now runs the runner cancels concurrently under a single 500 ms bound. Reachable runners reap in microseconds; an orphaned worker that can't be reaped is harmless (no writer can feed it; the RTS collects it) and no longer blocks teardown. Adds a deterministic RED→GREEN regression test (`pureclaw-ctd`).

## Verification

| | Before | After |
|---|---|---|
| `Tabs.Wiring` module | ~82s (2 tests at 40–48s) | **~3s** |
| Full suite (local) | 143s | **62.7s** |
| Linux CI | ∞ → 6h kill | bounded |
| Failures | 35 (pre-existing local-env) | same 35, **zero new**, zero `Tabs.Wiring` |

`hlint`: clean. `-Wall -Werror`: clean. Test-only change (no `src/` changes → library coverage unaffected).

> Separate safety-net follow-up worth doing: CI's test step has **no `timeout-minutes:`**, which is why the hang burned the full 6 hours instead of failing fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)