### PR TITLE
fix(harness): target tmux session unambiguously and reuse window 0 for first harness

### DIFF
--- a/src/PureClaw/Harness/ClaudeCode.hs
+++ b/src/PureClaw/Harness/ClaudeCode.hs
@@ -87,11 +87,15 @@ data ClaudeCodeDeps = ClaudeCodeDeps
     -- ^ Locate the @claude@ binary (production: @findExecutable \"claude\"@).
   , _ccd_checkTmux    :: IO (Either HarnessError ())
     -- ^ Confirm tmux is available (production: 'requireTmux').
-  , _ccd_addWindow    :: Text -> Text -> FilePath -> [Text] -> Maybe FilePath -> IO (Either HarnessError ())
-    -- ^ Create the harness window: @session windowName binary args workDir@
-    --   (production: 'addHarnessWindowNamed').
-  , _ccd_startSession :: Text -> IO (Either HarnessError ())
-    -- ^ Ensure the tmux session exists (production: 'startTmuxSession').
+  , _ccd_addWindow    :: TmuxSessionStatus -> Text -> Text -> FilePath -> [Text] -> Maybe FilePath -> IO (Either HarnessError ())
+    -- ^ Create the harness window:
+    --   @sessionStatus session windowName binary args workDir@. The status
+    --   (from '_ccd_startSession') tells the window step whether to reuse the
+    --   freshly created session's window 0 or append a new window (production:
+    --   'addHarnessWindowNamed').
+  , _ccd_startSession :: Text -> IO (Either HarnessError TmuxSessionStatus)
+    -- ^ Ensure the tmux session exists, reporting whether it was just created
+    --   or already existed (production: 'startTmuxSessionStatus').
   , _ccd_setMarker    :: Text -> Text -> Text -> IO ()
     -- ^ Stamp the @\@pcl_id@ marker: @session windowName uuidText@
     --   (production: 'setWindowMarker').
@@ -137,7 +141,7 @@ defaultClaudeCodeDeps = ClaudeCodeDeps
   , _ccd_findClaude   = Dir.findExecutable "claude"
   , _ccd_checkTmux    = requireTmux
   , _ccd_addWindow    = addHarnessWindowNamed
-  , _ccd_startSession = startTmuxSession
+  , _ccd_startSession = startTmuxSessionStatus
   , _ccd_setMarker    = setWindowMarker
   , _ccd_renameWindow = renameWindowNamed
   , _ccd_setRemain    = setRemainOnExit
@@ -288,13 +292,16 @@ mkClaudeCodeHarnessWith deps policy th session windowName _windowIdx mWorkDir ex
                 Left cmdErr -> pure (Left (HarnessNotAuthorized cmdErr))
                 Right authorizedCmd -> do
                   let program = getCommandProgram authorizedCmd
-                  -- Step 5: Start tmux session (idempotent)
+                  -- Step 5: Start tmux session (idempotent), learning whether
+                  -- we just created it or it already existed.
                   sessionResult <- _ccd_startSession deps session
                   case sessionResult of
                     Left err -> pure (Left err)
-                    Right () -> do
-                      -- Step 6: Add harness window (named)
-                      windowResult <- _ccd_addWindow deps session windowName program extraArgs mWorkDir
+                    Right sessionStatus -> do
+                      -- Step 6: Add harness window (named). A freshly created
+                      -- session reuses its window 0 so the first harness lands
+                      -- there; an existing session gets a new window.
+                      windowResult <- _ccd_addWindow deps sessionStatus session windowName program extraArgs mWorkDir
                       case windowResult of
                         Left err -> pure (Left err)
                         Right () -> do

--- a/src/PureClaw/Harness/Tmux.hs
+++ b/src/PureClaw/Harness/Tmux.hs
@@ -403,9 +403,19 @@ renameWindowNamedArgs sessionName windowName newLabel =
 
 -- | @new-window@ argv creating a named window in a session, optionally honoring
 -- a working directory (@-c@). The command string is run in the new window.
