### PR TITLE
perf(test): inject cheap scrypt work factor into passphrase vault tests

### DIFF
--- a/src/PureClaw/Security/Vault/Passphrase.hs
+++ b/src/PureClaw/Security/Vault/Passphrase.hs
@@ -1,5 +1,9 @@
 module PureClaw.Security.Vault.Passphrase
   ( mkPassphraseVaultEncryptor
+  , mkPassphraseVaultEncryptorWith
+  , ageWorkFactor
+  , WorkFactor
+  , mkWorkFactor
   ) where
 
 import Control.Concurrent.STM
@@ -17,7 +21,10 @@ import Data.Text qualified as T
 
 import PureClaw.Security.Vault.Age (VaultEncryptor (..), VaultError (..))
 
--- | scrypt work factor (N = 2^22), matching the age CLI default.
+-- | scrypt work factor for production vaults (N = 2^22): a deliberately high,
+-- fixed cost for brute-force resistance. The work factor only affects KDF
+-- cost, not correctness, so tests inject a small factor via
+-- 'mkPassphraseVaultEncryptorWith' to stay fast.
 ageWorkFactor :: WorkFactor
 ageWorkFactor = fromJust (mkWorkFactor 22)
 
@@ -29,8 +36,18 @@ toAgePass bs = Passphrase (convert bs)
 -- The resulting ciphertext is a standard age binary file, compatible with
 -- @age -d --passphrase@.
 -- The IO action is called at most once to obtain the passphrase, then cached.
+--
+-- Uses the production 'ageWorkFactor'. For a configurable work factor (e.g.
+-- a cheap one in tests), use 'mkPassphraseVaultEncryptorWith'.
 mkPassphraseVaultEncryptor :: IO ByteString -> IO VaultEncryptor
-mkPassphraseVaultEncryptor getPass = do
+mkPassphraseVaultEncryptor = mkPassphraseVaultEncryptorWith ageWorkFactor
+
+-- | Like 'mkPassphraseVaultEncryptor', but with an explicit scrypt work factor.
+-- Production callers should use 'mkPassphraseVaultEncryptor' (which supplies
+-- 'ageWorkFactor'); a low work factor makes the scrypt KDF cheap and is
+-- intended for tests, where the high production cost would dominate CI time.
+mkPassphraseVaultEncryptorWith :: WorkFactor -> IO ByteString -> IO VaultEncryptor
+mkPassphraseVaultEncryptorWith workFactor getPass = do
   cache <- newTVarIO Nothing
   let getOrPrompt = do
         c <- readTVarIO cache
@@ -50,7 +67,7 @@ mkPassphraseVaultEncryptor getPass = do
             let recipient = ScryptRecipient
                   { srPassphrase  = toAgePass passphrase
                   , srSalt        = salt
-                  , srWorkFactor  = ageWorkFactor
+                  , srWorkFactor  = workFactor
                   }
             result <- runExceptT (encrypt (RecipientsScrypt recipient) plaintext)
             case result of
@@ -60,7 +77,7 @@ mkPassphraseVaultEncryptor getPass = do
         passphrase <- getOrPrompt
         let identity   = ScryptIdentity
               { siPassphrase    = toAgePass passphrase
-              , siMaxWorkFactor = ageWorkFactor
+              , siMaxWorkFactor = workFactor
               }
             identities = IdentityScrypt identity :| []
         case decrypt identities ciphertext of

--- a/test/Security/VaultPassphraseSpec.hs
+++ b/test/Security/VaultPassphraseSpec.hs
@@ -2,6 +2,8 @@ module Security.VaultPassphraseSpec (spec) where
 
 import Data.ByteString qualified as BS
 import Data.Either (isLeft)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Maybe (fromJust)
 import Test.Hspec
 
 import PureClaw.Security.Vault.Age (VaultEncryptor (..), VaultError (..))
@@ -10,14 +12,18 @@ import PureClaw.Security.Vault.Passphrase
 spec :: Spec
 spec = do
   describe "mkPassphraseVaultEncryptor" $ do
-    let mkEnc pass = mkPassphraseVaultEncryptor (pure pass)
+    -- A tiny scrypt work factor keeps these tests fast even on small CI
+    -- hardware. Production uses 'ageWorkFactor' (N = 2^22); the work factor
+    -- only affects KDF cost, not correctness, so a low value exercises the
+    -- same code paths instantly.
+    let testWorkFactor = fromJust (mkWorkFactor 8)
+        mkEnc pass = mkPassphraseVaultEncryptorWith testWorkFactor (pure pass)
 
