### PR TITLE
test(frontend): cover useApi.ts (45%→100% lines) and useListsStream.ts (0%→100%)

### DIFF
--- a/frontend/src/hooks/__tests__/useApi.test.ts
+++ b/frontend/src/hooks/__tests__/useApi.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { act, renderHook } from '@testing-library/react'
-import { acknowledgeTab, adoptWindow, closeTab, dismissTab, mapDiscoverableWindow, mapTabInfo, releaseHarness, resumeArchivedSession, useDiscoverableWindows, useSendMessage } from '../useApi'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { acknowledgeTab, adoptWindow, closeTab, createSession, createTab, destroyHarness, dismissTab, fetchProviderModels, mapDiscoverableWindow, mapTabInfo, releaseHarness, resumeArchivedSession, setSessionArchived, setSessionDescription, setSessionPrompt, useAgents, useArchivedSessions, useConfiguredProviders, useDiscoverableWindows, useHarnesses, useRecentSessions, useSendMessage, useTabs, useTranscript } from '../useApi'
 
 describe('mapTabInfo', () => {
   it('maps snake_case wire fields to the camelCase TabInfo shape', () => {
@@ -365,5 +365,434 @@ describe('useSendMessage model body (U5)', () => {
     const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
     const body = JSON.parse((call[1] as RequestInit).body as string)
     expect(body).toEqual({ message: 'hello' })
+  })
+})
+
+describe('useSendMessage guard + error handling', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch; vi.restoreAllMocks() })
+
+  it('does nothing (no fetch, no onComplete) when there is no session id', async () => {
+    const onComplete = vi.fn()
+    const { result } = renderHook(() => useSendMessage(null, onComplete))
+    await act(async () => { await result.current.send('hi') })
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(onComplete).not.toHaveBeenCalled()
+  })
+
+  it('logs and still calls onComplete on a non-ok response', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, json: () => Promise.resolve({ error: 'bad' }) })
+    const onComplete = vi.fn()
+    const { result } = renderHook(() => useSendMessage('s', onComplete))
+    await act(async () => { await result.current.send('hi') })
+    expect(errSpy).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalled()
+    expect(result.current.sending).toBe(false)
+  })
+
+  it('logs and still calls onComplete when fetch throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    const onComplete = vi.fn()
+    const { result } = renderHook(() => useSendMessage('s', onComplete))
+    await act(async () => { await result.current.send('hi') })
+    expect(errSpy).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalled()
+  })
+})
+
+describe('setSessionDescription', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('PUTs the description (url-encoding the session id) and returns true', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    expect(await setSessionDescription('s 1', 'hello')).toBe(true)
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('/api/sessions/s%201/description')
+    const init = call[1] as RequestInit
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body as string)).toEqual({ description: 'hello' })
+  })
+
+  it('returns false (clears via null) on a non-ok response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    expect(await setSessionDescription('s', null)).toBe(false)
+  })
+
+  it('returns false when fetch throws', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    expect(await setSessionDescription('s', 'x')).toBe(false)
+  })
+})
+
+describe('setSessionArchived', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('POSTs /archive when archiving', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    expect(await setSessionArchived('s', true)).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/s/archive', { method: 'POST' })
+  })
+
+  it('POSTs /unarchive when unarchiving', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    expect(await setSessionArchived('s', false)).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/s/unarchive', { method: 'POST' })
+  })
+
+  it('returns false when fetch throws', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    expect(await setSessionArchived('s', true)).toBe(false)
+  })
+})
+
+describe('setSessionPrompt', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('PUTs the prompt and includes the name when provided', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    expect(await setSessionPrompt('s', 'do x', 'My Tab')).toBe(true)
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('/api/sessions/s/prompt')
+    const init = call[1] as RequestInit
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body as string)).toEqual({ prompt: 'do x', name: 'My Tab' })
+  })
+
+  it('omits the name when not provided', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    await setSessionPrompt('s', 'do x')
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(JSON.parse((call[1] as RequestInit).body as string)).toEqual({ prompt: 'do x' })
+  })
+
+  it('returns false when fetch throws', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    expect(await setSessionPrompt('s', 'do x')).toBe(false)
+  })
+})
+
+describe('createTab', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('POSTs a provider session tab to /api/tabs/new and returns the parsed response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ tab_index: 1, session_id: 's1', kind: 'session:provider' }),
+    })
+    const r = await createTab()
+    expect(r).toEqual({ tab_index: 1, session_id: 's1', kind: 'session:provider' })
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('/api/tabs/new')
+    const init = call[1] as RequestInit
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string)
+    expect(body.kind.tag).toBe('session')
+    expect(body.kind.session_kind).toEqual({ tag: 'provider', provider: 'anthropic', model: 'placeholder' })
+  })
+
+  it('includes the agent in the session_kind payload when given', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ tab_index: 2, session_id: 's2', kind: 'session:provider' }),
+    })
+    await createTab('researcher')
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    const body = JSON.parse((call[1] as RequestInit).body as string)
+    expect(body.kind.session_kind.agent).toBe('researcher')
+  })
+
+  it('returns null on a non-ok response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    expect(await createTab()).toBeNull()
+  })
+
+  it('returns null when fetch throws', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    expect(await createTab()).toBeNull()
+  })
+})
+
+describe('destroyHarness', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('POSTs /destroy with confirm_adopted and returns true', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true })
+    expect(await destroyHarness(3, true)).toBe(true)
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0]!
+    expect(call[0]).toBe('/api/tabs/3/destroy')
+    const init = call[1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({ confirm_adopted: true })
+  })
+
+  it('returns false on a non-ok response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    expect(await destroyHarness(1, false)).toBe(false)
+  })
+
+  it('returns false when fetch throws', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    expect(await destroyHarness(1, true)).toBe(false)
+  })
+})
+
+describe('createSession (deprecated wrapper)', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('synthesises a SessionInfo from the new-tab response', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ tab_index: 2, session_id: 's9', kind: 'session:provider' }),
+    })
+    const s = await createSession('agentX')
+    expect(s).not.toBeNull()
+    expect(s!.id).toBe('s9')
+    expect(s!.agent).toBe('agentX')
+    expect(s!.runtime).toBe('session:provider')
+  })
+
+  it('returns null when the created tab has no session_id (raw shell)', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ tab_index: 1, session_id: null, kind: 'shell:bash' }),
+    })
+    expect(await createSession()).toBeNull()
+  })
+
+  it('returns null when tab creation fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    expect(await createSession()).toBeNull()
+  })
+})
+
+describe('fetchProviderModels', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('returns the provider model list', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(['opus-4', 'sonnet-4']),
+    })
+    expect(await fetchProviderModels('anthropic')).toEqual(['opus-4', 'sonnet-4'])
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/providers/anthropic/models')
+  })
+
+  it('returns [] when the response is not an array', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ not: 'an array' }),
+    })
+    expect(await fetchProviderModels('anthropic')).toEqual([])
+  })
+
+  it('returns [] when the call fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    expect(await fetchProviderModels('bogus')).toEqual([])
+  })
+})
+
+describe('useHarnesses', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('polls /api/harnesses on mount and stores the result', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'h1', activity: 'idle' }]),
+    })
+    const { result } = renderHook(() => useHarnesses())
+    await waitFor(() => expect(result.current.harnesses).toHaveLength(1))
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/harnesses')
+    expect(result.current.error).toBe(false)
+  })
+
+  it('sets error when the poll fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useHarnesses())
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+
+  it('sets error when fetch throws (fetchJson swallows and returns null)', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('net'))
+    const { result } = renderHook(() => useHarnesses())
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+})
+
+describe('useRecentSessions', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('polls /api/sessions/recent on mount', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: 'r1' }]),
+    })
+    const { result } = renderHook(() => useRecentSessions())
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/recent')
+  })
+
+  it('sets error when the poll fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useRecentSessions())
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+})
+
+describe('useArchivedSessions', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('polls /api/sessions/archived on mount', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: 'a1' }]),
+    })
+    const { result } = renderHook(() => useArchivedSessions())
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1))
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/archived')
+  })
+
+  it('sets error when the poll fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useArchivedSessions())
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+})
+
+describe('useTabs', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('polls /api/tabs and maps the wire rows to camelCase', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([
+        { index: 0, kind: 'shell:bash', name: 'bash', status: 'idle', session_id: null },
+      ]),
+    })
+    const { result } = renderHook(() => useTabs())
+    await waitFor(() => expect(result.current.tabs).toHaveLength(1))
+    expect(result.current.tabs[0]!.extModified).toBe(false)
+    expect(result.current.tabs[0]!.attachCommand).toBeNull()
+  })
+
+  it('sets error when the poll fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useTabs())
+    await waitFor(() => expect(result.current.error).toBe(true))
+  })
+
+  it('refresh() forces an immediate re-poll', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+    const { result } = renderHook(() => useTabs())
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
+    await act(async () => { await result.current.refresh() })
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe('useTranscript', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('returns an empty list and does not fetch when sessionId is null', () => {
+    const { result } = renderHook(() => useTranscript(null))
+    expect(result.current.entries).toEqual([])
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches the transcript for a session id (url-encoded)', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: 'e1' }]),
+    })
+    const { result } = renderHook(() => useTranscript('sess 1'))
+    await waitFor(() => expect(result.current.entries).toHaveLength(1))
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/sessions/sess%201/transcript')
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('falls back to an empty list when the fetch fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useTranscript('s'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.entries).toEqual([])
+  })
+
+  it('re-fetches when refresh() is called', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+    const { result } = renderHook(() => useTranscript('s'))
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1))
+    act(() => { result.current.refresh() })
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('useAgents', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('loads the agent list from /api/agents', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'researcher', isDefault: true }]),
+    })
+    const { result } = renderHook(() => useAgents())
+    await waitFor(() => expect(result.current.agents).toHaveLength(1))
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/agents')
+  })
+})
+
+describe('useConfiguredProviders', () => {
+  const originalFetch = globalThis.fetch
+  beforeEach(() => { globalThis.fetch = vi.fn() })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it('loads providers and flips loaded to true', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ name: 'anthropic', isDefault: true }]),
+    })
+    const { result } = renderHook(() => useConfiguredProviders())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.providers).toHaveLength(1)
+  })
+
+  it('still flips loaded to true when the call fails', async () => {
+    ;(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false })
+    const { result } = renderHook(() => useConfiguredProviders())
+    await waitFor(() => expect(result.current.loaded).toBe(true))
+    expect(result.current.providers).toEqual([])
   })
 })