+--
+-- The target is the SESSION form @\<session\>:@ (trailing colon), NOT the bare
+-- session name. @new-window@'s @-t@ is an /insertion-window/ target: a bare
+-- name is resolved by tmux as a window-name match in the CURRENT session first,
+-- so if the user has a window named e.g. @pureclaw@ in their attached session,
+-- @-t pureclaw@ lands on that window's index and tmux fails with
+-- @create window failed: index 0 in use@ — the harness window is never created.
+-- The trailing colon pins the target to the session named @\<session\>@, so
+-- tmux allocates the next free window index there regardless of any same-named
+-- windows elsewhere on the server.
 newWindowNamedArgs :: Text -> Text -> Maybe FilePath -> String -> [String]
 newWindowNamedArgs sessionName windowName mWorkDir cmd =
-  ["new-window", "-t", T.unpack sessionName, "-n", T.unpack windowName]
+  ["new-window", "-t", T.unpack sessionName <> ":", "-n", T.unpack windowName]
     <> dirArgs
     <> [cmd]
   where
@@ -506,22 +516,36 @@ renameWindowNamed sessionName windowName newLabel = do
   _ <- runTmuxSilent (renameWindowNamedArgs sessionName windowName newLabel)
   pure ()
 
--- | Add a harness window addressed by name. If the session was just created
--- and still has its fresh default window 0, reuse it (send the command); else
--- create a new named window. Honors an optional working directory.
+-- | Add a harness window addressed by name, given whether the tmux session was
+-- just created by us ('TmuxSessionCreated') or already existed
+-- ('TmuxSessionExisted').
+--
+-- A freshly created session still holds only its default window 0 (a bare
+-- shell), so we REUSE it: rename it to @windowName@, @cd@ if asked, then run
+-- the command. This keeps the FIRST harness in window 0 instead of stranding an
+-- idle shell there and opening the harness in window 1. An existing session
+-- already has windows, so we append a new named window.
+--
+-- The status comes from 'startTmuxSessionStatus' and is authoritative. An
+-- earlier version inferred freshness from window 0's NAME (@name == index@),
+-- but that never holds under tmux @automatic-rename@ — a new session's window 0
+-- is named after its shell (e.g. @zsh@), not @0@ — so the reuse branch was dead
+-- and every harness, including the first, landed in a new window.
 --
 -- Targets and names the window by 'Text' rather than by index.
-addHarnessWindowNamed :: Text -> Text -> FilePath -> [Text] -> Maybe FilePath -> IO (Either HarnessError ())
-addHarnessWindowNamed sessionName windowName binary args mWorkDir = do
+addHarnessWindowNamed :: TmuxSessionStatus -> Text -> Text -> FilePath -> [Text] -> Maybe FilePath -> IO (Either HarnessError ())
+addHarnessWindowNamed sessionStatus sessionName windowName binary args mWorkDir = do
   tmuxCheck <- requireTmux
   case tmuxCheck of
     Left err -> pure (Left err)
     Right () -> do
       let stealthCmd = stealthShellCommand binary args
-      fresh <- isFreshDefaultWindow sessionName
-      if fresh
-        then do
-          -- Reuse the session's fresh default window 0: name it, then run.
+      case sessionStatus of
+        TmuxSessionCreated -> do
+          -- Reuse the freshly created session's default window 0: name it, then
+          -- run. 'renameWindowNamed' targets @session:0@, which resolves to
+          -- window INDEX 0 (no window is named "0"), so it works regardless of
+          -- the shell-derived default name.
           renameWindowNamed sessionName "0" windowName
           case mWorkDir of
             Just dir ->
@@ -533,22 +557,18 @@ addHarnessWindowNamed sessionName windowName binary args mWorkDir = do
           -- Enter to execute it.
           sendLineNamed sessionName windowName (BC.pack stealthCmd)
           pure (Right ())