-    -- TODO slow
-    -- it "roundtrip: encrypt then decrypt returns original plaintext" $ do
-    --   enc <- mkEnc "correcthorsebatterystaple"
-    --   Right ct <- _ve_encrypt enc "my secret"
-    --   Right pt <- _ve_decrypt enc ct
-    --   pt `shouldBe` "my secret"
+    it "roundtrip: encrypt then decrypt returns original plaintext" $ do
+      enc <- mkEnc "correcthorsebatterystaple"
+      Right ct <- _ve_encrypt enc "my secret"
+      Right pt <- _ve_decrypt enc ct
+      pt `shouldBe` "my secret"
 
     it "ciphertext differs from plaintext" $ do
       enc <- mkEnc "pass"
@@ -47,13 +53,23 @@ spec = do
       Right ct2 <- _ve_encrypt enc "same plaintext"
       ct1 `shouldNotBe` ct2
 
-    -- TODO slow
-    -- it "passphrase is prompted at most once (cached)" $ do
-    --   callCount <- newIORef (0 :: Int)
-    --   let getPass = modifyIORef callCount (+1) >> pure "pass"
-    --   enc <- mkPassphraseVaultEncryptor getPass
-    --   Right ct <- _ve_encrypt enc "secret"
-    --   Right _  <- _ve_decrypt enc ct
-    --   Right _  <- _ve_decrypt enc ct
-    --   count <- readIORef callCount
-    --   count `shouldBe` 1
+    it "mkPassphraseVaultEncryptor (production default) decrypts a vault" $ do
+      -- Exercises the production default, which delegates with 'ageWorkFactor'.
+      -- We encrypt cheaply, then decrypt through the production default: decrypt
+      -- forces the production max work factor (covering 'ageWorkFactor') for its
+      -- cap check, while the KDF runs at the file's cheap factor, so it's fast.
+      cheap    <- mkEnc "pass"
+      Right ct <- _ve_encrypt cheap "secret"
+      prod     <- mkPassphraseVaultEncryptor (pure "pass")
+      Right pt <- _ve_decrypt prod ct
+      pt `shouldBe` "secret"
+
+    it "passphrase is prompted at most once (cached)" $ do
+      callCount <- newIORef (0 :: Int)
+      let getPass = modifyIORef' callCount (+1) >> pure "pass"
+      enc <- mkPassphraseVaultEncryptorWith testWorkFactor getPass
+      Right ct <- _ve_encrypt enc "secret"
+      Right _  <- _ve_decrypt enc ct
+      Right _  <- _ve_decrypt enc ct
+      count <- readIORef callCount
+      count `shouldBe` 1


### PR DESCRIPTION
## Problem

The `Security.VaultPassphrase` spec ran `age` passphrase encryption at the production scrypt work factor (**N = 2²²**), so every test paid a full, deliberately-expensive KDF — ~5s each locally and considerably worse on GitHub's slower runners. This is the **"long delay right after `ciphertext differs from plaintext`"**: the whole block took **~30s**, and the two most valuable tests (roundtrip correctness and passphrase caching) had been commented out as `-- TODO slow`.

## Fix — make the work factor injectable (production unchanged)

- Add `mkPassphraseVaultEncryptorWith :: WorkFactor -> IO ByteString -> IO VaultEncryptor`.
- `mkPassphraseVaultEncryptor` now delegates to it with the production `ageWorkFactor` (still **2²²**). **Both production call sites (`SlashCommands.hs`, `CLI/Commands.hs`) are untouched — real vault security is unchanged.**
- Re-export `WorkFactor`/`mkWorkFactor` so tests need no new dependency.
- Tests inject a tiny factor (**2⁸**) → the KDF is instant. Re-enabled the **roundtrip** and **caching** tests.

## Result

| | Before | After |
|---|---|---|
| `Security.VaultPassphrase` block | **30.06s** | **0.0065s** |
| Tests in block | 5 (2 disabled) | 8 |

## Verification

- `cabal build all` clean under `-Wall -Werror`; `hlint`: **No hints**.
- Full suite: **2668 examples, 0 failures**; coverage gate command (`cabal test --enable-coverage`) passes.
- **No coverage regression**: confirmed via annotated HPC HTML that the only uncovered expressions are the two pre-existing impossible error branches (`salt generation failed`, `age encrypt:`). `ageWorkFactor` stays covered via a production-default decrypt test that forces the 2²² cap check without paying for a 2²² KDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)