--- a/frontend/src/hooks/__tests__/useListsStream.test.ts
+++ b/frontend/src/hooks/__tests__/useListsStream.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+
+// Mock the shared streamClient singleton so the default-client branch
+// (`client ?? streamClient()`) can be exercised without opening a real
+// WebSocket. Explicit-client tests pass their own fake and never hit this.
+const mocks = vi.hoisted(() => {
+  const unsub = vi.fn()
+  const fake = { onLists: vi.fn(() => unsub) }
+  return { streamClient: vi.fn(() => fake), fake, unsub }
+})
+vi.mock('../../lib/streamClient', () => ({ streamClient: mocks.streamClient }))
+
+import { useListsStream } from '../useListsStream'
+import type { SessionInfo } from '../../types'
+import type { ListsSnapshot, StreamClient } from '../../types/stream'
+
+function mkSession(id: string): SessionInfo {
+  return {
+    id,
+    agent: null,
+    runtime: 'provider',
+    model: 'opus',
+    lastActive: '2026-06-01T00:00:00Z',
+    createdAt: '2026-06-01T00:00:00Z',
+    description: null,
+    autoSummary: null,
+    firstMessageSnippet: null,
+    channel: null,
+    channelUserId: null,
+  }
+}
+
+/** A fake StreamClient that captures the `onLists` callback so a test can
+ *  drive a snapshot through it, and records its unsubscribe call. */
+function makeFakeClient() {
+  let cb: ((s: ListsSnapshot) => void) | null = null
+  const unsub = vi.fn()
+  const onLists = vi.fn((c: (s: ListsSnapshot) => void) => {
+    cb = c
+    return unsub
+  })
+  const client = {
+    status: 'open',
+    focus: vi.fn(),
+    onEntry: vi.fn(() => () => {}),
+    onActivity: vi.fn(() => () => {}),
+    onLists,
+    onStatusChange: vi.fn(() => () => {}),
+    lastError: () => null,
+  } as unknown as StreamClient
+  return {
+    client,
+    unsub,
+    emit: (s: ListsSnapshot) => {
+      if (cb) cb(s)
+    },
+  }
+}
+
+describe('useListsStream', () => {
+  it('starts with empty tabs and session lists', () => {
+    const { client } = makeFakeClient()
+    const { result } = renderHook(() => useListsStream(client))
+    expect(result.current.tabs).toEqual([])
+    expect(result.current.recentSessions).toEqual([])
+    expect(result.current.archivedSessions).toEqual([])
+  })
+
+  it('maps snake_case wire tabs to camelCase and stores the session lists on a snapshot', () => {
+    const { client, emit } = makeFakeClient()
+    const { result } = renderHook(() => useListsStream(client))
+    const recent = [mkSession('r1')]
+    const archived = [mkSession('a1')]
+    act(() => {
+      emit({
+        tabs: [
+          { index: 0, kind: 'shell:bash', name: 'bash', status: 'idle', session_id: null },
+        ],
+        recentSessions: recent,
+        archivedSessions: archived,
+      })
+    })
+    expect(result.current.tabs).toEqual([
+      {
+        index: 0,
+        kind: 'shell:bash',
+        name: 'bash',
+        status: 'idle',
+        session_id: null,
+        extModified: false,
+        stale: false,
+        origin: undefined,
+        attachCommand: null,
+      },
+    ])
+    expect(result.current.recentSessions).toEqual(recent)
+    expect(result.current.archivedSessions).toEqual(archived)
+  })
+
+  it('unsubscribes from the client on unmount', () => {
+    const { client, unsub } = makeFakeClient()
+    const { unmount } = renderHook(() => useListsStream(client))
+    unmount()
+    expect(unsub).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the shared streamClient when no client is passed', () => {
+    renderHook(() => useListsStream())
+    expect(mocks.streamClient).toHaveBeenCalled()
+    expect(mocks.fake.onLists).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Why

Frontend coverage was barely clearing thresholds, which contributed to recent CI nondeterminism. This targets the two thinnest, highest-traffic hook modules to add real margin.

## Coverage gains

| Module | Before | After |
|---|---|---|
| `hooks/useApi.ts` (the REST/API layer) | 45.7% stmts | **98.5% stmts · 100% lines** |
| `hooks/useListsStream.ts` | **0%** | **100%** |
| `src/hooks` (folder) | 68% | **94.5%** |
| **Whole frontend** | 75.3% stmts / 78.7% lines | **82.0% / 85.7%** |

## What's added

**`useApi.test.ts`** — tests for the previously-untested exports, each covering the ok / non-ok / throw branches:
- Polling list hooks: `useHarnesses`, `useRecentSessions`, `useTabs` (incl. `refresh`), `useArchivedSessions`
- `useTranscript` (null-session guard, fetch, `refresh`, failure→empty)
- `useAgents`, `useConfiguredProviders`
- Session mutators: `setSessionDescription`, `setSessionArchived` (archive + unarchive), `setSessionPrompt` (with/without name)
- `createTab` (with/without agent, payload shape), `destroyHarness` (confirm_adopted), `createSession` (deprecated wrapper), `fetchProviderModels`
- `useSendMessage` no-session guard + non-ok/throw error branches

**`useListsStream.test.ts`** (new) — drives a `lists` snapshot through a fake `StreamClient`: wire→camelCase tab mapping, session-list pass-through, unsubscribe on unmount, and the default-client fallback (via a mocked `streamClient`).

## Verification

- `npm test`: **331 passed** (was 285).
- `npm run build` (`tsc` strict + `vite build`): clean — the new tests type-check under `strict`/`noUncheckedIndexedAccess`.
- No production code changed; `package.json`/lock untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)