-        else do
-          (exitCode, _stderr) <- runTmux (newWindowNamedArgs sessionName windowName mWorkDir stealthCmd)
+        TmuxSessionExisted -> do
+          (exitCode, stderr) <- runTmux (newWindowNamedArgs sessionName windowName mWorkDir stealthCmd)
           case exitCode of
             ExitSuccess   -> pure (Right ())
-            ExitFailure _ -> pure (Right ())
-
--- | A session has a \"fresh\" default window when it holds exactly one window
--- still named with tmux's default (a bare numeric index, e.g. @0@). Used to
--- decide whether 'addHarnessWindowNamed' should reuse window 0 or create a new
--- one (spike §11).
-isFreshDefaultWindow :: Text -> IO Bool
-isFreshDefaultWindow sessionName = do
-  windows <- listSessionWindows sessionName
-  pure $ case windows of
-    [(idx, name)] -> name == T.pack (show idx)
-    _             -> False
+            -- Surface the failure rather than swallowing it as success: a
+            -- dropped @new-window@ error previously left the caller believing
+            -- the harness launched (registering a phantom entry the reconciler
+            -- later evicts) while no window or command ever ran. Fail loud so
+            -- the create path reports the real tmux error (everything-visible).
+            ExitFailure c -> pure (Left (HarnessTmuxNotAvailable
+              ("tmux new-window failed (exit " <> T.pack (show c) <> "): "
+                <> TE.decodeUtf8Lenient stderr)))
 
 -- ---------------------------------------------------------------------------
 -- Identity markers + server sweep

--- a/test/Harness/ClaudeCodeSpec.hs
+++ b/test/Harness/ClaudeCodeSpec.hs
@@ -19,7 +19,7 @@ import PureClaw.Handles.Harness
 import PureClaw.Handles.Transcript
 import PureClaw.Harness.ClaudeCode
 import PureClaw.Harness.Registry qualified as Reg
-import PureClaw.Harness.Tmux (TmuxWindowRow (..), validateTmuxIdent)
+import PureClaw.Harness.Tmux (TmuxSessionStatus (..), TmuxWindowRow (..), validateTmuxIdent)
 import PureClaw.Security.Adoption
 import PureClaw.Security.Command
 import PureClaw.Security.Policy
