### PR TITLE
fix(tabs): stop swallowing AsyncCancelled in the provider turn (fixes flaky 6h CI hang)

### DIFF
--- a/src/PureClaw/Agent/Turn.hs
+++ b/src/PureClaw/Agent/Turn.hs
@@ -167,7 +167,10 @@ cycleTurn deps ctx = do
   streamedRef <- Ref.newIORef False
   -- Mirror Loop's @try@ around the stream so a throwing provider does not
   -- bring the turn down. The sink, not @_env_channel@, receives framing.
-  streamResult <- E.try @E.SomeException $
+  -- Catches SYNCHRONOUS provider failures only — async exceptions are
+  -- re-thrown (see 'tryStreamSync') so a tab's '_rt_stop' can actually cancel a
+  -- worker blocked mid-stream.
+  streamResult <- tryStreamSync $
     _turn_stream deps req $ \case
       P.StreamText t   -> Ref.writeIORef streamedRef True >> _turn_emit deps (TurnChunk sid t)
       P.StreamWarning _ -> pure ()      -- non-fatal; logged by prod sink elsewhere
@@ -208,6 +211,24 @@ cycleTurn deps ctx = do
       case mResp of
         Nothing   -> pure ctx        -- no StreamDone captured: stop gracefully
         Just resp -> handleResponse deps ctx resp
+
+-- | Run the provider stream, returning 'Left' for a SYNCHRONOUS provider
+-- failure (so a throwing provider does not bring the turn down — the legacy
+-- behaviour) but RE-THROWING async exceptions.
+--
+-- A catch-all @try \@SomeException@ would also catch 'AsyncCancelled' (it is a
+-- 'SomeException'), so when a tab's '_rt_stop' (@Async.cancel@) throws it to a
+-- worker blocked mid-stream, the catch would swallow it: the worker would loop
+-- on, never terminate, and the canceller's @wait@ would block forever — the
+-- provider-runtime teardown hang (a 6h CI timeout). Re-throwing any
+-- 'E.SomeAsyncException' (which wraps 'AsyncCancelled', 'ThreadKilled', …) lets
+-- cancellation propagate and kill the worker.
+tryStreamSync :: IO a -> IO (Either E.SomeException a)
+tryStreamSync act = do
+  result <- E.try act
+  case result of
+    Left e | Just (E.SomeAsyncException _) <- E.fromException e -> E.throwIO e
+    _ -> pure result
 
 -- | Fold a captured response into the context: append + record the assistant
 -- message, then either finish (no tool calls) or run the calls and re-complete

--- a/test/Tabs/RuntimesSpec.hs
+++ b/test/Tabs/RuntimesSpec.hs
@@ -66,6 +66,7 @@ import PureClaw.Tabs.Runtimes
   )
 import PureClaw.Tabs.Types (TabRef (..))
 import System.Exit (ExitCode (..))
+import System.Timeout (timeout)
 
 -- ---------------------------------------------------------------------------
 -- Shared fakes / helpers
@@ -391,7 +392,31 @@ spec = do
       result <- sendUntilLeft rt 50
       -- Force the Left payload: back-pressure surfaces as 'TabConcurrencyLimit'.
       assertConcurrencyLimit result
-      _rt_stop rt
+      -- Bound teardown so a regression that swallows the cancel surfaces as a
+      -- fast failure here instead of a 6h CI hang (see "stop while mid-stream").
+      stopWithin rt
+
+  describe "mkProviderRuntime — stop while mid-stream" $
+    it "cancels a worker blocked inside the provider stream (no teardown hang)" $ do
+      -- The worker reaches the provider stream and blocks there forever; '_rt_stop'
+      -- must still terminate it. A catch-all @try@ that swallowed the
+      -- 'AsyncCancelled' from '_rt_stop' (Async.cancel) would leave the worker
+      -- alive and the canceller's wait blocked forever — the provider-runtime
+      -- teardown hang. The MVar handshake makes "worker is mid-stream" exact, so
+      -- this is deterministic, not timing-dependent.
+      started <- newEmptyMVar
+      gate    <- newEmptyMVar          -- never filled: the stream blocks forever
+      emits   <- newIORef []
+      records <- newIORef []
+      seedRef <- newIORef (Ctx.emptyContext Nothing)
+      let stallStream _req _cb = putMVar started () >> takeMVar gate
+          deps = mkProvDeps stallStream noExec
+                            (recordingEmit emits) (\m -> modifyIORef' records (++ [m]))
+                            (readIORef seedRef)
+      rt <- mkProviderRuntime deps
+      _rt_send rt "go" `shouldReturn` Right ()
+      takeMVar started                 -- worker is now blocked INSIDE the stream
+      stopWithin rt
 
   describe "mkHarnessRuntime — send queue full" $
     it "returns Left when the writer is stalled and the bounded queue fills" $ do
@@ -423,10 +448,20 @@ spec = do
       recvDone  <- newEmptyMVar
       signalled <- newIORef False
       fh <- mkFakeHarness scriptRef statusRef recvDone signalled
-      emits <- newIORef []
-      let deps = mkHarnDeps (_fh_handle fh) (recordingEmit emits)
+      emits   <- newIORef []
+      emitted <- newEmptyMVar       -- fires once when the drainer EMITS a FullMsg
+      -- Synchronise on the EMIT, not on _hh_receive: the fake signals recvDone
+      -- INSIDE receive, BEFORE the drainer emits the FullMsg, so gating on
+      -- recvDone could race _rt_stop ahead of the emit (cancelling the drainer
+      -- mid-cycle -> "[] does not contain [\"out\"]"). Gating on the emit is exact.
+      let recordingEmitThenSignal r ev = do
+            recordingEmit emits r ev
+            case ev of
+              FullMsg _ _ -> void (tryPutMVar emitted ())
+              _           -> pure ()
+          deps = mkHarnDeps (_fh_handle fh) recordingEmitThenSignal
       rt <- mkHarnessRuntime deps
-      takeMVar recvDone             -- drainer consumed the scripted output
+      takeMVar emitted              -- drainer has emitted the FullMsg
       sendR <- _rt_send rt "cmd"
       sendR `shouldSatisfy` isRight
       forwarded <- takeMVar (_fh_sendDone fh)  -- block until writer forwarded it
@@ -499,3 +534,12 @@ assertConcurrencyLimit = \case
     expectationFailure ("expected TabConcurrencyLimit, got " <> show other)
   Right ()                         ->
     expectationFailure "expected Left (back-pressure), got Right ()"
+
+-- | Stop a runtime, asserting teardown COMPLETES within a generous bound. A
+-- runtime whose worker swallows the cancel never terminates, so '_rt_stop'
+-- (Async.cancel) would block forever; the timeout converts that regression into
+-- a fast, clear test failure instead of a multi-hour CI hang.
+stopWithin :: Runtime -> Expectation
+stopWithin rt = do
+  done <- timeout 5000000 (_rt_stop rt)   -- 5s; teardown is otherwise instant
+  done `shouldBe` Just ()


### PR DESCRIPTION
## Summary

Fixes the flaky `aarch64-darwin` CI hang on `Tabs.Runtimes` (the 6-hour timeout seen on #89's CI, e.g. `mkProviderRuntime — input queue full`). Root cause is a **source bug**, not just a flaky test.

### Root cause: a catch-all `try` swallows `AsyncCancelled`

`cycleTurn` (Agent/Turn.hs) wrapped the provider stream in:

```haskell
streamResult <- E.try @E.SomeException $ _turn_stream deps req (\case …)
```

`try @SomeException` catches **`AsyncCancelled`** too (it's a `SomeException`). A tab's `_rt_stop` cancels its worker via `Async.cancel`, which throws `AsyncCancelled` and then **waits** for the worker to terminate. If the worker is blocked *inside* the stream `try` (e.g. mid-completion), the `try` swallows the cancel, the worker loops back to `readTBQueue` still alive, and `Async.cancel`'s wait **blocks forever** → the provider-runtime teardown hang.

It's flaky because it only hangs when `_rt_stop` fires while the worker is inside the stream `try` — timing-dependent (common on the darwin runner, rare locally where the bounded queue fills before the worker is even scheduled to process its first item). This matches the prior "6h CI hang" history in this subsystem.

### Fix

`tryStreamSync` re-throws any `SomeAsyncException` (which wraps `AsyncCancelled`, `ThreadKilled`, …) while still returning `Left` for *synchronous* provider failures — so a throwing provider still doesn't bring the turn down, but cancellation now propagates and kills the worker. Consistent with the existing rethrow-`AsyncCancelled` pattern in `Frontend/Stream.hs` and `Frontend/BroadcastingTranscript.hs`.

This is a real production correctness fix: closing/detaching a provider tab mid-stream would otherwise hang the caller of `_rt_stop`.

## Tests
- **New deterministic regression** `mkProviderRuntime — stop while mid-stream`: an `MVar` handshake puts the worker *inside* the stream, then asserts `_rt_stop` completes within a 5s bound. Verified **RED** against the unfixed source (`expected Just () but got Nothing` — teardown hung to the timeout).
- `stopWithin` also bounds teardown in the `input queue full` test, so any future teardown-hang regression fails fast in ~5s instead of burning 6h of CI.
- Fixed a **second flaky test**, `mkHarnessRuntime — drainer + writer`: it synchronised on `recvDone`, which the fake signals *inside* `_hh_receive` (before the drainer emits), letting `_rt_stop` race ahead and cancel the drainer before the emit (`[] does not contain ["out"]`). It now gates on the emit landing — deterministic.

## Verification
- Full suite green: **2758 examples, 0 failures**.
- `Tabs.Runtimes` run **8×** locally with a 90s-per-run hang guard — all pass, no hang.
- `-Wall -Werror` and hlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)