@@ -47,8 +47,8 @@ okDeps = ClaudeCodeDeps
   { _ccd_newId        = pure fixedId
   , _ccd_findClaude   = pure (Just "/usr/bin/claude")
   , _ccd_checkTmux    = pure (Right ())
-  , _ccd_addWindow    = \_ _ _ _ _ -> pure (Right ())
-  , _ccd_startSession = \_ -> pure (Right ())
+  , _ccd_addWindow    = \_ _ _ _ _ _ -> pure (Right ())
+  , _ccd_startSession = \_ -> pure (Right TmuxSessionCreated)
   , _ccd_setMarker    = \_ _ _ -> pure ()
   , _ccd_renameWindow = \_ _ _ -> pure ()
   , _ccd_setRemain    = \_ _ -> pure ()
@@ -127,7 +127,7 @@ spec = do
       result <- mkClaudeCodeHarnessWith
         okDeps
           { _ccd_findClaude = pure (Just "/custom/path/to/claude")
-          , _ccd_addWindow = \_ _ binary _ _ -> do
+          , _ccd_addWindow = \_ _ _ binary _ _ -> do
               writeIORef usedPathRef (Just binary)
               pure (Right ())
           }
@@ -424,7 +424,7 @@ spec = do
           uuid  = "fedcfedc-1234-4abc-8abc-fedcfedcfedc"
           extra = claudeCodeExtraArgs True (Just uuid)
       result <- mkClaudeCodeHarnessWith
-        okDeps { _ccd_addWindow = \_ _ _ args _ -> do
+        okDeps { _ccd_addWindow = \_ _ _ _ args _ -> do
                    writeIORef argvRef args
                    pure (Right ()) }
         policy mkNoOpTranscriptHandle "pureclaw" "claude-code-0" 0 Nothing

--- a/test/Harness/TmuxSpec.hs
+++ b/test/Harness/TmuxSpec.hs
@@ -71,12 +71,26 @@ spec = do
 
     it "newWindowNamedArgs creates a named window without a workdir" $ do
       let argv = newWindowNamedArgs "pureclaw" "claude-code-x" Nothing "the-cmd"
-      argv `shouldBe` ["new-window", "-t", "pureclaw", "-n", "claude-code-x", "the-cmd"]
+      argv `shouldBe` ["new-window", "-t", "pureclaw:", "-n", "claude-code-x", "the-cmd"]
 
     it "newWindowNamedArgs honors an optional working directory" $ do
       let argv = newWindowNamedArgs "pureclaw" "claude-code-x" (Just "/tmp/work") "the-cmd"
       argv `shouldBe`
-        ["new-window", "-t", "pureclaw", "-n", "claude-code-x", "-c", "/tmp/work", "the-cmd"]
+        ["new-window", "-t", "pureclaw:", "-n", "claude-code-x", "-c", "/tmp/work", "the-cmd"]
+
+    -- Regression: new-window's @-t@ is an INSERTION-WINDOW target, not a
+    -- session target. A BARE session name (@-t pureclaw@) is resolved by tmux
+    -- as a window-name match in the CURRENT session first — so if the user has
+    -- a window named @pureclaw@ in their attached session, the launch lands on
+    -- that window's index ("create window failed: index 0 in use") and the
+    -- harness silently never starts. The trailing colon (@-t pureclaw:@) pins
+    -- the target to the SESSION named @pureclaw@, so tmux allocates the next
+    -- free window index there regardless of same-named windows elsewhere.
+    it "newWindowNamedArgs targets the SESSION (trailing colon), not a bare name" $ do
+      let argv = newWindowNamedArgs "pureclaw" "claude-code-x" Nothing "the-cmd"
+      -- The target must be the session form, never the ambiguous bare name.
+      drop 1 (takeWhile (/= "-n") argv) `shouldBe` ["-t", "pureclaw:"]
+      argv `shouldNotContain` ["-t", "pureclaw"]
 
   -- D6.3 (regression) — the launch path (`cd <dir>` + the stealth-launch
   -- command, in addHarnessWindowNamed / realSendNamed) must STILL EXECUTE: it
@@ -548,6 +562,47 @@ spec = do
           sendToWindowNamed sName wName (BC.pack "echo PURECLAW_NAMED_MARKER")
           out <- captureWindowNamed sName wName 300
           BC.unpack out `shouldContain` "PURECLAW_NAMED_MARKER"
+          stopTmuxSession sName
+
+    -- The existing-session branch must FAIL LOUD: a failing `tmux new-window`
+    -- (here, an absent target session) returns Left rather than swallowing the
+    -- error as success. Previously it returned Right (), so a launch that never
+    -- created a window or ran a command looked successful — leaving a phantom
+    -- registry entry the reconciler later evicts.
+    it "addHarnessWindowNamed surfaces a new-window failure as Left" $ do
+      available <- requireTmux
+      case available of
+        Left _ -> pendingWith "tmux not available on this system"
+        Right () -> do
+          -- TmuxSessionExisted -> the new-window branch; `new-window -t
+          -- '<missing>:'` fails ("can't find session") for an absent session.
+          result <- addHarnessWindowNamed TmuxSessionExisted
+                      "pureclaw-test-absent-session" "claude-code-0" "/bin/echo" [] Nothing
+          result `shouldSatisfy` isLeft
+
+    -- The first harness in a freshly created session reuses window 0; a second
+    -- harness (session now exists) appends window 1. This pins the placement so
+    -- a fresh session does not strand an idle shell in window 0 (regression for
+    -- the dead `name == index` freshness heuristic that always opened window 1).
+    it "reuses window 0 for the first harness, appends for the next" $ do
+      available <- requireTmux
+      case available of
+        Left _ -> pendingWith "tmux not available on this system"
+        Right () -> do
+          let sName = "pureclaw-test-window0-reuse"
+          stopTmuxSession sName
+          -- A long-lived command keeps both windows alive for the assertions
+          -- (the new-window branch closes the window when its command exits).
+          created <- startTmuxSessionStatus sName
+          created `shouldBe` Right TmuxSessionCreated
+          r1 <- addHarnessWindowNamed TmuxSessionCreated sName "claude-code-0" "/bin/sleep" ["30"] Nothing
+          r1 `shouldSatisfy` isRight
+          ws1 <- listSessionWindows sName
+          ws1 `shouldBe` [(0, "claude-code-0")]
+          r2 <- addHarnessWindowNamed TmuxSessionExisted sName "claude-code-1" "/bin/sleep" ["30"] Nothing
+          r2 `shouldSatisfy` isRight
+          ws2 <- listSessionWindows sName
+          ws2 `shouldBe` [(0, "claude-code-0"), (1, "claude-code-1")]
           stopTmuxSession sName
 
     -- D1.6 — harnessPidOf returns Nothing for a bogus shell pid


### PR DESCRIPTION
## Summary

Two fixes in the tmux harness launch path, both surfaced while debugging "create a new harness in the web frontend → tmux session appears but the harness never runs."

### 1. Harness silently never launched when a tmux window was named after the session
The frontend adds a harness as a **window** in the `pureclaw` **session** via `tmux new-window -t pureclaw …`. But `new-window`'s `-t` is an *insertion-window* target, so a bare session name resolves to a **window** of that name in the current session first. If the user has a window named `pureclaw` in their attached session, tmux lands on that window's index and fails:

```
create window failed: index 0 in use
```

The session itself is created via `new-session -s pureclaw` (unambiguous), so it *appeared* while the harness never started. Two changes:
- `newWindowNamedArgs` now targets the **session form `<session>:`** (trailing colon), which always allocates the next free window index in the named session, regardless of same-named windows elsewhere.
- The existing-session branch now returns `Left` with the real tmux stderr instead of **swallowing `ExitFailure` as success** — a swallowed failure previously left a phantom registry entry the reconciler later evicted (`evicting harness … after 15 orphaned ticks`).

### 2. First harness opened in window 1, leaving an idle shell in window 0
The reuse-window-0 path was gated by `isFreshDefaultWindow`, which inferred freshness from window 0's **name** (`name == index`). Under tmux `automatic-rename` that's never true (a new session's window 0 is named after its shell, e.g. `zsh`), so the branch was **dead** and every harness — including the first — opened in a new window.

Replaced the heuristic with the authoritative `TmuxSessionCreated | TmuxSessionExisted` status that `startTmuxSession**Status**` already returns, threaded through `_ccd_startSession` → `_ccd_addWindow` → `addHarnessWindowNamed`, and **deleted `isFreshDefaultWindow`**. Net: less code, no guessing.

## Verification (real gateway, clean boot)
- 1st harness, no existing session → single window `idx=0 claude-code-0` running Claude, **no idle shell**.
- 2nd harness → `idx=0 claude-code-0`, `idx=1 claude-code-1`.
- Original trigger reproduced (a window named `pureclaw` present) → harness now launches correctly.

## Tests / gates
- New: argv-shape tests pinning the `<session>:` target; integration tests for window-0 reuse (first → window 0, second → window 1) and fail-loud on `new-window` failure. Updated `newWindowNamedArgs` arg-shape tests and the `ClaudeCodeDeps` fakes.
- Full suite **2757 examples, 0 failures**; `-Wall -Werror` and hlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)