### PR TITLE
Harness output streaming — Phase 1 (reliable output flow)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-harness-output-streaming-phase1.md
+++ b/docs/superpowers/plans/2026-06-19-harness-output-streaming-phase1.md
@@ -1,0 +1,1025 @@
+# Harness Output Streaming — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make tmux-harness output (Claude Code today) flow reliably into the PureClaw session — on-demand via a `/harness output` command and automatically via a background watcher — with correct working / idle / awaiting-input detection.
+
+**Architecture:** A per-flavour pure `HarnessObserver` (classify activity + extract response + relevant tail) replaces the broken `isIdle`. The reconcile loop (already polling every 2 s) adopts the observer and becomes the sole recorder of harness Response output on working→settle transitions. The harness send path is decoupled from receive. A `_hh_snapshot` handle capability powers the on-demand command.
+
+**Tech Stack:** Haskell (GHC 9.12, `-Wall -Werror`, hspec, TDD); React/TypeScript (vitest) for the status pill.
+
+**Design spec:** `docs/superpowers/specs/2026-06-18-harness-output-streaming-design.md`
+
+## Global Constraints
+
+- Build/test only via Nix: `nix develop . --command cabal build` / `… cabal test`. Never bare `cabal`.
+- GHC `-Wall -Werror -Wincomplete-record-updates -Wmissing-export-lists`; hlint clean. Adding a record field means updating ALL construction sites.
+- Import style: `qualified as` (no explicit import lists except canonical `import Data.Set (Set)`).
+- TDD mandatory: write the failing test, run it red, implement minimally, run green, commit. Commit the failing test separately is encouraged but a single red→green→commit per step is acceptable.
+- Coverage gate: `.coverage-thresholds.json` (lines/branches/functions/statements ≥ 95), enforced via `cabal test --enable-coverage`. Blocking before PR.
+- Frontend: `cd frontend && npx vitest run` and `npx tsc --noEmit` must pass; no eslint gate.
+- `HarnessEntry` does NOT derive Eq/Show (it holds a `HarnessHandle`); do not add deriving.
+- AsyncCancelled must always be re-raised in any catch-all (project invariant) — see reconcile loop's `outer` handler.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/PureClaw/Harness/Tmux.hs` | tmux capture argv | add `-J` to `captureNamedArgs` |
+| `src/PureClaw/Harness/Observer.hs` | **NEW** per-flavour pure detection/extraction seam | create |
+| `src/PureClaw/Frontend/Activity/Types.hs` | `HarnessActivity` vocabulary | add `HarnessNeedsInput` |
+| `src/PureClaw/Frontend/Stream.hs` | `ActivityKind` + encoding | (no change — encodes via `HarnessActivity`) |
+| `src/PureClaw/Harness/Registry.hs` | `Liveness`, `HarnessEntry` | add `LivenessAwaitingInput`, `_he_flavour` |
+| `src/PureClaw/Frontend/TabsView.hs` | `livenessToTabStatus` | add `LivenessAwaitingInput` arm |
+| `src/PureClaw/Handles/Harness.hs` | `HarnessHandle` | add `_hh_snapshot` |
+| `src/PureClaw/Harness/ClaudeCode.hs` | Claude handle + (now thin) marker reuse | wire `_hh_snapshot`; use Observer in `pollUntilIdle` |
+| `src/PureClaw/Harness/Reconcile.hs` | activity classification + output watcher | observer-based classify; record on settle |
+| `src/PureClaw/Agent/SlashCommands.hs` | `/harness output` | add subcommand + spec + parser + handler |
+| `src/PureClaw/Frontend/API.hs` | send path | decouple send from receive |
+| `frontend/src/types.ts` | `HarnessActivity` TS type | add `'needs-input'` |
+| `frontend/src/components/StatusDot.tsx` | activity → dot class | add `'needs-input'` key |
+| `test/fixtures/harness/*.txt` | **NEW** real capture fixtures | create |
+
+## Cascade & construction-site inventory (-Werror)
+
+Adding constructors/fields forces edits at EVERY match/construction site. These are the complete, verified lists; the owning task must edit all of them (file scope includes every file named here).
+
+**Adding `LivenessAwaitingInput` to `Liveness` (Task 3)** — every exhaustive `case` on `Liveness`:
+- `src/PureClaw/Harness/Reconcile.hs` `livenessToActivity` → `HarnessNeedsInput` (Task 6 finalizes).
+- `src/PureClaw/Frontend/TabsView.hs:105-111` `livenessToTabStatus` → `"running"` (the tab-row status keeps its existing 4-value frontend vocabulary; the awaiting-input distinction is carried by the activity dot, not the tab badge). Add a test asserting this in `test/Frontend/TabsViewSpec.hs` and the `livenessToTabStatus` describe in `test/Frontend/APISpec.hs`.
+- Any other `case … of` on `Reg.Liveness` the compiler flags (e.g. `diffLiveness` in Reconcile.hs uses `Eq`, not a case — no change). Build to confirm none remain.
+
+**Adding `HarnessNeedsInput` to `HarnessActivity` (Task 3)** — every exhaustive site:
+- `ToJSON HarnessActivity` (Activity/Types.hs) → `"needs-input"`.
+- `frontend/src/types.ts` `HarnessActivity` union → add `'needs-input'`.
+- `frontend/src/components/StatusDot.tsx` `activityDotClass: Record<HarnessActivity,string>` → add key.
+- Confirm no other exhaustive Haskell `case` on `HarnessActivity` (grep: only the `ToJSON` instance).
+
+**Adding `_he_flavour :: !HarnessFlavour` to `HarnessEntry` (Task 6)** — ALL 8 construction sites:
+- `src/PureClaw/Harness/ClaudeCode.hs:331`, `:547`
+- `src/PureClaw/Harness/Reconcile.hs:545` (boot reconstruct)
+- `test/Frontend/TabsViewSpec.hs:62`
+- `test/Frontend/APISpec.hs:~4182` (`baseEntry`)
+- `test/Harness/RegistrySpec.hs:30` (`mkEntry`) and `:303` (inline)
+- `test/Harness/ReconcileSpec.hs:57` (`mkEntry`)
+All set `HClaudeCode` (every current harness is Claude Code).
+
+**Adding `_hh_snapshot :: Int -> IO Text` to `HarnessHandle` (Task 4)** — ALL construction sites:
+- `src/PureClaw/Handles/Harness.hs:45` (`mkNoOpHarnessHandle`) → `\_ -> pure ""`
+- `src/PureClaw/Harness/ClaudeCode.hs:399` (real), `:857` (discovered) → real wiring
+- `src/PureClaw/Agent/SlashCommands.hs:~2416` (`mkHandle`) → wire or `\_ -> pure ""`
+- `test/Frontend/APISpec.hs:4017,4049,4064`; `test/Tabs/RuntimesSpec.hs:188,428,498` → `\_ -> pure ""`
+- Any inline `HarnessHandle{…}` the compiler flags.
+
+**`isIdle` disposition (Task 8)** — `isIdle` (ClaudeCode.hs:782) has call sites at `ClaudeCode.hs:753` and `:918`, is exported (`:23`), and imported by `Reconcile.hs:85`. It is NOT deleted; it is redefined via the observer (see Task 8). The `Reconcile.hs:85` import is dropped in Task 6 (the reconcile path moves to `_ho_classify`). Its direct tests at `test/Harness/ClaudeCodeSpec.hs:444-451` are updated to the corrected expectations in Task 8.
+
+**`classifyLiveness` disposition (Task 6)** — `classifyLiveness` (Reconcile.hs:222) is REPLACED by `classifyFromObserver`. Its direct tests at `test/Harness/ReconcileSpec.hs:171-179` are removed and replaced by the `classifyFromObserver` tests in Task 6.
+
+**`_rd_capture` signature change (Task 6)** — `_rd_capture :: Text -> Text -> IO Bool` (Reconcile.hs:111) becomes `IO (Maybe Text)`. This is a `-Werror` type break at every fake-deps site in `test/Harness/ReconcileSpec.hs`: `:108`, `:116`, `:365`, `:559` (and `defaultReconcileDeps` at Reconcile.hs:143). All must be updated: the production dep returns `Just <raw capture>`/`Nothing`; fakes return `Just "<frame text>"` / `Nothing`. ReconcileSpec is in Task 6 scope.
+
+**`reconcileTick` / `classifyRow` / loop signatures (Tasks 6, 7)** — these change concretely (new prev-capture + prev-response threading); the exact new signatures are given in Tasks 6 and 7. Any test calling `reconcileTick`/`classifyRow` directly (search `test/Harness/ReconcileSpec.hs` for both names) is updated there.
+
+---
+
+### Task 1: Capture joins wrapped lines (`-J`)
+
+**Files:**
+- Modify: `src/PureClaw/Harness/Tmux.hs` (`captureNamedArgs`, lines 387-391)
+- Test: `test/Harness/TmuxSpec.hs` (add to existing capture-args describe; if none, add a new `describe`)
+
+**Interfaces:**
+- Produces: `captureNamedArgs :: Text -> Text -> Int -> [String]` (unchanged signature; argv now contains `-J`).
+
+- [ ] **Step 1: Write the failing test**
+
+```haskell
+  describe "captureNamedArgs" $
+    it "joins wrapped lines with -J so long lines are not split" $
+      captureNamedArgs "sess" "win" 50
+        `shouldBe`
+        [ "capture-pane", "-t", "sess:win", "-p", "-J", "-S", "-50" ]
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `nix develop . --command cabal test --test-options='--match "/captureNamedArgs/"'`
+Expected: FAIL — actual list lacks `"-J"`.
+
+- [ ] **Step 3: Implement**
+
+```haskell
+captureNamedArgs :: Text -> Text -> Int -> [String]
+captureNamedArgs sessionName windowName lineCount =
+  [ "capture-pane", "-t", windowTarget sessionName windowName
+  , "-p", "-J", "-S", "-" <> show lineCount
+  ]
+```
+
+- [ ] **Step 4: Run green** — same command, PASS.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PureClaw/Harness/Tmux.hs test/Harness/TmuxSpec.hs
+git commit -m "feat(tmux): join wrapped lines with -J in capture-pane"
+```
+
+---
+
+### Task 2: `HarnessObserver` module (per-flavour detection + extraction)
+
+**Files:**
+- Create: `src/PureClaw/Harness/Observer.hs`
+- Create fixtures: `test/fixtures/harness/claude-working.txt`, `claude-idle.txt`, `claude-approval.txt`, `claude-response.txt`, `claude-menu-cursor.txt`
+- Test: `test/Harness/ObserverSpec.hs`
+- Modify: `pureclaw.cabal` (add `PureClaw.Harness.Observer` to library `exposed-modules` and `Harness.ObserverSpec` to the test suite `other-modules`)
+
+**Interfaces:**
+- Produces:
+  ```haskell
+  data HarnessActivityState = HasWorking | HasAwaitingInput | HasIdle
+    deriving stock (Eq, Show)
+  data HarnessObserver = HarnessObserver
+    { _ho_classify        :: Text -> HarnessActivityState
+    , _ho_extractResponse :: Int -> ByteString -> Text
+    , _ho_relevantTail    :: Int -> ByteString -> Text
+    }
+  observerFor :: HarnessFlavour -> HarnessObserver
+  claudeObserver :: HarnessObserver
+  genericObserver :: HarnessObserver
+  ```
+- Consumes: `HarnessFlavour` from `PureClaw.Session.Kind`.
+
+**Fixtures (create from real captures — representative content):**
+
+`test/fixtures/harness/claude-working.txt`:
+```
+⏺ Reading the file to understand the layout.
+
+  Read 1 file (ctrl+o to expand)
+
+✶ Smooshing… (4m 55s · ↓ 16.6k tokens)
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+  arrakis /path [Opus 4.8 | ctx: 77% left]
+```
+
+`test/fixtures/harness/claude-idle.txt`:
+```
+⏺ Done. Applied the fix to foo.ts and ran the tests.
+
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+  arrakis /path [Opus 4.8 | ctx: 77% left]
+```
+
+`test/fixtures/harness/claude-approval.txt`:
+```
+⏺ I'll run the test suite.
+
+  Bash(npm test)
+  Do you want to proceed?
+❯ 1. Yes
+  2. Yes, and don't ask again
+  3. No
+```
+
+`test/fixtures/harness/claude-response.txt`:
+```
+❯ fix the bug in foo.ts
+
+⏺ I found the bug in foo.ts:42 — an off-by-one. Here is the fix.
+
+  Read 1 file (ctrl+o to expand)
+⏺ Applied the change and the tests pass.
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+```
+
+`test/fixtures/harness/claude-menu-cursor.txt` (the `❯ N.` ambiguity — must NOT be idle):
+```
+⏺ Which layout?
+❯ 1. Mobile only
+  2. All sizes
+```
+
+- [ ] **Step 1: Write failing tests** (`test/Harness/ObserverSpec.hs`)
+
+```haskell
+module Harness.ObserverSpec (spec) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           PureClaw.Harness.Observer
+import           PureClaw.Session.Kind (HarnessFlavour (..))
+import           Test.Hspec
+
+loadFix :: FilePath -> IO BS.ByteString
+loadFix name = BS.readFile ("test/fixtures/harness/" <> name)
+
+spec :: Spec
+spec = do
+  describe "claudeObserver._ho_classify" $ do
+    it "HasWorking when a spinner/status line is present" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-working.txt"
+      _ho_classify claudeObserver t `shouldBe` HasWorking
+    it "HasAwaitingInput on an approval prompt" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-approval.txt"
+      _ho_classify claudeObserver t `shouldBe` HasAwaitingInput
+    it "HasIdle on a bare prompt with no spinner/approval" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-idle.txt"
+      _ho_classify claudeObserver t `shouldBe` HasIdle
+    it "is NOT HasIdle when the prompt is a menu cursor (❯ N.)" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-menu-cursor.txt"
+      _ho_classify claudeObserver t `shouldNotBe` HasIdle
+
+  describe "claudeObserver._ho_extractResponse" $ do
+    it "returns the last assistant block, marker + chrome stripped" $ do
+      cap <- loadFix "claude-response.txt"
+      let out = _ho_extractResponse claudeObserver 0 cap
+      out `shouldSatisfy` T.isInfixOf "Applied the change and the tests pass."
+      out `shouldNotSatisfy` T.isInfixOf "\x23FA"        -- no ⏺ marker
+      out `shouldNotSatisfy` T.isInfixOf "ctrl+o"         -- chrome stripped
+      out `shouldNotSatisfy` T.isInfixOf "fix the bug"    -- not the user line
+    it "returns the prompt text when awaiting input" $ do
+      cap <- loadFix "claude-approval.txt"
+      _ho_extractResponse claudeObserver 0 cap
+        `shouldSatisfy` T.isInfixOf "Do you want to proceed?"
+
+  describe "claudeObserver._ho_relevantTail" $
+    it "returns the last N cleaned lines without box-drawing chrome" $ do
+      cap <- loadFix "claude-idle.txt"
+      let out = _ho_relevantTail claudeObserver 3 cap
+      length (T.lines out) `shouldSatisfy` (<= 3)
+      out `shouldNotSatisfy` T.isInfixOf "────"
+
+  describe "genericObserver" $ do
+    it "classify is always HasIdle (no markers; stability decides in the loop)" $
+      _ho_classify genericObserver "anything at all" `shouldBe` HasIdle
+    it "relevantTail returns the last N lines" $
+      _ho_relevantTail genericObserver 2 (TE.encodeUtf8 "a\nb\nc\nd")
+        `shouldBe` "c\nd"
+
+  describe "observerFor" $ do
+    it "maps HClaudeCode to the Claude observer" $
+      _ho_classify (observerFor HClaudeCode) "✶ Working… (3s · 1k tokens)"
+        `shouldBe` HasWorking
+    it "maps non-Claude flavours to the generic observer" $
+      _ho_classify (observerFor HCodex) "✶ anything" `shouldBe` HasIdle
+```
+
+- [ ] **Step 2: Run red**
+
+Run: `nix develop . --command cabal test --test-options='--match "/claudeObserver/"'`
+Expected: FAIL — module/functions not defined.
+
+- [ ] **Step 3: Implement `src/PureClaw/Harness/Observer.hs`**
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Per-flavour, PURE detection and extraction of harness terminal output.
+-- Each harness TUI (Claude Code, Codex, …) draws its screen differently, so
+-- working/idle/awaiting-input detection and response extraction are
+-- flavour-specific. The reconcile loop and the @/harness output@ command both
+-- select an observer via 'observerFor'. Heuristics are facts about each tool's
+-- terminal output; they were validated against live captures (faryo, MIT, was
+-- a reference for the patterns).
+module PureClaw.Harness.Observer
+  ( HarnessActivityState (..)
+  , HarnessObserver (..)
+  , observerFor
+  , claudeObserver
+  , genericObserver
+  ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Char (isSpace)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           PureClaw.Session.Kind (HarnessFlavour (..))
+
+data HarnessActivityState = HasWorking | HasAwaitingInput | HasIdle
+  deriving stock (Eq, Show)
+
+data HarnessObserver = HarnessObserver
+  { _ho_classify        :: Text -> HarnessActivityState
+  , _ho_extractResponse :: Int -> ByteString -> Text
+  , _ho_relevantTail    :: Int -> ByteString -> Text
+  }
+
+observerFor :: HarnessFlavour -> HarnessObserver
+observerFor HClaudeCode = claudeObserver
+observerFor _           = genericObserver
+
+-- ── Claude Code ────────────────────────────────────────────────────────────
+
+-- | Spinner glyphs Claude rotates while working (Dingbats range + a few extras).
+claudeSpinnerGlyphs :: [Char]
+claudeSpinnerGlyphs = "·✢✱✲✳✴✵✶✷✸✹✺✻✼✽✾✿★"
+
+-- | A working/status line: a spinner glyph followed by a gerund, or an
+-- @(Ns · …tokens|thinking)@ counter, or the @esc to interrupt@ hint.
+isClaudeWorkingLine :: Text -> Bool
+isClaudeWorkingLine raw =
+  let l = T.stripStart raw
+  in (not (T.null l) && T.head l `elem` claudeSpinnerGlyphs
+       && (T.isInfixOf "…" l || T.isInfixOf "..." l))
+     || hasTokenCounter l
+     || T.isInfixOf "esc to interrupt" (T.toLower l)
+  where
+    hasTokenCounter t =
+      T.isInfixOf "tokens" (T.toLower t)
+      && T.isInfixOf "(" t && T.isInfixOf ")" t
+
+-- | An approval/menu prompt: Claude is blocked on the user.
+isClaudeApprovalLine :: Text -> Bool
+isClaudeApprovalLine raw =
+  let l = T.toLower (T.stripStart raw)
+  in T.isInfixOf "do you want to proceed?" l
+     || T.isInfixOf "yes, and don't ask again" l
+     || T.isInfixOf "yes, and don\8217t ask again" l
+     || T.isInfixOf "enter to confirm" l
+     || T.isInfixOf "esc to cancel" l
+     || isNumberedYesNo (T.stripStart raw)
+
+-- | A numbered option line, optionally led by the @❯@ menu cursor: @❯ 1. Yes@.
+isNumberedYesNo :: Text -> Bool
+isNumberedYesNo l0 =
+  let l = T.dropWhile (`elem` ("\10095\8250 " :: String)) l0  -- strip ❯ ›  and spaces
+  in case T.span (`elem` ("0123456789" :: String)) l of
+       (ds, rest) -> not (T.null ds) && T.isPrefixOf "." rest
+
+-- | The idle input prompt: a bare @❯@/@›@ NOT followed by a number+dot
+-- (which would be a menu-selection cursor, not the prompt).
+isIdlePromptLine :: Text -> Bool
+isIdlePromptLine raw =
+  let l = T.stripStart raw
+  in (T.isPrefixOf "\10095" l || T.isPrefixOf "\8250" l)  -- ❯ ›
+     && not (isNumberedYesNo l)
+
+classifyClaude :: Text -> HarnessActivityState
+classifyClaude screen =
+  let ls = T.lines screen
+  in if any isClaudeWorkingLine ls then HasWorking
+     else if any isClaudeApprovalLine ls then HasAwaitingInput
+     else HasIdle
+
+-- | True for chrome lines that must never appear in extracted output.
+isClaudeChrome :: Text -> Bool
+isClaudeChrome raw =
+  let l = T.stripStart raw
+  in T.null (T.strip l)
+     || isClaudeWorkingLine raw
+     || (isIdlePromptLine raw && T.null (T.strip (T.drop 1 l)))
+     || T.isInfixOf "for shortcuts" (T.toLower l)
+     || T.isInfixOf "ctrl+o to expand" (T.toLower l)
+     || T.all (\c -> c == '\9472' || c == '\9600' || c == '\9604' || isSpace c) l  -- ─ ▀ ▄
+
+isResponseMarkerLine :: Text -> Bool
+isResponseMarkerLine line =
+  let l = T.stripStart line
+  in T.isPrefixOf "\x23FA" l    -- ⏺
+     || T.isPrefixOf "\x25CF" l -- ● (alternate, faryo)
+     || T.isPrefixOf "\x2B24" l -- ⬤ (alternate)
+
+stripResponseMarker :: Text -> Text
+stripResponseMarker line =
+  T.stripStart (T.dropWhile (`elem` ("\x23FA\x25CF\x2B24 " :: String)) (T.stripStart line))
+
+isClaudeUserLine :: Text -> Bool
+isClaudeUserLine raw =
+  let l = T.stripStart raw
+  in (T.isPrefixOf "\10095" l) && not (isNumberedYesNo l)
+     && not (T.null (T.strip (T.drop 1 l)))
+
+-- | Extract the latest assistant response. When awaiting input, return the
+-- approval/menu prompt block so the user sees the question.
+extractClaude :: Int -> ByteString -> Text
+extractClaude baseline capture =
+  let body = dropBaseline baseline capture
+      ls   = T.lines (TE.decodeUtf8Lenient body)
+  in if any isClaudeApprovalLine ls
+       then T.strip . T.unlines $ dropWhile (not . isClaudeApprovalLine) ls
+       else case reverse [ i | (i, l) <- zip [0 :: Int ..] ls, isResponseMarkerLine l ] of
+              []      -> ""
+              (i : _) ->
+                let block   = takeWhile (not . isIdlePromptLine) (drop i ls)
+                    cleaned = case block of
+                      (h : rest) -> stripResponseMarker h : filter (not . isClaudeChrome) rest
+                      []         -> []
+                in T.strip (T.intercalate "\n" (filter (not . T.null) cleaned))
+
+relevantTailClaude :: Int -> ByteString -> Text
+relevantTailClaude n capture =
+  let ls = filter (not . isClaudeChrome) (T.lines (TE.decodeUtf8Lenient capture))
+  in T.intercalate "\n" (lastN n ls)
+
+claudeObserver :: HarnessObserver
+claudeObserver = HarnessObserver
+  { _ho_classify        = classifyClaude
+  , _ho_extractResponse = extractClaude
+  , _ho_relevantTail    = relevantTailClaude
+  }
+
+-- ── Generic fallback (Codex/OpenCode/Hermes/PureClaw/Custom) ─────────────────
+
+genericObserver :: HarnessObserver
+genericObserver = HarnessObserver
+  { _ho_classify        = const HasIdle   -- stability in the loop is the only signal
+  , _ho_extractResponse = \n cap -> T.intercalate "\n" (lastN (max 1 n) (cleanLines cap))
+  , _ho_relevantTail    = \n cap -> T.intercalate "\n" (lastN n (cleanLines cap))
+  }
+  where cleanLines cap = filter (not . T.null . T.strip) (T.lines (TE.decodeUtf8Lenient cap))
+
+-- ── Shared helpers ───────────────────────────────────────────────────────────
+
+dropBaseline :: Int -> ByteString -> ByteString
+dropBaseline n cap
+  | n <= 0    = cap
+  | otherwise = BS.intercalate (BS.singleton 0x0A) (drop n (BS.split 0x0A cap))
+
+lastN :: Int -> [a] -> [a]
+lastN n xs = drop (length xs - n) xs
+```
+
+Note: the generic `_ho_extractResponse 0` returns the whole cleaned capture (`max 1 0 = 1`? no — fix: use `n` directly with a sensible default). For the watcher, the generic path will pass an explicit line count. Verify against the test `genericObserver relevantTail` returns `"c\nd"`.
+
+- [ ] **Step 4: Run green** — `nix develop . --command cabal test --test-options='--match "/Harness.Observer/"'`. PASS. Adjust glyph/regex details against fixtures until green.
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PureClaw/Harness/Observer.hs test/Harness/ObserverSpec.hs test/fixtures/harness pureclaw.cabal
+git commit -m "feat(harness): per-flavour HarnessObserver (classify/extract/tail) with golden fixtures"
+```
+
+---
+
+### Task 3: Add `HarnessNeedsInput` to the activity vocabulary (end to end)
+
+**Files:**
+- Modify: `src/PureClaw/Frontend/Activity/Types.hs:17-26` (`HarnessActivity` + `ToJSON`)
+- Modify: `src/PureClaw/Harness/Registry.hs:110-115` (`Liveness` — add `LivenessAwaitingInput`)
+- Modify: `src/PureClaw/Frontend/TabsView.hs:105-111` (`livenessToTabStatus` — add arm → `"running"`)
+- Test: `test/Frontend/ActivityTypesSpec.hs` (or existing); `test/Frontend/TabsViewSpec.hs`; `test/Frontend/APISpec.hs` (`livenessToTabStatus` describe); `frontend/src/components/__tests__/StatusDot.test.tsx`
+- Modify: `frontend/src/types.ts:13` (`HarnessActivity` union); `frontend/src/components/StatusDot.tsx:10-14`
+
+This task adds BOTH enum constructors and resolves every exhaustive-match site in the Cascade inventory above. After implementing, build under `-Werror` and fix any case the compiler flags.
+
+**Interfaces:**
+- Produces: `HarnessActivity` gains `HarnessNeedsInput` (JSON `"needs-input"`); `Liveness` gains `LivenessAwaitingInput`. TS `HarnessActivity` gains `'needs-input'`.
+
+- [ ] **Step 1: Failing Haskell test** (`test/Frontend/ActivityTypesSpec.hs`)
+
+```haskell
+    it "encodes HarnessNeedsInput as \"needs-input\"" $
+      Aeson.toJSON HarnessNeedsInput `shouldBe` Aeson.String "needs-input"
+```
+
+- [ ] **Step 2: Run red** — `nix develop . --command cabal test --test-options='--match "/needs-input/"'`. FAIL (constructor undefined).
+- [ ] **Step 3: Implement Haskell**
+
+`Activity/Types.hs`:
+```haskell
+data HarnessActivity
+  = HarnessThinking
+  | HarnessIdle
+  | HarnessNeedsInput
+  | HarnessStopped
+  deriving stock (Show, Eq)
+
+instance ToJSON HarnessActivity where
+  toJSON HarnessThinking   = Aeson.String "thinking"
+  toJSON HarnessIdle       = Aeson.String "idle"
+  toJSON HarnessNeedsInput = Aeson.String "needs-input"
+  toJSON HarnessStopped    = Aeson.String "stopped"
+```
+
+`Registry.hs`:
+```haskell
+data Liveness
+  = LivenessIdle
+  | LivenessThinking
+  | LivenessAwaitingInput  -- ^ Window present, harness blocked on an approval/menu prompt.
+  | LivenessExited
+  | LivenessOrphaned
+  deriving stock (Eq, Show)
+```
+
+- [ ] **Step 4a: Add the `livenessToTabStatus` arm** (`TabsView.hs:105-111`) — required now because the new `Liveness` constructor makes this `case` non-exhaustive under `-Werror`:
+
+```haskell
+livenessToTabStatus lv = case lv of
+  Registry.LivenessIdle          -> "idle"
+  Registry.LivenessThinking      -> "running"
+  Registry.LivenessAwaitingInput -> "running"  -- distinct state shown via the activity dot, not the tab badge
+  Registry.LivenessExited        -> "exited"
+  Registry.LivenessOrphaned      -> "orphaned"
+```
+
+Add a test in `test/Frontend/TabsViewSpec.hs` (and the `livenessToTabStatus` describe in `test/Frontend/APISpec.hs`): `livenessToTabStatus Registry.LivenessAwaitingInput \`shouldBe\` "running"`.
+
+- [ ] **Step 4b: Run green** (Haskell). Then fix any remaining non-exhaustive `case` on `Liveness`/`HarnessActivity` the compiler flags under `-Werror` — in particular `livenessToActivity` (Task 6 finalizes it; for now add `LivenessAwaitingInput -> HarnessNeedsInput`).
+- [ ] **Step 5: Failing frontend test** (`StatusDot.test.tsx`)
+
+```tsx
+import { render } from '@testing-library/react'
+import { ActivityDot } from '../StatusDot'
+
+it('renders a needs-input activity with the dot-needs class', () => {
+  const { container } = render(<ActivityDot activity={'needs-input'} />)
+  expect(container.firstChild).toHaveClass('dot-needs')
+})
+```
+
+- [ ] **Step 6: Run red** — `cd frontend && npx vitest run src/components/__tests__/StatusDot.test.tsx`. FAIL (type + missing key).
+- [ ] **Step 7: Implement frontend**
+
+`types.ts:13`:
+```ts
+export type HarnessActivity = 'thinking' | 'idle' | 'needs-input' | 'stopped'
+```
+
+`StatusDot.tsx:10-14`:
+```tsx
+const activityDotClass: Record<HarnessActivity, string> = {
+  'thinking': 'dot dot-thinking',
+  'idle': 'dot dot-idle',
+  'needs-input': 'dot dot-needs',
+  'stopped': 'dot dot-completed',
+}
+```
+
+- [ ] **Step 8: Run green** (`npx vitest run` + `npx tsc --noEmit`).
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/PureClaw/Frontend/Activity/Types.hs src/PureClaw/Harness/Registry.hs \
+        src/PureClaw/Frontend/TabsView.hs test/Frontend/ActivityTypesSpec.hs \
+        test/Frontend/TabsViewSpec.hs test/Frontend/APISpec.hs frontend/src/types.ts \
+        frontend/src/components/StatusDot.tsx frontend/src/components/__tests__/StatusDot.test.tsx
+git commit -m "feat(activity): add needs-input / awaiting-input state end to end"
+```
+
+---
+
+### Task 4: `HarnessHandle` gains `_hh_snapshot` (non-blocking capture+extract)
+
+**Files:**
+- Modify: `src/PureClaw/Handles/Harness.hs:35-42` (add field) + `mkNoOpHarnessHandle:45`
+- Modify: `src/PureClaw/Harness/ClaudeCode.hs:399` (real handle) and `:857` (discovered handle) — wire it
+- Modify: `src/PureClaw/Agent/SlashCommands.hs:~2416` (`mkHandle`) — `_hh_snapshot = \_ -> pure ""`
+- Modify: `test/Frontend/APISpec.hs:4017,4049,4064`, `test/Tabs/RuntimesSpec.hs:188,428,498` — `_hh_snapshot = \_ -> pure ""`
+- Test: `test/Harness/ClaudeCodeSpec.hs`
+
+See the Cascade inventory for the complete construction-site list. The `_hh_snapshot` field is added to the record; every site above plus any inline `HarnessHandle{…}` the compiler flags must be updated (`-Werror`).
+
+**Interfaces:**
+- Produces: `_hh_snapshot :: Int -> IO Text` on `HarnessHandle` — "capture the pane now and return the latest response (N≤0) or the last N relevant lines (N>0)" via the flavour observer. Non-blocking (single capture; no poll).
+
+- [ ] **Step 1: Failing test** — extend an adopt/handle test to assert a snapshot returns the latest response from a fake capture:
+
+```haskell
+    it "_hh_snapshot returns the latest extracted response (no polling)" $
+      withSystemTempDirectory "pcl-snap" $ \tmp -> do
+        reg <- Reg.newRegistry
+        let deps = okDeps
+              { _ccd_newId        = pure fixedId
+              , _ccd_sweep        = \_ -> pure [adoptableRow 0 "win-snap"]
+              , _ccd_panePidOf    = \_ _ -> pure (Just 7)
+              , _ccd_captureNamed = \_ _ _ -> pure (Just (TE.encodeUtf8
+                  "\x23FA Hello from the harness.\n\10095\n"))
+              }
+        Right (_, hh) <- adoptExternalWindow deps reg mkNoOpTranscriptHandle tmp mkToken Nothing "win-snap"
+        out <- _hh_snapshot hh 0
+        out `shouldSatisfy` T.isInfixOf "Hello from the harness."
+```
+
+- [ ] **Step 2: Run red** — record-field `_hh_snapshot` undefined. FAIL.
+- [ ] **Step 3: Implement field** (`Handles/Harness.hs`)
+
+```haskell
+data HarnessHandle = HarnessHandle
+  { _hh_send     :: ByteString -> IO ()
+  , _hh_receive  :: IO ByteString
+  , _hh_snapshot :: Int -> IO Text   -- ^ one-shot capture+extract via the flavour observer
+  , _hh_name     :: Text
+  , _hh_session  :: Text
+  , _hh_status   :: IO HarnessStatus
+  , _hh_stop     :: IO ()
+  }
+```
+
+- [ ] **Step 4: Implement Claude wiring** — in `mkClaudeCodeHandleWithBaseline` (and `mkDiscoveredClaudeCodeHandle`), where `session`, `windowName`/coord resolution, and `baselineRef` are in scope, add:
+
+```haskell
+    , _hh_snapshot = \n -> do
+        mCoord <- currentCoord reg hid
+        case mCoord of
+          Nothing -> pure ""
+          Just (sess, win) -> do
+            raw <- fromMaybe "" <$> _ccd_captureNamed deps sess win (if n <= 0 then 0 else max n 50)
+            baseline <- readIORef baselineRef
+            let obs = observerFor HClaudeCode
+            pure $ if n <= 0
+              then _ho_extractResponse obs baseline raw
+              else _ho_relevantTail obs n raw
+```
+
+(For `mkDiscoveredClaudeCodeHandle`, which has `session`/`windowName` directly and no baseline IORef, pass baseline `0` and capture by name via `captureWindowNamed`.)
+
+- [ ] **Step 5: Update ALL other construction sites** — add `_hh_snapshot = \_ -> pure ""` at each site in the Cascade inventory: `Handles/Harness.hs:45` (`mkNoOpHarnessHandle`), `SlashCommands.hs:~2416` (`mkHandle`), `APISpec.hs:4017,4049,4064`, `RuntimesSpec.hs:188,428,498`, plus any inline `HarnessHandle{…}` the compiler flags. Confirm with: `awk '/HarnessHandle$|HarnessHandle \{|HarnessHandle$/{print FILENAME":"NR}' $(find src test -name '*.hs')`.
+- [ ] **Step 6: Run green** — `nix develop . --command cabal test --test-options='--match "/_hh_snapshot/"'`. PASS; `nix develop . --command cabal build` clean under `-Werror`.
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PureClaw/Handles/Harness.hs src/PureClaw/Harness/ClaudeCode.hs \
+        src/PureClaw/Agent/SlashCommands.hs test/Harness/ClaudeCodeSpec.hs \
+        test/Frontend/APISpec.hs test/Tabs/RuntimesSpec.hs
+git commit -m "feat(harness): _hh_snapshot one-shot capture+extract on HarnessHandle"
+```
+
+---
+
+### Task 5: `/harness output [name] [N]` slash command
+
+**Files:**
+- Modify: `src/PureClaw/Agent/SlashCommands.hs` (`HarnessSubCommand`:178-184; `harnessCommandSpecs`:410-416; a new parser; `executeHarnessCommand`:1820)
+- Test: `test/Agent/SlashCommandsSpec.hs` (parser); `test/Frontend/APISpec.hs` (web dispatch, optional)
+
+**Interfaces:**
+- Consumes: `_hh_snapshot` (Task 4); `_env_harnesses` (`IORef (Map Text HarnessHandle)`).
+- Produces: `HarnessSubCommand` gains `HarnessOutput (Maybe Text) Int` (optional name, line count; 0 = latest response).
+
+- [ ] **Step 1: Failing parser test**
+
+```haskell
+    it "parses /harness output with optional name and N" $ do
+      parseInputCmd "/harness output"          `shouldBe` Just (CmdHarness (HarnessOutput Nothing 0))
+      parseInputCmd "/harness output coder"    `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 0))
+      parseInputCmd "/harness output coder 40" `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 40))
+```
+
+(Use the project's existing parse entry point used by other harness parser tests.)
+
+- [ ] **Step 2: Run red.** FAIL (constructor + parser missing).
+- [ ] **Step 3: Implement constructor + spec + parser**
+
+`HarnessSubCommand` (add):
+```haskell
+  | HarnessOutput (Maybe Text) Int  -- ^ Show last response (N=0) or last N relevant lines
+```
+
+`harnessCommandSpecs` (add):
+```haskell
+  , CommandSpec "/harness output [name] [N]" "Show recent harness output (last response, or last N lines)" GroupHarness harnessOutputP
+```
+
+Parser:
+```haskell
+harnessOutputP :: Text -> Maybe SlashCommand
+harnessOutputP t =
+  case T.words t of
+    (cmd : "output" : rest) | T.toLower cmd == "/harness" ->
+      Just $ CmdHarness $ case rest of
+        []        -> HarnessOutput Nothing 0
+        [a]       -> case readMaybeInt a of
+                       Just n  -> HarnessOutput Nothing n
+                       Nothing -> HarnessOutput (Just a) 0
+        (a : b : _) -> HarnessOutput (Just a) (maybe 0 id (readMaybeInt b))
+    _ -> Nothing
+  where readMaybeInt = fmap fst . listToMaybe . reads . T.unpack
+```
+
+- [ ] **Step 4: Run green** (parser). PASS.
+- [ ] **Step 5: Failing handler test** — in `executeHarnessCommand`, with a fake handle whose `_hh_snapshot` returns a known string, assert the command sends it. Mirror the existing `HarnessList` handler test harness (a captured channel + `_env_harnesses`).
+
+```haskell
+    it "HarnessOutput sends the snapshot text for the named harness" $ do
+      (env, readOut) <- mkCapturingEnv  -- builds AgentEnv with a capture channel
+      let hh = noopHandle { _hh_snapshot = \_ -> pure "latest harness reply" }
+      writeIORef (_env_harnesses env) (Map.fromList [("coder", hh)])
+      _ <- executeSlashCommand env (CmdHarness (HarnessOutput (Just "coder") 0)) emptyCtx
+      out <- readOut
+      out `shouldSatisfy` T.isInfixOf "latest harness reply"
+```
+
+- [ ] **Step 6: Run red.** FAIL (no handler case).
+- [ ] **Step 7: Implement handler** in `executeHarnessCommand` (alongside `HarnessList`):
+
+```haskell
+    HarnessOutput mName n -> do
+      harnesses <- readIORef (_env_harnesses env)
+      let pick = case mName of
+            Just nm -> Map.lookup nm harnesses
+            Nothing -> case Map.toList harnesses of
+                         [(_, hh)] -> Just hh   -- exactly one running → use it
+                         _         -> Nothing
+      case pick of
+        Nothing -> do
+          send (case mName of
+                  Just nm -> "No running harness named '" <> nm <> "'."
+                  Nothing -> "Specify a harness name: /harness output <name> [N].")
+          pure ctx
+        Just hh -> do
+          out <- _hh_snapshot hh n
+          send (if T.null (T.strip out) then "(no recent output)" else out)
+          pure ctx
+```
+
+- [ ] **Step 8: Run green.** PASS.
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/PureClaw/Agent/SlashCommands.hs test/Agent/SlashCommandsSpec.hs
+git commit -m "feat(slash): /harness output [name] [N] shows recent harness output"
+```
+
+---
+
+### Task 6: Reconcile classification via the observer (3-state + stability) + `_he_flavour`
+
+**Files:**
+- Modify: `src/PureClaw/Harness/Registry.hs` (add `_he_flavour :: !HarnessFlavour` to `HarnessEntry`)
+- Modify ALL `_he_flavour` construction sites (Cascade inventory): `ClaudeCode.hs:331,547`; `Reconcile.hs:545`; `test/Frontend/TabsViewSpec.hs:62`; `test/Frontend/APISpec.hs` (`baseEntry`); `test/Harness/RegistrySpec.hs:30,303`; `test/Harness/ReconcileSpec.hs:57` — all set `HClaudeCode`.
+- Modify: `src/PureClaw/Harness/Reconcile.hs` (`ReconcileDeps._rd_capture :: Text -> Text -> IO (Maybe Text)`; replace `classifyLiveness` with `classifyFromObserver`; finalize `livenessToActivity`; DROP the now-unused `import PureClaw.Harness.ClaudeCode (isIdle)` at `:85`)
+- Test: `test/Harness/ReconcileSpec.hs` — REMOVE the `classifyLiveness` tests at `:171-179`, replaced by the `classifyFromObserver` tests below.
+
+**Interfaces:**
+- Consumes: `observerFor`, `HarnessActivityState` (Task 2); `LivenessAwaitingInput`, `HarnessNeedsInput` (Task 3).
+- Produces / changes (exact signatures):
+  ```haskell
+  -- ReconcileDeps field (was: IO Bool)
+  _rd_capture :: Text -> Text -> IO (Maybe Text)   -- raw capture; Nothing = capture failed
+
+  classifyFromObserver
+    :: HarnessObserver -> Bool {-paneDead-} -> Bool {-harnessAlive-} -> Bool {-stable-} -> Text -> Reg.Liveness
+
+  -- classifyRow now takes the entry's PREVIOUS capture (for the stability gate)
+  -- and returns the capture it took this tick (so the loop can carry it forward).
+  classifyRow
+    :: ReconcileDeps -> Reg.HarnessEntry -> TmuxWindowRow
+    -> Maybe Text                       -- previous capture for this entry
+    -> IO (Reg.Liveness, Maybe Text)    -- (liveness, capture taken this tick)
+
+  -- reconcileTick takes prev captures (id-text → last raw) and returns, per id,
+  -- the observation the loop needs (sessionId, liveness, capture-taken).
+  data TickObservation = TickObservation
+    { _to_sessionId :: !Text            -- sidOf e (may be the label fallback)
+    , _to_liveness  :: !Reg.Liveness
+    , _to_capture   :: !(Maybe Text)    -- raw capture this tick, if any
+    }
+  reconcileTick
+    :: ReconcileDeps -> Reg.HarnessRegistry -> LogHandle
+    -> Map Text Text                              -- prev captures (id-text → last raw)
+    -> IO (Map Text TickObservation, [Text])      -- (per-id observation, evicted sessionIds)
+  ```
+  The loop (`runReconcileLoopWith`) threads a new `prevCaps :: Map Text Text` alongside the existing prev snapshot, derived from `Map.mapMaybe _to_capture` of the previous tick.
+
+- [ ] **Step 1: Failing test** — observer-based classification with stability:
+
+```haskell
+    it "classifies a spinner frame as Thinking regardless of stability" $
+      classifyFromObserver claudeObserver False True True spinnerFrame
+        `shouldBe` Reg.LivenessThinking
+    it "classifies an approval frame as AwaitingInput" $
+      classifyFromObserver claudeObserver False True True approvalFrame
+        `shouldBe` Reg.LivenessAwaitingInput
+    it "an idle-marker frame is Thinking until it is stable across ticks" $ do
+      classifyFromObserver claudeObserver False True False idleFrame `shouldBe` Reg.LivenessThinking
+      classifyFromObserver claudeObserver False True True  idleFrame `shouldBe` Reg.LivenessIdle
+    it "livenessToActivity maps AwaitingInput to needs-input" $
+      livenessToActivity Reg.LivenessAwaitingInput `shouldBe` HarnessNeedsInput
+```
+
+- [ ] **Step 2: Run red.** FAIL.
+- [ ] **Step 3: Implement**
+
+Add `_he_flavour :: !HarnessFlavour` to `HarnessEntry` and set `HClaudeCode` at every site in the Cascade inventory (8 sites). `import qualified PureClaw.Session.Kind as Kind` where needed. REMOVE `classifyLiveness` (Reconcile.hs:222) and its `ReconcileSpec.hs:171-179` tests — they are replaced by `classifyFromObserver` and the tests in Step 1 above.
+
+`Reconcile.hs`:
+```haskell
+classifyFromObserver
+  :: HarnessObserver -> Bool -> Bool -> Bool -> Text -> Reg.Liveness
+classifyFromObserver obs paneDead harnessAlive stable screen
+  | paneDead || not harnessAlive = Reg.LivenessExited
+  | otherwise = case _ho_classify obs screen of
+      HasWorking       -> Reg.LivenessThinking
+      HasAwaitingInput -> Reg.LivenessAwaitingInput
+      HasIdle          -> if stable then Reg.LivenessIdle else Reg.LivenessThinking
+
+livenessToActivity :: Reg.Liveness -> HarnessActivity
+livenessToActivity Reg.LivenessIdle          = HarnessIdle
+livenessToActivity Reg.LivenessThinking      = HarnessThinking
+livenessToActivity Reg.LivenessAwaitingInput = HarnessNeedsInput
+livenessToActivity Reg.LivenessExited        = HarnessStopped
+livenessToActivity Reg.LivenessOrphaned      = HarnessStopped
+```
+
+Change `_rd_capture` to `Text -> Text -> IO (Maybe Text)`: production `defaultReconcileDeps:143` = `\session windowName -> Just . TE.decodeUtf8Lenient <$> captureWindowNamed session windowName 50` (wrap in `try` → `Nothing` on exception); update the four `ReconcileSpec` fake sites (`:108,:116,:365,:559`) to return `Just "<frame>"` / `Nothing`.
+
+Rewrite `classifyRow` to take the previous capture and return `(liveness, capture-taken)`:
+```haskell
+classifyRow deps e row prevCap
+  | _twr_paneDead row = pure (Reg.LivenessExited, Nothing)
+  | otherwise = do
+      alive <- case (Reg._he_harnessPid e, _twr_panePid row) of
+        (Just _, Just shellPid) -> _rd_harnessAlive deps shellPid
+        _                       -> pure True
+      if not alive
+        then pure (Reg.LivenessExited, Nothing)
+        else do
+          mCap <- _rd_capture deps (Reg._he_session e) (_twr_windowName row)
+          let cap    = fromMaybe "" mCap
+              stable = Maybe.isJust mCap && mCap == prevCap
+              obs    = observerFor (Reg._he_flavour e)
+          pure (classifyFromObserver obs False True stable cap, mCap)
+```
+In `reconcileTick`, add the `prevCaps :: Map Text Text` parameter; in the `(row : _)` corroborated branch use `classifyRow deps e row (Map.lookup idText prevCaps)`, store the returned capture in `_to_capture`, and return `Map Text TickObservation` (the held/orphaned `mkObserved*` paths set `_to_capture = Nothing`; keep `_to_sessionId = sidOf e`, `_to_liveness` as before). In `runReconcileLoopWith`, thread `prevCaps` (init `Map.empty`; `nextCaps = Map.mapMaybe _to_capture obs`) alongside the existing prev snapshot, and build the `Map Text (Text, Reg.Liveness)` the `diffLiveness` publish path expects via `Map.map (\o -> (_to_sessionId o, _to_liveness o)) obs`.
+
+- [ ] **Step 4: Run green.** PASS; whole suite builds (fix `-Werror` exhaustiveness on the new `Liveness` constructor everywhere it is matched — `diffLiveness`, any rendering).
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/PureClaw/Harness/Registry.hs src/PureClaw/Harness/Reconcile.hs \
+        src/PureClaw/Harness/ClaudeCode.hs test/Harness/ReconcileSpec.hs \
+        test/Harness/RegistrySpec.hs test/Frontend/TabsViewSpec.hs test/Frontend/APISpec.hs
+git commit -m "feat(reconcile): observer-based 3-state harness classification with stability gate"
+```
+
+---
+
+### Task 7: Output watcher — record Response on settle (deduped)
+
+**Files:**
+- Modify: `src/PureClaw/Harness/Reconcile.hs` (`ReconcileDeps` gains `_rd_recordResponse`; the loop detects settle transitions and records; threads a per-session last-response `Map`)
+- Modify: `src/PureClaw/CLI/Commands.hs` (the `runReconcileLoopWith` call site at `:1044` — wire `_rd_recordResponse` using the in-scope `sessionsDir:622` + `broker` + `logger`)
+- Test: `test/Harness/ReconcileSpec.hs`
+
+**Interfaces (exact):**
+- Consumes: `_hh_snapshot` (Task 4 — capture+extract the latest response per flavour, behind the handle), `_he_sessionId :: Maybe Text`, `_he_handle :: Maybe HarnessHandle`, `Reg.lookupById`, `mkBroadcastingFileTranscriptHandle`.
+- Produces:
+  ```haskell
+  -- New ReconcileDeps field. Records ONE Response entry for a session.
+  _rd_recordResponse :: SessionId -> Text -> IO ()
+  ```
+  The settle recorder reuses `_hh_snapshot` (NOT a new extract in the loop), so flavour/baseline are handled behind the handle and no flavour/baseline threading is needed here. The loop gains a `prevResponses :: Map Text Text` (keyed by id-text → last recorded response); dedup is plain `Text` equality (NO `hashable` — absent from `pureclaw.cabal`).
+
+- [ ] **Step 1: Failing test** — drive a fake harness through working→idle and assert exactly one Response is recorded, and a second idle tick dedups to zero. The fake entry carries a `_he_handle` whose `_hh_snapshot` returns a fixed string and a real `_he_sessionId = Just "sess-1"`:
+
+```haskell
+    it "records exactly one Response on a working→idle settle, then dedups" $ do
+      recorded <- newIORef ([] :: [(SessionId, Text)])
+      let hh   = noopHandle { _hh_snapshot = \_ -> pure "the answer" }
+          deps = baseDeps
+            { _rd_capture        = scriptedCaptures   -- spinner, spinner, idle, idle
+            , _rd_recordResponse = \sid txt -> modifyIORef' recorded ((sid, txt) :)
+            }
+      -- register one entry: _he_sessionId = Just "sess-1", _he_handle = Just hh
+      runTicksWith 4 deps reg
+      xs <- readIORef recorded
+      length xs `shouldBe` 1
+      xs `shouldBe` [(SessionId "sess-1", "the answer")]
+    it "records the approval prompt on a working→awaiting-input settle" $ ...  -- snapshot returns prompt text
+    it "skips recording when _he_sessionId is Nothing (label-only entry)" $ ...
+    it "records output produced with no preceding send (direct-tmux: spinner→idle without a /send)" $ ...
+```
+
+- [ ] **Step 2: Run red.** FAIL (`_rd_recordResponse` field + settle logic absent).
+- [ ] **Step 3: Implement** — add `_rd_recordResponse :: SessionId -> Text -> IO ()` to `ReconcileDeps` (default/test stub: `\_ _ -> pure ()`). In `runReconcileLoopWith`, after computing the liveness diff for the tick, detect settle transitions directly from `(prevSnap, obs)`: an id whose previous liveness was `LivenessThinking` and whose new `_to_liveness` is `LivenessIdle` or `LivenessAwaitingInput`. For each such id:
+
+```haskell
+    settle prevSnap obs prevResponses = do
+      newPairs <- forM (settledIds prevSnap obs) $ \idText ->
+        case Reg.parseHarnessId idText of
+          Nothing  -> pure Nothing
+          Just hid -> do
+            mEntry <- Reg.lookupById reg hid
+            case mEntry of
+              Just e
+                | Just realSid <- Reg._he_sessionId e   -- real session, not the label fallback
+                , Just hh      <- Reg._he_handle e -> do
+                    resp <- _hh_snapshot hh 0           -- latest response, full capture, per-flavour
+                    let prev = Map.lookup idText prevResponses
+                    if not (T.null (T.strip resp)) && prev /= Just resp
+                      then do _rd_recordResponse deps (SessionId realSid) resp
+                              pure (Just (idText, resp))
+                      else pure Nothing
+              _ -> pure Nothing
+      pure (foldr (\(k,v) -> Map.insert k v) prevResponses (catMaybes newPairs))
+```
+
+Thread `prevResponses :: Map Text Text` through the loop (init `Map.empty`; updated by `settle`). `settledIds` compares `Map.lookup id prevSnap` (`(_, Liveness)`) against `_to_liveness` in `obs`. (A harness with no `_he_handle` or no real `_he_sessionId` is skipped — Phase-1 limitation: a boot-discovered entry without an attached handle is not auto-recorded until a handle exists.)
+
+Production `_rd_recordResponse` (wired in `CLI/Commands.hs` where `sessionsDir`, `broker`, `logger` are in scope; `SessionId`/`unSessionId` from the session-id module already imported there):
+
+```haskell
+_rd_recordResponse = \sid txt -> do
+  let path = sessionsDir </> T.unpack (unSessionId sid) </> "transcript.jsonl"
+  bracket (mkBroadcastingFileTranscriptHandle (Just broker) sid logger path)
+          (\th -> _th_flush th >> _th_close th)
+          (\th -> recordResponseEntry th txt)
+```
+
+where `recordResponseEntry th txt` builds and `_th_record`s a `Response` `TranscriptEntry` (mirror the existing `recordHarnessEntry … Response` in API.hs — same field shape).
+
+- [ ] **Step 4: Run green.** PASS.
+- [ ] **Step 5: Wire `_rd_recordResponse` at the call site** (`CLI/Commands.hs:1044`, where `runReconcileLoopWith` is started and `sessionsDir:622`/`broker`/`logger` are in scope) — set the production `_rd_recordResponse` per Step 3. Build.
+- [ ] **Step 6: Run green** (full suite).
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/PureClaw/Harness/Reconcile.hs src/PureClaw/CLI/Commands.hs test/Harness/ReconcileSpec.hs
+git commit -m "feat(reconcile): record harness Response on settle (deduped) — auto output streaming"
+```
+
+---
+
+### Task 8: Decouple send from receive (harness send no longer blocks/records Response)
+
+**Files:**
+- Modify: `src/PureClaw/Frontend/API.hs` (`routeViaHandle`:2122-2158 — record Request + send; drop the inline `_hh_receive`/Response recording for the harness path)
+- Modify: `src/PureClaw/Harness/ClaudeCode.hs` (`isIdle:782` — redefine via the observer; keep its call sites at `:753` and `:918` working)
+- Test: `test/Frontend/APISpec.hs`; `test/Harness/ClaudeCodeSpec.hs` (update `isIdle` tests at `:444-451`)
+
+**Interfaces:**
+- Changed: `routeViaHandle` records only the Request and injects keystrokes; the watcher (Task 7) records the Response. `POST /send` returns promptly with `{"kind":"assistant","response":""}` (the reply arrives via WS).
+
+- [ ] **Step 1: Failing test**
+
+```haskell
+    it "harness /send records a Request and injects keystrokes but records NO Response inline" $ do
+      sent <- newIORef []
+      recorded <- newIORef []
+      let hh = noopHandle
+            { _hh_send    = \bs -> modifyIORef' sent (bs :)
+            , _hh_receive = error "receive must not be called on the send path"
+            }
+      -- wire env with a registry entry carrying hh + a capturing transcript
+      (st, _) <- postJSON env ["api","sessions", sid, "send"] (msgBody "hello")
+      st `shouldBe` HTTP.status200
+      readIORef sent     `shouldReturn` [TE.encodeUtf8 "hello"]
+      dirs <- readIORef recorded
+      map _te_direction dirs `shouldBe` [Request]   -- no Response inline
+```
+
+- [ ] **Step 2: Run red.** FAIL (current code calls `_hh_receive` and records a Response).
+- [ ] **Step 3: Implement** — in `routeViaHandle`, replace the inner action:
+
+```haskell
+      (\th -> do
+        recordHarnessEntry th Request userText
+        _hh_send hh (TE.encodeUtf8 userText)
+        -- Response is recorded by the reconcile watcher on settle; the send
+        -- path no longer blocks on _hh_receive (which mis-fired off the broken
+        -- isIdle and double-recorded against the watcher). Reply arrives via WS.
+        pure "")
+```
+
+and respond with `"response" .= ("" :: Text)`.
+
+Note: the CLI `/msg` path (`SlashCommands.hs:1119-1133`, `CmdMsg`) also does `_hh_send` + blocking `_hh_receive`; this is INTENTIONALLY preserved for the CLI/TUI (non-frontend) flow — after the `isIdle` redefinition it blocks correctly on the observer-driven poll. Do not change it.
+
+- [ ] **Step 4: Run green.** PASS. Update any existing APISpec tests that asserted an inline harness Response from `_hh_receive` — they now assert the Request-only behavior (a Request entry recorded, no Response on the send path).
+- [ ] **Step 5: Redefine `isIdle` via the observer** (do NOT delete — it has call sites at `ClaudeCode.hs:753` and `:918`, both `pollUntilIdle`/`discoveredReceive`). Replacing its body keeps both working and corrects the CLI/TUI path:
+
+```haskell
+-- | Idle iff the flavour observer classifies the screen as settled (replaces
+-- the stale ❯/⠋ heuristic; the input box ❯ is always present, so it can't mean idle).
+isIdle :: Text -> Bool
+isIdle screen = _ho_classify claudeObserver screen == HasIdle
+```
+
+Add `import PureClaw.Harness.Observer (claudeObserver, _ho_classify, HarnessActivityState (..))` to ClaudeCode.hs. (The `Reconcile.hs:85` import of `isIdle` was already dropped in Task 6.)
+
+- [ ] **Step 6: Update the `isIdle` tests** (`ClaudeCodeSpec.hs:444-451`) to the corrected expectations: a bare-prompt idle frame → `True`; a spinner/working frame (`✶ …` / token counter) → `False`; an approval frame → `False`.
+- [ ] **Step 7: Run green** (full suite) + `nix develop . --command cabal build` clean under `-Werror`.
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/PureClaw/Frontend/API.hs src/PureClaw/Harness/ClaudeCode.hs \
+        test/Frontend/APISpec.hs test/Harness/ClaudeCodeSpec.hs
+git commit -m "refactor(api): decouple harness send from receive; isIdle via observer; watcher owns Response recording"
+```
+
+---
+
+## Final verification (after all tasks)
+
+- [ ] `nix develop . --command bash -c "cabal clean && cabal build"` — clean under `-Wall -Werror`.
+- [ ] `nix develop . --command cabal test` — full suite green.
+- [ ] `nix develop . --command cabal test --enable-coverage` — ≥95% per `.coverage-thresholds.json`.
+- [ ] `cd frontend && npx tsc --noEmit && npx vitest run` — green.
+- [ ] Manual smoke (live): adopt/spawn a Claude harness, send a message from the web UI, confirm the reply appears via the stream; trigger an approval prompt and confirm the needs-input pill + prompt text; run `/harness output`.
+
+## Self-review notes
+
+- **Spec coverage:** Mechanism 1 → Task 5; Mechanism 2 → Tasks 6–7; observer seam → Task 2; three states + pill → Tasks 3, 6; decouple send/receive → Task 8; `-J` capture → Task 1; generic fallback → Task 2.
+- **Known Phase-1 limitation** (last `⏺` block per settle) is inherent to Task 7's extract-on-settle; `/harness output` (Task 5) is the manual workaround. Phase 2 (live-edit) is out of scope.
+- **Loop state, not entry widening:** per-entry previous-capture (for the stability gate, `Map HarnessId Text`) and per-session last-response (for dedup, `Map SessionId Text`, plain equality — no `hashable`) live in the reconcile loop's fold state, not on `HarnessEntry`. Task 7's test pins the dedup behavior.
+- **Cascade coverage:** every `-Werror`-forced match/construction site for the two new enum constructors (`LivenessAwaitingInput`, `HarnessNeedsInput`) and the two new fields (`_he_flavour`, `_hh_snapshot`) is enumerated in the "Cascade & construction-site inventory" section, and each owning task's file scope and commit list includes those files (incl. `TabsView.hs`, `RuntimesSpec.hs`, `RegistrySpec.hs`, `SlashCommands.hs mkHandle`). `classifyLiveness`/`isIdle` dispositions and their existing tests are explicitly handled (Tasks 6, 8).

--- a/frontend/src/components/StatusDot.tsx
+++ b/frontend/src/components/StatusDot.tsx
@@ -10,6 +10,7 @@ const dotClass: Record<AgentStatus, string> = {
 const activityDotClass: Record<HarnessActivity, string> = {
   'thinking': 'dot dot-thinking',
   'idle': 'dot dot-idle',
+  'needs-input': 'dot dot-needs',
   'stopped': 'dot dot-completed',
 }
 

--- a/frontend/src/components/__tests__/StatusDot.test.tsx
+++ b/frontend/src/components/__tests__/StatusDot.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ActivityDot } from '../StatusDot'
+
+describe('ActivityDot', () => {
+  it('renders a needs-input activity with the dot-needs class', () => {
+    const { container } = render(<ActivityDot activity={'needs-input'} />)
+    expect(container.firstChild).toHaveClass('dot-needs')
+  })
+
+  it('renders a thinking activity with the dot-thinking class', () => {
+    const { container } = render(<ActivityDot activity={'thinking'} />)
+    expect(container.firstChild).toHaveClass('dot-thinking')
+  })
+
+  it('renders an idle activity with the dot-idle class', () => {
+    const { container } = render(<ActivityDot activity={'idle'} />)
+    expect(container.firstChild).toHaveClass('dot-idle')
+  })
+
+  it('renders a stopped activity with the dot-completed class', () => {
+    const { container } = render(<ActivityDot activity={'stopped'} />)
+    expect(container.firstChild).toHaveClass('dot-completed')
+  })
+})

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,7 +10,7 @@ export interface Agent {
 
 // API types matching the Haskell backend
 
-export type HarnessActivity = 'thinking' | 'idle' | 'stopped'
+export type HarnessActivity = 'thinking' | 'idle' | 'needs-input' | 'stopped'
 
 export interface HarnessInfo {
   name: string

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -107,6 +107,7 @@ library
     PureClaw.Harness.Discovery
     PureClaw.Harness.JsonlTail
     PureClaw.Harness.Reconcile
+    PureClaw.Harness.Id
     PureClaw.Harness.Registry
     PureClaw.Harness.Tmux
     PureClaw.Harness.Observer

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -368,6 +368,8 @@ test-suite pureclaw-test
     Frontend.StreamIntegrationSpec
     -- Frontend (live transcript streaming — WU4)
     Frontend.ActivityProbeSpec
+    -- Frontend Activity.Types unit tests (Task 3)
+    Frontend.ActivityTypesSpec
     -- Frontend (live transcript streaming — WU6: HTTP-API regression)
     Frontend.APISpec
     Harness.ClaudeCodeSpec

--- a/pureclaw.cabal
+++ b/pureclaw.cabal
@@ -109,6 +109,7 @@ library
     PureClaw.Harness.Reconcile
     PureClaw.Harness.Registry
     PureClaw.Harness.Tmux
+    PureClaw.Harness.Observer
     -- Tools (take handles, return IO results)
     PureClaw.Tools.Registry
     PureClaw.Tools.Shell
@@ -378,6 +379,7 @@ test-suite pureclaw-test
     Harness.ReconcileSpec
     Harness.RegistrySpec
     Harness.TmuxSpec
+    Harness.ObserverSpec
     -- WU0 (tabbed-chat) red-phase scaffold specs
     -- Routing.ParseSpec removed in 8c.3: it imported the deleted
     -- PureClaw.Routing.Dispatcher / PureClaw.Routing.Registry modules.

--- a/src/PureClaw/Agent/SlashCommands.hs
+++ b/src/PureClaw/Agent/SlashCommands.hs
@@ -180,6 +180,7 @@ data HarnessSubCommand
   | HarnessStop Text           -- ^ Stop a named harness
   | HarnessList                -- ^ List running harnesses
   | HarnessAttach              -- ^ Show tmux attach command
+  | HarnessOutput (Maybe Text) Int -- ^ Show last response (N=0) or last N relevant lines
   | HarnessUnknown Text        -- ^ Unrecognised subcommand
   deriving stock (Show, Eq)
 
@@ -413,6 +414,7 @@ harnessCommandSpecs =
   , CommandSpec "/harness stop <name>"   "Stop a running harness"               GroupHarness (harnessArgP "stop" HarnessStop)
   , CommandSpec "/harness list"          "List running harnesses"               GroupHarness (harnessExactP "list" HarnessList)
   , CommandSpec "/harness attach"        "Show tmux attach command"             GroupHarness (harnessExactP "attach" HarnessAttach)
+  , CommandSpec "/harness output [name] [N]" "Show recent harness output (last response, or last N lines)" GroupHarness harnessOutputP
   ]
 
 agentCommandSpecs :: [CommandSpec]
@@ -861,6 +863,20 @@ harnessArgP sub mkCmd t =
              then Nothing
              else Just (CmdHarness (mkCmd arg))
      else Nothing
+
+-- | Parse "/harness output [name] [N]".
+-- If N is given and name is omitted, the bare integer parses as N (no name).
+harnessOutputP :: Text -> Maybe SlashCommand
+harnessOutputP t =
+  case T.words t of
+    (cmd : "output" : rest) | T.toLower cmd == "/harness" ->
+      Just $ CmdHarness $ case rest of
+        []        -> HarnessOutput Nothing 0
+        [a]       -> case Data.Maybe.listToMaybe (reads (T.unpack a)) of
+                       Just (n, "") -> HarnessOutput Nothing n
+                       _            -> HarnessOutput (Just a) 0
+        (a : b : _) -> HarnessOutput (Just a) (maybe 0 id (fmap fst (Data.Maybe.listToMaybe (reads (T.unpack b)))))
+    _ -> Nothing
 
 -- | Catch-all for any "/harness <X>" not matched by 'allCommandSpecs'.
 harnessUnknownFallback :: Text -> Maybe SlashCommand
@@ -1900,6 +1916,24 @@ executeHarnessCommand env sub ctx = do
       send "tmux attach -t pureclaw"
       pure ctx
 
+    HarnessOutput mName n -> do
+      harnesses <- readIORef (_env_harnesses env)
+      let pick = case mName of
+            Just nm -> Map.lookup nm harnesses
+            Nothing -> case Map.toList harnesses of
+                         [(_, hh)] -> Just hh   -- exactly one running → use it
+                         _         -> Nothing
+      case pick of
+        Nothing -> do
+          send (case mName of
+                  Just nm -> "No running harness named '" <> nm <> "'."
+                  Nothing -> "Specify a harness name: /harness output <name> [N].")
+          pure ctx
+        Just hh -> do
+          out <- _hh_snapshot hh n
+          send (if T.null (T.strip out) then "(no recent output)" else out)
+          pure ctx
+
     HarnessUnknown subcmd
       | T.null subcmd -> do
           -- Bare /harness: show status + available subcommands
@@ -1919,6 +1953,7 @@ executeHarnessCommand env sub ctx = do
                 , "  /harness stop <name>   — Stop a harness"
                 , "  /harness list          — List harnesses"
                 , "  /harness attach        — Show tmux attach command"
+                , "  /harness output [name] [N]  — Show recent harness output"
                 ]
           send output
           pure ctx

--- a/src/PureClaw/CLI/Commands.hs
+++ b/src/PureClaw/CLI/Commands.hs
@@ -20,7 +20,7 @@ module PureClaw.CLI.Commands
   ) where
 
 import Control.Concurrent.Async qualified as Async
-import Control.Exception (IOException, SomeException, bracket_, catch, try)
+import Control.Exception (IOException, SomeException, bracket, bracket_, catch, try)
 import Control.Monad (filterM, unless, when)
 import Data.ByteString (ByteString)
 import Data.Either (fromRight)
@@ -93,7 +93,12 @@ import PureClaw.Frontend.StreamBroker
 import PureClaw.Harness.ClaudeCode (adoptExternalWindow, defaultClaudeCodeDeps)
 import PureClaw.Harness.Reconcile qualified as Reconcile
 import PureClaw.Harness.Registry qualified as Registry
-import PureClaw.Handles.Transcript (mkNoOpTranscriptHandle)
+import PureClaw.Handles.Transcript (TranscriptHandle (..), mkNoOpTranscriptHandle)
+import PureClaw.Frontend.BroadcastingTranscript (mkBroadcastingFileTranscriptHandle)
+import PureClaw.Transcript.Types
+  (Direction (..), TranscriptEntry (..), encodePayload)
+import Data.UUID qualified as UUID
+import Data.UUID.V4 qualified as UUID
 import PureClaw.Channels.AllowList
 import PureClaw.Channels.CLI
 import PureClaw.Channels.Signal
@@ -987,6 +992,15 @@ runChat consentChannel serverMode opts = do
         let reconcileDeps = Reconcile.defaultReconcileDeps
               { Reconcile._rd_evict = \_hid label ->
                   modifyIORef' harnessRef (Map.delete label)
+                -- Output watcher (Task 7): on a working→settle transition the
+                -- loop records ONE Response transcript entry for the session,
+                -- broadcasting it to subscribers via the shared broker.
+              , Reconcile._rd_recordResponse = \sid txt -> do
+                  let path = sessionsDir </> T.unpack (unSessionId sid) </> "transcript.jsonl"
+                  bracket
+                    (mkBroadcastingFileTranscriptHandle (Just broker) sid logger path)
+                    (\rth -> _th_flush rth >> _th_close rth)
+                    (`recordResponseEntry` txt)
               }
         -- WU8 (#80): restore the persisted tab view BEFORE the frontend server
         -- (and the tabbed loop) start, so the very first sidebar lists snapshot
@@ -1382,6 +1396,26 @@ resolveApiKey Nothing vaultKeyName vaultOpt = do
 -- is recoverable on the next mutation.
 ignoreExc :: IO () -> IO ()
 ignoreExc act = act `catch` \(_ :: SomeException) -> pure ()
+
+-- | Record a single harness @Response@ transcript entry. Mirrors the field
+-- shape of @recordHarnessEntry … Response@ in "PureClaw.Frontend.API" — the
+-- output watcher (Task 7) uses it to land one settle-captured response on the
+-- session transcript.
+recordResponseEntry :: TranscriptHandle -> T.Text -> IO ()
+recordResponseEntry th payload = do
+  entryId <- UUID.toText <$> UUID.nextRandom
+  now <- getCurrentTime
+  _th_record th TranscriptEntry
+    { _te_id            = entryId
+    , _te_timestamp     = now
+    , _te_harness       = Just "harness"
+    , _te_model         = Nothing
+    , _te_direction     = Response
+    , _te_payload       = encodePayload (TE.encodeUtf8 payload)
+    , _te_durationMs    = Nothing
+    , _te_correlationId = entryId
+    , _te_metadata      = Map.empty
+    }
 
 -- | Render a 'HarnessError' to a concise user-facing 'Text' for the
 -- @\/tab new harness@ dispatcher (WU-B). Mirrors the surface

--- a/src/PureClaw/Frontend/API.hs
+++ b/src/PureClaw/Frontend/API.hs
@@ -44,7 +44,7 @@ module PureClaw.Frontend.API
 
 import Control.Concurrent.STM (TVar, newTVarIO)
 import Control.Exception (IOException, SomeException, bracket, bracket_, try)
-import Control.Monad (filterM, unless, when)
+import Control.Monad (filterM, when)
 import Data.Aeson qualified as Aeson
 import Data.Aeson (Value, ToJSON (..), FromJSON (..), object, (.=), (.:), (.:?), (.!=))
 import Data.Aeson.Types qualified as AesonTypes
@@ -2120,34 +2120,31 @@ routeViaHandle
   -> (Response -> IO ResponseReceived)
   -> IO ResponseReceived
 routeViaHandle env sid hh userText transcriptPath postSend respond = do
-  -- 'handleSend' is the sole writer of THIS session's transcript: on the
-  -- fresh-create path the harness handle was given a no-op transcript
-  -- ('createHarnessTab'), and a restart-discovered handle records to the
-  -- CLI's own session transcript (a different file), so recording here never
-  -- duplicates an entry in this session transcript. 'bracket' guarantees the
-  -- transcript fd is flushed + closed even if '_hh_send'/'_hh_receive' throws
-  -- (tmux IO), so a failed send cannot leak a file descriptor.
+  -- 'handleSend' records the Request entry and injects keystrokes. The
+  -- Response entry is recorded by the reconcile watcher (Task 8 decoupling):
+  -- the send path no longer blocks on '_hh_receive', so the HTTP response
+  -- returns promptly with {"response":""} and the real reply arrives via the
+  -- WS stream (watcher → broker → WS). 'bracket' guarantees the transcript
+  -- fd is flushed + closed even if '_hh_send' throws (tmux IO), so a failed
+  -- send cannot leak a file descriptor.
   result <- try @SomeException $
     bracket
       (mkBroadcastingFileTranscriptHandle
          (_fe_broker env) (SessionId sid) (_fe_logger env) transcriptPath)
       (\th -> _th_flush th >> _th_close th)
       (\th -> do
-        -- Record the user message as a Request entry (mirrors 'harnesseSend').
+        -- Record the user message as a Request entry (mirrors 'harnessSend').
         recordHarnessEntry th Request userText
         _hh_send hh (TE.encodeUtf8 userText)
-        raw <- _hh_receive hh
-        let resp = sanitizeHarnessOutput (TE.decodeUtf8 raw)
-        -- Only record a Response entry when the harness produced output;
-        -- a blank reply must not leave an empty/duplicate entry.
-        unless (T.null (T.strip resp)) $
-          recordHarnessEntry th Response resp
-        pure resp)
+        -- Response is recorded by the reconcile watcher on settle; the send
+        -- path no longer blocks on _hh_receive (which mis-fired off the broken
+        -- isIdle and double-recorded against the watcher). Reply arrives via WS.
+        pure (mempty :: T.Text))
   case result of
     Left e -> do
       _lh_logError (_fe_logger env) $ "Harness send error: " <> T.pack (show e)
       respond $ jsonResponse status500 (object ["error" .= ("Harness send failed" :: Text)])
-    Right resp -> do
+    Right _ -> do
       touchSessionLastActive (_fe_sessionsDir env) (SessionId sid)
       broadcastLists env
       -- Synchronous-but-exception-proof post-send hook (e.g. the D6.5 id
@@ -2155,7 +2152,7 @@ routeViaHandle env sid hh userText transcriptPath postSend respond = do
       -- minor latency — but is exception-proof at the source, so it cannot fail
       -- the send the user is about to receive.
       postSend
-      respond $ jsonResponse status200 (object ["response" .= resp, "kind" .= ("assistant" :: Text)])
+      respond $ jsonResponse status200 (object ["response" .= ("" :: Text), "kind" .= ("assistant" :: Text)])
 
 -- | Lazy migration (D6.5): if a corroborated registry entry's label matches
 -- @windowName@, persist its 'Registry.HarnessId' onto the session's

--- a/src/PureClaw/Frontend/Activity/Types.hs
+++ b/src/PureClaw/Frontend/Activity/Types.hs
@@ -17,10 +17,12 @@ import Data.Aeson (ToJSON (..))
 data HarnessActivity
   = HarnessThinking
   | HarnessIdle
+  | HarnessNeedsInput  -- ^ Window present, harness blocked on an approval/menu prompt.
   | HarnessStopped
   deriving stock (Show, Eq)
 
 instance ToJSON HarnessActivity where
-  toJSON HarnessThinking = Aeson.String "thinking"
-  toJSON HarnessIdle     = Aeson.String "idle"
-  toJSON HarnessStopped  = Aeson.String "stopped"
+  toJSON HarnessThinking   = Aeson.String "thinking"
+  toJSON HarnessIdle       = Aeson.String "idle"
+  toJSON HarnessNeedsInput = Aeson.String "needs-input"
+  toJSON HarnessStopped    = Aeson.String "stopped"

--- a/src/PureClaw/Frontend/TabsView.hs
+++ b/src/PureClaw/Frontend/TabsView.hs
@@ -104,10 +104,11 @@ instance ToJSON TabSnapshot where
 -- words so the frontend can render the state→visual table.
 livenessToTabStatus :: Registry.Liveness -> Text
 livenessToTabStatus lv = case lv of
-  Registry.LivenessIdle     -> "idle"
-  Registry.LivenessThinking -> "running"
-  Registry.LivenessExited   -> "exited"
-  Registry.LivenessOrphaned -> "orphaned"
+  Registry.LivenessIdle          -> "idle"
+  Registry.LivenessThinking      -> "running"
+  Registry.LivenessAwaitingInput -> "running"  -- distinct state shown via the activity dot, not the tab badge
+  Registry.LivenessExited        -> "exited"
+  Registry.LivenessOrphaned      -> "orphaned"
 
 -- | Map a registry 'Registry.HarnessOrigin' to the @TabSnapshot@ origin
 -- vocabulary (the §7 origin pill): @\"spawned\"@ (we launched it),

--- a/src/PureClaw/Handles/Harness.hs
+++ b/src/PureClaw/Handles/Harness.hs
@@ -33,23 +33,25 @@ data HarnessError
 
 -- | Capability handle for interacting with a harness (e.g. Claude Code in tmux).
 data HarnessHandle = HarnessHandle
-  { _hh_send    :: ByteString -> IO ()   -- ^ Write to harness input
-  , _hh_receive :: IO ByteString         -- ^ Read harness output (scrollback capture)
-  , _hh_name    :: Text                  -- ^ Human-readable name
-  , _hh_session :: Text                  -- ^ tmux session name
-  , _hh_status  :: IO HarnessStatus      -- ^ Check if running
-  , _hh_stop    :: IO ()                 -- ^ Kill and cleanup
+  { _hh_send     :: ByteString -> IO ()   -- ^ Write to harness input
+  , _hh_receive  :: IO ByteString         -- ^ Read harness output (scrollback capture)
+  , _hh_snapshot :: Int -> IO Text        -- ^ One-shot capture+extract via the flavour observer
+  , _hh_name     :: Text                  -- ^ Human-readable name
+  , _hh_session  :: Text                  -- ^ tmux session name
+  , _hh_status   :: IO HarnessStatus      -- ^ Check if running
+  , _hh_stop     :: IO ()                 -- ^ Kill and cleanup
   }
 
 -- | No-op harness handle for testing.
 mkNoOpHarnessHandle :: HarnessHandle
 mkNoOpHarnessHandle = HarnessHandle
-  { _hh_send    = \_ -> pure ()
-  , _hh_receive = pure ""
-  , _hh_name    = ""
-  , _hh_session = ""
-  , _hh_status  = pure HarnessRunning
-  , _hh_stop    = pure ()
+  { _hh_send     = \_ -> pure ()
+  , _hh_receive  = pure ""
+  , _hh_snapshot = \_ -> pure ""
+  , _hh_name     = ""
+  , _hh_session  = ""
+  , _hh_status   = pure HarnessRunning
+  , _hh_stop     = pure ()
   }
 
 -- | Prefix harness output with the origin name on the first line only.

--- a/src/PureClaw/Harness/ClaudeCode.hs
+++ b/src/PureClaw/Harness/ClaudeCode.hs
@@ -791,14 +791,11 @@ harnessStop deps reg hid = do
 -- Response extraction (pure)
 -- ---------------------------------------------------------------------------
 
--- | Check if Claude Code is idle (showing prompt, not busy).
+-- | Idle iff the flavour observer classifies the screen as settled (replaces
+-- the stale ❯\/⠋ heuristic; the input box ❯ is always present, so it
+-- cannot mean idle on its own).
 isIdle :: Text -> Bool
-isIdle screen =
-  let hasPrompt = T.isInfixOf "\x276F" screen   -- ❯
-      isBusy    = T.isInfixOf "\x280B" screen    -- ⠋ (spinner)
-                || T.isInfixOf "Thinking" screen
-                || T.isInfixOf "Running" screen
-  in hasPrompt && not isBusy
+isIdle screen = Obs._ho_classify Obs.claudeObserver screen == Obs.HasIdle
 
 -- | Drop the first @n@ scrollback lines from a raw capture (B3 baseline
 -- mechanism). The baseline is the number of pre-existing lines to EXCLUDE.

--- a/src/PureClaw/Harness/ClaudeCode.hs
+++ b/src/PureClaw/Harness/ClaudeCode.hs
@@ -336,6 +336,7 @@ mkClaudeCodeHarnessWith deps policy th session windowName _windowIdx mWorkDir ex
                                 , Reg._he_shellPid    = mShellPid
                                 , Reg._he_harnessPid  = mHarnessPid
                                 , Reg._he_origin      = Reg.OriginSpawned
+                                , Reg._he_flavour     = HClaudeCode
                                 , Reg._he_liveness    = Reg.LivenessIdle
                                 , Reg._he_extModified = False
                                 , Reg._he_stale       = False
@@ -562,6 +563,7 @@ adoptValidated deps reg th sessionsDir session mWindowIndex windowName = do
             , Reg._he_shellPid    = mShellPid
             , Reg._he_harnessPid  = mHarnessPid
             , Reg._he_origin      = Reg.OriginAdopted
+            , Reg._he_flavour     = HClaudeCode
             , Reg._he_liveness    = Reg.LivenessIdle
             , Reg._he_extModified = False
             , Reg._he_stale       = False

--- a/src/PureClaw/Harness/ClaudeCode.hs
+++ b/src/PureClaw/Harness/ClaudeCode.hs
@@ -49,7 +49,7 @@ import System.FilePath ((</>))
 import System.Process.Typed qualified as P
 import PureClaw.Handles.Harness
 import PureClaw.Handles.Transcript
-import PureClaw.Harness.Observer (observerFor, _ho_extractResponse, _ho_relevantTail)
+import PureClaw.Harness.Observer qualified as Obs
 import PureClaw.Harness.Registry (HarnessId, HarnessRegistry)
 import PureClaw.Harness.Registry qualified as Reg
 import PureClaw.Harness.Tmux
@@ -406,10 +406,10 @@ mkClaudeCodeHandleWithBaseline deps reg hid th session baseline = do
           Nothing -> pure ""
           Just (sess, win) -> do
             raw <- fromMaybe "" <$> _ccd_captureNamed deps sess win (if n <= 0 then 0 else max n 50)
-            let obs = observerFor HClaudeCode
+            let obs = Obs.observerFor HClaudeCode
             pure $ if n <= 0
-              then _ho_extractResponse obs 0 raw
-              else _ho_relevantTail obs n raw
+              then Obs._ho_extractResponse obs 0 raw
+              else Obs._ho_relevantTail obs n raw
     , _hh_name     = "Claude Code"
     , _hh_session  = session
     , _hh_status   = harnessStatus deps reg hid
@@ -870,10 +870,10 @@ mkDiscoveredClaudeCodeHandle th session windowName =
     , _hh_receive  = discoveredReceive th session windowName
     , _hh_snapshot = \n -> do
         raw <- fromMaybe "" <$> realCaptureNamed session windowName (if n <= 0 then 0 else max n 50)
-        let obs = observerFor HClaudeCode
+        let obs = Obs.observerFor HClaudeCode
         pure $ if n <= 0
-          then _ho_extractResponse obs 0 raw
-          else _ho_relevantTail obs n raw
+          then Obs._ho_extractResponse obs 0 raw
+          else Obs._ho_relevantTail obs n raw
     , _hh_name     = "Claude Code"
     , _hh_session  = session
     , _hh_status   = realStatus session windowName

--- a/src/PureClaw/Harness/ClaudeCode.hs
+++ b/src/PureClaw/Harness/ClaudeCode.hs
@@ -49,6 +49,7 @@ import System.FilePath ((</>))
 import System.Process.Typed qualified as P
 import PureClaw.Handles.Harness
 import PureClaw.Handles.Transcript
+import PureClaw.Harness.Observer (observerFor, _ho_extractResponse, _ho_relevantTail)
 import PureClaw.Harness.Registry (HarnessId, HarnessRegistry)
 import PureClaw.Harness.Registry qualified as Reg
 import PureClaw.Harness.Tmux
@@ -397,12 +398,22 @@ mkClaudeCodeHandleWithBaseline
 mkClaudeCodeHandleWithBaseline deps reg hid th session baseline = do
   baselineRef <- newIORef baseline
   pure HarnessHandle
-    { _hh_send    = harnessSend deps reg hid th baselineRef
-    , _hh_receive = harnessReceive deps reg hid th baselineRef
-    , _hh_name    = "Claude Code"
-    , _hh_session = session
-    , _hh_status  = harnessStatus deps reg hid
-    , _hh_stop    = harnessStop deps reg hid
+    { _hh_send     = harnessSend deps reg hid th baselineRef
+    , _hh_receive  = harnessReceive deps reg hid th baselineRef
+    , _hh_snapshot = \n -> do
+        mCoord <- currentCoord reg hid
+        case mCoord of
+          Nothing -> pure ""
+          Just (sess, win) -> do
+            raw <- fromMaybe "" <$> _ccd_captureNamed deps sess win (if n <= 0 then 0 else max n 50)
+            let obs = observerFor HClaudeCode
+            pure $ if n <= 0
+              then _ho_extractResponse obs 0 raw
+              else _ho_relevantTail obs n raw
+    , _hh_name     = "Claude Code"
+    , _hh_session  = session
+    , _hh_status   = harnessStatus deps reg hid
+    , _hh_stop     = harnessStop deps reg hid
     }
 
 -- ---------------------------------------------------------------------------
@@ -855,12 +866,18 @@ stripMarker line =
 mkDiscoveredClaudeCodeHandle :: TranscriptHandle -> Text -> Text -> IO HarnessHandle
 mkDiscoveredClaudeCodeHandle th session windowName =
   pure HarnessHandle
-    { _hh_send    = discoveredSend th session windowName
-    , _hh_receive = discoveredReceive th session windowName
-    , _hh_name    = "Claude Code"
-    , _hh_session = session
-    , _hh_status  = realStatus session windowName
-    , _hh_stop    = stopHarnessWindowNamed session windowName
+    { _hh_send     = discoveredSend th session windowName
+    , _hh_receive  = discoveredReceive th session windowName
+    , _hh_snapshot = \n -> do
+        raw <- fromMaybe "" <$> realCaptureNamed session windowName (if n <= 0 then 0 else max n 50)
+        let obs = observerFor HClaudeCode
+        pure $ if n <= 0
+          then _ho_extractResponse obs 0 raw
+          else _ho_relevantTail obs n raw
+    , _hh_name     = "Claude Code"
+    , _hh_session  = session
+    , _hh_status   = realStatus session windowName
+    , _hh_stop     = stopHarnessWindowNamed session windowName
     }
 
 -- | Send for a discovered (registry-less) handle: log the request, then send by

--- a/src/PureClaw/Harness/Id.hs
+++ b/src/PureClaw/Harness/Id.hs
@@ -1,0 +1,50 @@
+-- | Leaf module for 'HarnessId' — a UUID-backed harness identity.
+--
+-- This module exists purely to break the import cycle between
+-- 'PureClaw.Harness.Registry' (which defines 'HarnessEntry' and may import
+-- 'PureClaw.Session.Kind') and 'PureClaw.Session.Kind' (which embeds
+-- 'HarnessId' in 'HarnessSpec'). By isolating 'HarnessId' here, both modules
+-- can import this leaf without creating a cycle.
+--
+-- Depends ONLY on @uuid@, @text@, @aeson@, and @base@. Never imports any
+-- project module.
+module PureClaw.Harness.Id
+  ( -- * Identity
+    HarnessId (..)
+  , parseHarnessId
+  , harnessIdToText
+  ) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.UUID (UUID)
+import Data.UUID qualified as UUID
+
+-- | A PureClaw-assigned, UUID-backed harness identity. This is the canonical
+-- key for the registry and the durable anchor that survives tmux window
+-- rename\/move and PureClaw restart (persisted in @session.json@).
+newtype HarnessId = HarnessId { unHarnessId :: UUID }
+  deriving stock (Eq, Ord, Show)
+
+-- | Parse a 'HarnessId' from its canonical UUID text representation.
+-- Returns 'Nothing' for any non-UUID input.
+parseHarnessId :: Text -> Maybe HarnessId
+parseHarnessId = fmap HarnessId . UUID.fromText
+
+-- | Render a 'HarnessId' as its canonical UUID text representation.
+harnessIdToText :: HarnessId -> Text
+harnessIdToText = UUID.toText . unHarnessId
+
+-- | Round-trippable JSON: a 'HarnessId' is encoded as the canonical UUID
+-- string (D2.4). We hand-write the codec rather than @deriving newtype@ so the
+-- on-the-wire shape (a plain string) is explicit and decode rejects malformed
+-- UUIDs with a clear error.
+instance ToJSON HarnessId where
+  toJSON = Aeson.String . harnessIdToText
+
+instance FromJSON HarnessId where
+  parseJSON = Aeson.withText "HarnessId" $ \t ->
+    case parseHarnessId t of
+      Just hid -> pure hid
+      Nothing  -> fail ("invalid HarnessId (not a UUID): " <> show t)

--- a/src/PureClaw/Harness/Observer.hs
+++ b/src/PureClaw/Harness/Observer.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Per-flavour, PURE detection and extraction of harness terminal output.
+-- Each harness TUI (Claude Code, Codex, …) draws its screen differently, so
+-- working/idle/awaiting-input detection and response extraction are
+-- flavour-specific. The reconcile loop and the @/harness output@ command both
+-- select an observer via 'observerFor'. Heuristics are facts about each tool's
+-- terminal output; they were validated against live captures.
+module PureClaw.Harness.Observer
+  ( HarnessActivityState (..)
+  , HarnessObserver (..)
+  , observerFor
+  , claudeObserver
+  , genericObserver
+  ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Data.Char (isSpace)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           PureClaw.Session.Kind (HarnessFlavour (..))
+
+data HarnessActivityState = HasWorking | HasAwaitingInput | HasIdle
+  deriving stock (Eq, Show)
+
+data HarnessObserver = HarnessObserver
+  { _ho_classify        :: Text -> HarnessActivityState
+  , _ho_extractResponse :: Int -> ByteString -> Text
+  , _ho_relevantTail    :: Int -> ByteString -> Text
+  }
+
+observerFor :: HarnessFlavour -> HarnessObserver
+observerFor HClaudeCode = claudeObserver
+observerFor _           = genericObserver
+
+-- ── Claude Code ────────────────────────────────────────────────────────────
+
+-- | Spinner glyphs Claude rotates while working (Dingbats range + a few extras).
+claudeSpinnerGlyphs :: [Char]
+claudeSpinnerGlyphs = "\x23FA\x25CF\x2B24\x2022\x2726\x2732\x2733\x2734\x2735\x2736\x2737\x2738\x2739\x273A\x273B\x273C\x273D\x273E\x273F\x2605\xB7\x2022\x22C6\x2642\x2666\xB7\x00B7\x2019\x2022\x2605\x2736\x2737\x2738\x2739\x273A\x273B\x273C\x273D\x273E\x273F\xB7\x22C6\x22C7"
+
+-- Additional spinner chars observed in the wild (Hermes, faryo patterns).
+-- Claude Code uses the ✶ (U+2736) glyph and ⏺ (U+23FA) as status/response markers.
+-- The status line for "working" looks like: ✶ Smooshing… (4m 55s · ↓ 16.6k tokens)
+-- So we also need to match U+2736 STAR (✶) and U+22C6 STAR OPERATOR (⋆).
+
+-- | A working/status line: starts with a spinner/star glyph followed by
+-- a description containing ellipsis or a token counter in parens, or the
+-- @esc to interrupt@ hint.
+isClaudeWorkingLine :: Text -> Bool
+isClaudeWorkingLine raw =
+  let l = T.stripStart raw
+  in (not (T.null l) && (isSpinnerGlyph (T.head l))
+       && (T.isInfixOf "\x2026" l || T.isInfixOf "..." l))   -- … or ...
+     || hasTokenCounter l
+     || T.isInfixOf "esc to interrupt" (T.toLower l)
+  where
+    -- Spinner glyphs: ✶ ⏺ ● ⬤ • ⋆ ✢ ✱ ✲ ✳ ✴ ✵ ✶ ✷ ✸ ✹ ✺ ✻ ✼ ✽ ✾ ✿ ★ · and more
+    isSpinnerGlyph c = c `elem` claudeSpinnerGlyphs
+                    || c == '\x2736'   -- ✶  SIX POINTED BLACK STAR
+                    || c == '\x22C6'   -- ⋆  STAR OPERATOR
+                    || c == '\x2022'   -- •  BULLET
+                    || c == '\x00B7'   -- ·  MIDDLE DOT
+                    || c == '\x2026'   -- … (shouldn't start a line but just in case)
+                    || c == '\x2732'   -- ✲
+                    || c == '\x2733'   -- ✳
+                    || c == '\x2734'   -- ✴
+                    || c == '\x2735'   -- ✵
+                    || c == '\x2737'   -- ✷
+                    || c == '\x2738'   -- ✸
+                    || c == '\x2739'   -- ✹
+                    || c == '\x273A'   -- ✺
+                    || c == '\x273B'   -- ✻
+                    || c == '\x273C'   -- ✼
+                    || c == '\x273D'   -- ✽
+                    || c == '\x273E'   -- ✾
+                    || c == '\x273F'   -- ✿
+                    || c == '\x2605'   -- ★
+    hasTokenCounter t =
+      T.isInfixOf "tokens" (T.toLower t)
+      && T.isInfixOf "(" t && T.isInfixOf ")" t
+
+-- | An approval/menu prompt: Claude is blocked on the user.
+isClaudeApprovalLine :: Text -> Bool
+isClaudeApprovalLine raw =
+  let l = T.toLower (T.stripStart raw)
+  in T.isInfixOf "do you want to proceed?" l
+     || T.isInfixOf "yes, and don't ask again" l
+     || T.isInfixOf "yes, and don\x2019t ask again" l
+     || T.isInfixOf "enter to confirm" l
+     || T.isInfixOf "esc to cancel" l
+     || isNumberedYesNo (T.stripStart raw)
+
+-- | A numbered option line, optionally led by the @❯@ menu cursor: @❯ 1. Yes@.
+-- Matches lines like "❯ 1. Yes", "  2. No", "1. Something".
+isNumberedYesNo :: Text -> Bool
+isNumberedYesNo l0 =
+  -- strip leading ❯ ›  and spaces
+  let l = T.dropWhile (\c -> c == '\x276F' || c == '\x203A' || c == ' ') l0
+  in case T.span (\c -> c >= '0' && c <= '9') l of
+       (ds, rest) -> not (T.null ds) && T.isPrefixOf "." rest
+
+-- | The idle input prompt: a bare @❯@/@›@ NOT followed by a number+dot
+-- (which would be a menu-selection cursor, not the prompt).
+isIdlePromptLine :: Text -> Bool
+isIdlePromptLine raw =
+  let l = T.stripStart raw
+  in (T.isPrefixOf "\x276F" l || T.isPrefixOf "\x203A" l)  -- ❯ ›
+     && not (isNumberedYesNo l)
+     && T.null (T.strip (T.drop 1 l))  -- nothing after the prompt glyph
+
+classifyClaude :: Text -> HarnessActivityState
+classifyClaude screen =
+  let ls = T.lines screen
+  in if any isClaudeWorkingLine ls then HasWorking
+     else if any isClaudeApprovalLine ls then HasAwaitingInput
+     else HasIdle
+
+-- | True for chrome lines that must never appear in extracted output.
+isClaudeChrome :: Text -> Bool
+isClaudeChrome raw =
+  let l = T.stripStart raw
+  in T.null (T.strip l)
+     || isClaudeWorkingLine raw
+     || (isIdlePromptLine raw)
+     || T.isInfixOf "for shortcuts" (T.toLower l)
+     || T.isInfixOf "ctrl+o to expand" (T.toLower l)
+     || isBoxDrawingLine l  -- ─ ▀ ▄ lines (horizontal rules)
+
+isBoxDrawingLine :: Text -> Bool
+isBoxDrawingLine l =
+  not (T.null l)
+  && T.all (\c -> c == '\x2500' || c == '\x2580' || c == '\x2584' || isSpace c) l
+
+isResponseMarkerLine :: Text -> Bool
+isResponseMarkerLine line =
+  let l = T.stripStart line
+  in T.isPrefixOf "\x23FA" l    -- ⏺
+     || T.isPrefixOf "\x25CF" l -- ● (alternate, faryo)
+     || T.isPrefixOf "\x2B24" l -- ⬤ (alternate)
+
+stripResponseMarker :: Text -> Text
+stripResponseMarker line =
+  T.stripStart (T.dropWhile (`elem` ("\x23FA\x25CF\x2B24 " :: String)) (T.stripStart line))
+
+-- | Extract the latest assistant response. @baseline@ is the number of lines
+-- already seen (used to skip already-delivered content). When awaiting input,
+-- return the approval/menu prompt block so the user sees the question.
+extractClaude :: Int -> ByteString -> Text
+extractClaude baseline capture =
+  let body = dropBaseline baseline capture
+      ls   = T.lines (TE.decodeUtf8Lenient body)
+  in if any isClaudeApprovalLine ls
+       then T.strip . T.unlines $ dropWhile (not . isClaudeApprovalLine) ls
+       else case reverse [ i | (i, l) <- zip [0 :: Int ..] ls, isResponseMarkerLine l ] of
+              []      -> ""
+              (i : _) ->
+                let block   = takeWhile (not . isIdlePromptLine) (drop i ls)
+                    cleaned = case block of
+                      (h : rest) -> stripResponseMarker h : filter (not . isClaudeChrome) rest
+                      []         -> []
+                in T.strip (T.intercalate "\n" (filter (not . T.null) cleaned))
+
+relevantTailClaude :: Int -> ByteString -> Text
+relevantTailClaude n capture =
+  let ls = filter (not . isClaudeChrome) (T.lines (TE.decodeUtf8Lenient capture))
+  in T.intercalate "\n" (lastN n ls)
+
+claudeObserver :: HarnessObserver
+claudeObserver = HarnessObserver
+  { _ho_classify        = classifyClaude
+  , _ho_extractResponse = extractClaude
+  , _ho_relevantTail    = relevantTailClaude
+  }
+
+-- ── Generic fallback (Codex/OpenCode/Hermes/PureClaw/Custom) ─────────────────
+
+-- | Generic observer for non-Claude harnesses. Classification is always
+-- 'HasIdle' — stability over time (in the reconcile loop) is the only signal.
+genericObserver :: HarnessObserver
+genericObserver = HarnessObserver
+  { _ho_classify        = const HasIdle
+  , _ho_extractResponse = \n cap ->
+      let ls = cleanLines cap
+      in if n <= 0
+           then T.intercalate "\n" ls
+           else T.intercalate "\n" (lastN n ls)
+  , _ho_relevantTail    = \n cap -> T.intercalate "\n" (lastN n (cleanLines cap))
+  }
+  where
+    cleanLines cap = filter (not . T.null . T.strip) (T.lines (TE.decodeUtf8Lenient cap))
+
+-- ── Shared helpers ───────────────────────────────────────────────────────────
+
+dropBaseline :: Int -> ByteString -> ByteString
+dropBaseline n cap
+  | n <= 0    = cap
+  | otherwise = BS.intercalate (BS.singleton 0x0A) (drop n (BS.split 0x0A cap))
+
+lastN :: Int -> [a] -> [a]
+lastN n xs = drop (max 0 (length xs - n)) xs

--- a/src/PureClaw/Harness/Observer.hs
+++ b/src/PureClaw/Harness/Observer.hs
@@ -38,13 +38,41 @@ observerFor _           = genericObserver
 -- ── Claude Code ────────────────────────────────────────────────────────────
 
 -- | Spinner glyphs Claude rotates while working (Dingbats range + a few extras).
+-- NOTE: the response-marker characters ⏺ (U+23FA), ● (U+25CF), and ⬤ (U+2B24)
+-- are intentionally NOT included here — they introduce those glyph characters as
+-- actual content (e.g. "⏺ Let me check the other call sites…") and must NOT be
+-- classified as working-spinner lines.  'isResponseMarkerLine' handles them for
+-- extraction; classification sees them only via the idle-prompt path.
 claudeSpinnerGlyphs :: [Char]
-claudeSpinnerGlyphs = "\x23FA\x25CF\x2B24\x2022\x2726\x2732\x2733\x2734\x2735\x2736\x2737\x2738\x2739\x273A\x273B\x273C\x273D\x273E\x273F\x2605\xB7\x2022\x22C6\x2642\x2666\xB7\x00B7\x2019\x2022\x2605\x2736\x2737\x2738\x2739\x273A\x273B\x273C\x273D\x273E\x273F\xB7\x22C6\x22C7"
+claudeSpinnerGlyphs =
+  "\x2022"   -- •  BULLET
+  <> "\x2019"   -- '  RIGHT SINGLE QUOTATION MARK (used in some spinner patterns)
+  <> "\x2726"   -- ✦  BLACK FOUR POINTED STAR
+  <> "\x2732"   -- ✲  OPEN CENTRE ASTERISK
+  <> "\x2733"   -- ✳  EIGHT SPOKED ASTERISK
+  <> "\x2734"   -- ✴  EIGHT POINTED BLACK STAR
+  <> "\x2735"   -- ✵  EIGHT POINTED PINWHEEL STAR
+  <> "\x2736"   -- ✶  SIX POINTED BLACK STAR
+  <> "\x2737"   -- ✷  EIGHT POINTED RECTILINEAR BLACK STAR
+  <> "\x2738"   -- ✸  HEAVY EIGHT POINTED RECTILINEAR BLACK STAR
+  <> "\x2739"   -- ✹  TWELVE POINTED BLACK STAR
+  <> "\x273A"   -- ✺  SIXTEEN POINTED ASTERISK
+  <> "\x273B"   -- ✻  TEARDROP-SPOKED ASTERISK
+  <> "\x273C"   -- ✼  OPEN CENTRE TEARDROP-SPOKED ASTERISK
+  <> "\x273D"   -- ✽  HEAVY TEARDROP-SPOKED ASTERISK
+  <> "\x273E"   -- ✾  SIX PETALLED BLACK AND WHITE FLORETTE
+  <> "\x273F"   -- ✿  BLACK FLORETTE
+  <> "\x2605"   -- ★  BLACK STAR
+  <> "\x22C6"   -- ⋆  STAR OPERATOR
+  <> "\x22C7"   -- ⋇  DIVISION TIMES
+  <> "\x2642"   -- ♂  MALE SIGN (used in some Hermes spinner patterns)
+  <> "\x2666"   -- ♦  BLACK DIAMOND SUIT
+  <> "\x00B7"   -- ·  MIDDLE DOT
+  <> "\x2026"   -- …  HORIZONTAL ELLIPSIS (shouldn't start a line, belt-and-suspenders)
 
 -- Additional spinner chars observed in the wild (Hermes, faryo patterns).
--- Claude Code uses the ✶ (U+2736) glyph and ⏺ (U+23FA) as status/response markers.
+-- Claude Code uses the ✶ (U+2736) glyph as the primary working-status marker.
 -- The status line for "working" looks like: ✶ Smooshing… (4m 55s · ↓ 16.6k tokens)
--- So we also need to match U+2736 STAR (✶) and U+22C6 STAR OPERATOR (⋆).
 
 -- | A working/status line: starts with a spinner/star glyph followed by
 -- a description containing ellipsis or a token counter in parens, or the
@@ -52,32 +80,13 @@ claudeSpinnerGlyphs = "\x23FA\x25CF\x2B24\x2022\x2726\x2732\x2733\x2734\x2735\x2
 isClaudeWorkingLine :: Text -> Bool
 isClaudeWorkingLine raw =
   let l = T.stripStart raw
-  in (not (T.null l) && (isSpinnerGlyph (T.head l))
+  in (not (T.null l) && isSpinnerGlyph (T.head l)
        && (T.isInfixOf "\x2026" l || T.isInfixOf "..." l))   -- … or ...
      || hasTokenCounter l
      || T.isInfixOf "esc to interrupt" (T.toLower l)
   where
-    -- Spinner glyphs: ✶ ⏺ ● ⬤ • ⋆ ✢ ✱ ✲ ✳ ✴ ✵ ✶ ✷ ✸ ✹ ✺ ✻ ✼ ✽ ✾ ✿ ★ · and more
+    -- A spinner glyph is any character in 'claudeSpinnerGlyphs'.
     isSpinnerGlyph c = c `elem` claudeSpinnerGlyphs
-                    || c == '\x2736'   -- ✶  SIX POINTED BLACK STAR
-                    || c == '\x22C6'   -- ⋆  STAR OPERATOR
-                    || c == '\x2022'   -- •  BULLET
-                    || c == '\x00B7'   -- ·  MIDDLE DOT
-                    || c == '\x2026'   -- … (shouldn't start a line but just in case)
-                    || c == '\x2732'   -- ✲
-                    || c == '\x2733'   -- ✳
-                    || c == '\x2734'   -- ✴
-                    || c == '\x2735'   -- ✵
-                    || c == '\x2737'   -- ✷
-                    || c == '\x2738'   -- ✸
-                    || c == '\x2739'   -- ✹
-                    || c == '\x273A'   -- ✺
-                    || c == '\x273B'   -- ✻
-                    || c == '\x273C'   -- ✼
-                    || c == '\x273D'   -- ✽
-                    || c == '\x273E'   -- ✾
-                    || c == '\x273F'   -- ✿
-                    || c == '\x2605'   -- ★
     hasTokenCounter t =
       T.isInfixOf "tokens" (T.toLower t)
       && T.isInfixOf "(" t && T.isInfixOf ")" t

--- a/src/PureClaw/Harness/Reconcile.hs
+++ b/src/PureClaw/Harness/Reconcile.hs
@@ -229,10 +229,11 @@ classifyLiveness paneDead harnessAlive idle
 -- Both @Exited@ and @Orphaned@ collapse to 'HarnessStopped' (the frontend's
 -- richer state→glyph mapping is Phase 2).
 livenessToActivity :: Reg.Liveness -> HarnessActivity
-livenessToActivity Reg.LivenessIdle     = HarnessIdle
-livenessToActivity Reg.LivenessThinking = HarnessThinking
-livenessToActivity Reg.LivenessExited   = HarnessStopped
-livenessToActivity Reg.LivenessOrphaned = HarnessStopped
+livenessToActivity Reg.LivenessIdle          = HarnessIdle
+livenessToActivity Reg.LivenessThinking      = HarnessThinking
+livenessToActivity Reg.LivenessAwaitingInput = HarnessNeedsInput
+livenessToActivity Reg.LivenessExited        = HarnessStopped
+livenessToActivity Reg.LivenessOrphaned      = HarnessStopped
 
 -- ---------------------------------------------------------------------------
 -- Pure symmetric diff (D5.2)

--- a/src/PureClaw/Harness/Reconcile.hs
+++ b/src/PureClaw/Harness/Reconcile.hs
@@ -83,6 +83,7 @@ import PureClaw.Frontend.StreamBroker
   , SessionActivity (..)
   , StreamBroker (..)
   )
+import PureClaw.Handles.Harness (HarnessHandle (..))
 import PureClaw.Handles.Log (LogHandle (..))
 import PureClaw.Harness.Observer qualified as Obs
 import PureClaw.Harness.Registry qualified as Reg
@@ -134,6 +135,14 @@ data ReconcileDeps = ReconcileDeps
     --   delete is done by the loop itself, in 'reconcileTick'); it must NOT
     --   touch @session.json@ so the session reappears in Recent Sessions.
     --   Tests inject a recorder to assert the @(id, label)@ that was evicted.
+  , _rd_recordResponse :: SessionId -> Text -> IO ()
+    -- ^ Output watcher (Task 7). Records ONE harness @Response@ transcript entry
+    --   for a session on a working→settle transition. The loop reuses the
+    --   entry's '_hh_snapshot' to capture the latest response (per-flavour,
+    --   behind the handle) and dedupes against the last response it recorded for
+    --   that id, so a steady-state idle does not re-record. Production wires this
+    --   to append a @Response@ entry to the session transcript (via a
+    --   broadcasting file transcript handle); tests inject a recorder.
   }
 
 -- | Production dependency set. Sweeps the @\"pureclaw\"@ session plus any other
@@ -172,6 +181,9 @@ defaultReconcileDeps = ReconcileDeps
     -- overrides this seam via 'runReconcileLoopWith'). Crucially this never
     -- deletes @session.json@.
   , _rd_evict = \_hid _label -> pure ()
+    -- Default recorder is a no-op: the production transcript wiring is injected
+    -- in CLI.Commands (which has 'sessionsDir' + the broker in scope).
+  , _rd_recordResponse = \_sid _txt -> pure ()
   }
   where
     dedup = go []
@@ -546,9 +558,11 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
   -- stable (a fresh idle frame reads Thinking until a second identical capture).
   (initial, evicted0) <- reconcileTick deps reg logger Map.empty
   publishEvictions evicted0
-  loop (livenessSnap initial) (capSnap initial)
+  -- The baseline tick has no previous liveness, so it is not a "transition"
+  -- and never records a Response; settle detection begins on the second tick.
+  loop (livenessSnap initial) (capSnap initial) Map.empty
   where
-    loop prev prevCaps = do
+    loop prev prevCaps prevResponses = do
       threadDelay tickMicros
       (obs, evicted) <- reconcileTick deps reg logger prevCaps
       let next = livenessSnap obs
@@ -559,7 +573,45 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
       -- already Orphaned, so the diff above does NOT re-emit it; this guarantees
       -- the frontend sees it leave even though no liveness transition occurred.
       publishEvictions evicted
-      loop next (capSnap obs)
+      -- Output watcher (Task 7): for each id that just transitioned from
+      -- Thinking to a settled state (Idle / AwaitingInput), snapshot the latest
+      -- response and record ONE Response transcript entry (deduped).
+      prevResponses' <- settle prev obs prevResponses
+      loop next (capSnap obs) prevResponses'
+
+    -- Detect working→settle transitions and record one Response per settled id,
+    -- deduped against the last response recorded for that id. Returns the
+    -- updated id-text → last-response map.
+    settle prev obs prevResponses = do
+      newPairs <- forM (settledIds prev obs) $ \idText ->
+        case Reg.parseHarnessId idText of
+          Nothing  -> pure Nothing
+          Just hid -> do
+            mEntry <- Reg.lookupById reg hid
+            case mEntry of
+              Just e
+                | Just realSid <- Reg._he_sessionId e
+                , Just hh      <- Reg._he_handle e -> do
+                    resp <- _hh_snapshot hh 0
+                    let prevResp = Map.lookup idText prevResponses
+                    if not (T.null (T.strip resp)) && prevResp /= Just resp
+                      then do _rd_recordResponse deps (SessionId realSid) resp
+                              pure (Just (idText, resp))
+                      else pure Nothing
+              -- A harness with no real sessionId or no attached handle is
+              -- skipped (Phase-1 limitation): a boot-discovered, handle-less
+              -- entry is not auto-recorded until a handle exists.
+              _ -> pure Nothing
+      pure (foldr (uncurry Map.insert) prevResponses (catMaybes newPairs))
+
+    -- Ids whose PREVIOUS liveness was Thinking and whose NEW liveness (this
+    -- tick) is Idle or AwaitingInput — the working→settle edge.
+    settledIds prev obs =
+      [ idText
+      | (idText, o) <- Map.toList obs
+      , _to_liveness o `elem` [Reg.LivenessIdle, Reg.LivenessAwaitingInput]
+      , Just (_, Reg.LivenessThinking) <- [Map.lookup idText prev]
+      ]
 
     -- Project the observation map into the (sessionId, liveness) snapshot the
     -- 'diffLiveness' publish path consumes, and into the carry-forward captures.

--- a/src/PureClaw/Harness/Reconcile.hs
+++ b/src/PureClaw/Harness/Reconcile.hs
@@ -582,6 +582,12 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
     -- Detect working→settle transitions and record one Response per settled id,
     -- deduped against the last response recorded for that id. Returns the
     -- updated id-text → last-response map.
+    --
+    -- Per-entry snapshot + record IO is wrapped in 'try @SomeException' (D5.3
+    -- resilience, extended to the settle path): a non-async failure (disk full,
+    -- permission error, session dir deleted mid-tick) is logged and skipped so
+    -- that sibling entries still get recorded and the loop never dies.
+    -- 'AsyncCancelled' is always re-raised (project-wide invariant).
     settle prev obs prevResponses = do
       newPairs <- forM (settledIds prev obs) $ \idText ->
         case Reg.parseHarnessId idText of
@@ -592,12 +598,22 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
               Just e
                 | Just realSid <- Reg._he_sessionId e
                 , Just hh      <- Reg._he_handle e -> do
-                    resp <- _hh_snapshot hh 0
-                    let prevResp = Map.lookup idText prevResponses
-                    if not (T.null (T.strip resp)) && prevResp /= Just resp
-                      then do _rd_recordResponse deps (SessionId realSid) resp
-                              pure (Just (idText, resp))
-                      else pure Nothing
+                    r <- try @SomeException $ do
+                      resp <- _hh_snapshot hh 0
+                      let prevResp = Map.lookup idText prevResponses
+                      if not (T.null (T.strip resp)) && prevResp /= Just resp
+                        then do _rd_recordResponse deps (SessionId realSid) resp
+                                pure (Just (idText, resp))
+                        else pure Nothing
+                    case r of
+                      Left err
+                        | Just AsyncCancelled <- fromException err -> throwIO err
+                        | otherwise -> do
+                            _lh_logWarn logger
+                              ("reconcile: settle snapshot/record for " <> idText
+                                 <> " failed: " <> T.pack (show err) <> " — skipping")
+                            pure Nothing
+                      Right res -> pure res
               -- A harness with no real sessionId or no attached handle is
               -- skipped (Phase-1 limitation): a boot-discovered, handle-less
               -- entry is not auto-recorded until a handle exists.

--- a/src/PureClaw/Harness/Reconcile.hs
+++ b/src/PureClaw/Harness/Reconcile.hs
@@ -15,7 +15,8 @@
 --      marked live. A row with no recorded shell PID falls back to a second
 --      signal (the window-name prefix) to defend against PID reuse.
 --   3. Liveness classification (ours only): @Exited@ on @pane_dead@ or a dead
---      harness PID; @Idle@\/@Thinking@ via a screen capture + 'isIdle'; an
+--      harness PID; @Idle@\/@Thinking@\/@AwaitingInput@ via a screen capture
+--      classified by the entry's per-flavour observer (with a stability gate); an
 --      entry whose corroborated window is absent from the sweep → @Orphaned@.
 --   4. 'Reg.mergeReconcile' the observed fields into the registry atomically.
 --   5. /Symmetric diff/ (D5.2): emit one 'ActivityChanged' per entry whose
@@ -47,10 +48,11 @@ module PureClaw.Harness.Reconcile
     -- * Pure classification + corroboration
   , CorroborationResult (..)
   , corroborate
-  , classifyLiveness
+  , classifyFromObserver
   , livenessToActivity
   , diffLiveness
     -- * Reconcile tick + loop
+  , TickObservation (..)
   , reconcileTick
   , runReconcileLoopWith
   , runReconcileLoop
@@ -82,8 +84,9 @@ import PureClaw.Frontend.StreamBroker
   , StreamBroker (..)
   )
 import PureClaw.Handles.Log (LogHandle (..))
-import PureClaw.Harness.ClaudeCode (isIdle)
+import PureClaw.Harness.Observer qualified as Obs
 import PureClaw.Harness.Registry qualified as Reg
+import PureClaw.Session.Kind qualified as Kind
 import PureClaw.Harness.Tmux
   ( TmuxWindowRow (..)
   , captureWindowNamed
@@ -108,10 +111,13 @@ data ReconcileDeps = ReconcileDeps
   , _rd_sweep :: Text -> IO [TmuxWindowRow]
     -- ^ One server sweep of a session (production: 'readMarkers'). May throw on
     --   a transient tmux failure; the loop catches it and marks entries stale.
-  , _rd_capture :: Text -> Text -> IO Bool
-    -- ^ Capture @session windowName@ and report whether the screen reads idle
-    --   (production: 'captureWindowNamed' + 'isIdle'). Only called for
-    --   corroborated, live (not pane_dead) windows.
+  , _rd_capture :: Text -> Text -> IO (Maybe Text)
+    -- ^ Capture @session windowName@ and return the raw screen text, or
+    --   'Nothing' if the capture failed (production: 'captureWindowNamed'
+    --   decoded leniently, wrapped in 'try'). The classifier (per-flavour
+    --   observer) decides liveness from the raw text; @Nothing@ disables the
+    --   stability gate for the tick. Only called for corroborated, live (not
+    --   pane_dead) windows.
   , _rd_harnessAlive :: Int -> IO Bool
     -- ^ Whether a recorded harness PID is still alive (production: a
     --   'harnessPidOf'-style liveness probe). Distinguishes @Exited@
@@ -131,7 +137,8 @@ data ReconcileDeps = ReconcileDeps
   }
 
 -- | Production dependency set. Sweeps the @\"pureclaw\"@ session plus any other
--- session on the server; capture\/idle via 'captureWindowNamed' + 'isIdle';
+-- session on the server; capture via 'captureWindowNamed' (classified by the
+-- per-flavour observer in 'classifyFromObserver');
 -- harness liveness via 'harnessPidOf'; legacy stamping via 'setWindowMarker'.
 defaultReconcileDeps :: ReconcileDeps
 defaultReconcileDeps = ReconcileDeps
@@ -141,8 +148,10 @@ defaultReconcileDeps = ReconcileDeps
       pure (dedup ("pureclaw" : others))
   , _rd_sweep = readMarkers
   , _rd_capture = \session windowName -> do
-      bytes <- captureWindowNamed session windowName 50
-      pure (isIdle (TE.decodeUtf8Lenient bytes))
+      r <- try @SomeException (captureWindowNamed session windowName 50)
+      pure $ case r of
+        Left _      -> Nothing
+        Right bytes -> Just (TE.decodeUtf8Lenient bytes)
   , _rd_harnessAlive = \shellPid -> do
       -- Re-derive the harness PID by descending from the recorded shell PID and
       -- matching the flavour comm. If the descent still finds the agent binary
@@ -210,20 +219,34 @@ corroborate e row =
 -- ---------------------------------------------------------------------------
 
 -- | Classify a corroborated window's liveness from @(paneDead, harnessAlive,
--- isIdle)@:
+-- stable, screen)@ via the entry's per-flavour 'Obs.HarnessObserver':
 --
 --   * @pane_dead@ OR a dead harness PID ⇒ 'Reg.LivenessExited' (the window is
 --     present but the agent is gone).
---   * otherwise the screen capture decides: idle ⇒ 'Reg.LivenessIdle',
---     busy ⇒ 'Reg.LivenessThinking'.
+--   * otherwise the observer's 3-state screen classifier decides:
+--     working ⇒ 'Reg.LivenessThinking', awaiting-input ⇒
+--     'Reg.LivenessAwaitingInput', idle ⇒ 'Reg.LivenessIdle' only once the
+--     capture is /stable/ across ticks (an unstable idle frame stays
+--     'Reg.LivenessThinking', defending against mid-spinner frames).
 --
 -- 'Reg.LivenessOrphaned' is NOT produced here — it is assigned to entries whose
 -- corroborated window is /absent/ from the sweep (see 'reconcileTick').
-classifyLiveness :: Bool -> Bool -> Bool -> Reg.Liveness
-classifyLiveness paneDead harnessAlive idle
+classifyFromObserver
+  :: Obs.HarnessObserver
+  -> Bool  -- ^ pane_dead
+  -> Bool  -- ^ harness PID alive
+  -> Bool  -- ^ the capture is stable (unchanged since the previous tick)
+  -> Text  -- ^ raw screen capture
+  -> Reg.Liveness
+classifyFromObserver obs paneDead harnessAlive stable screen
   | paneDead || not harnessAlive = Reg.LivenessExited
-  | idle                         = Reg.LivenessIdle
-  | otherwise                    = Reg.LivenessThinking
+  | otherwise = case Obs._ho_classify obs screen of
+      Obs.HasWorking       -> Reg.LivenessThinking
+      Obs.HasAwaitingInput -> Reg.LivenessAwaitingInput
+      -- An idle-looking screen is only trusted once it is STABLE across ticks:
+      -- a single idle-marker frame mid-stream is treated as still Thinking
+      -- (the spinner may simply be between frames).
+      Obs.HasIdle          -> if stable then Reg.LivenessIdle else Reg.LivenessThinking
 
 -- | Map a registry 'Reg.Liveness' to the broker's 'HarnessActivity' vocabulary.
 -- Both @Exited@ and @Orphaned@ collapse to 'HarnessStopped' (the frontend's
@@ -266,21 +289,36 @@ diffLiveness prev next =
 -- Reconcile tick (IO)
 -- ---------------------------------------------------------------------------
 
--- | A single reconcile pass: sweep, corroborate, classify, merge, and return
--- the per-entry liveness snapshot keyed by 'Reg.HarnessId' text (for the loop's
--- diff). On a transient sweep failure the registry's entries are marked
--- '_he_stale' (holding last-known liveness) and the snapshot reflects the held
--- state; the tick never throws on a sweep failure.
+-- | The per-entry observation a single 'reconcileTick' produces, keyed by the
+-- entry's 'Reg.HarnessId' text in the returned map. It carries the SessionId the
+-- loop publishes under, the classified liveness for the diff, and the raw screen
+-- capture taken this tick (so the loop can feed it back as next tick's @prevCap@
+-- for the stability gate). The held\/orphaned paths set '_to_capture' to
+-- 'Nothing' (no fresh capture was taken).
+data TickObservation = TickObservation
+  { _to_sessionId :: !Text            -- ^ @sidOf e@ (the recorded sessionId, or the label fallback).
+  , _to_liveness  :: !Reg.Liveness    -- ^ classified liveness this tick.
+  , _to_capture   :: !(Maybe Text)    -- ^ raw capture taken this tick, if any.
+  }
+
+-- | A single reconcile pass: sweep, corroborate, classify, merge, and return the
+-- per-entry observation map keyed by 'Reg.HarnessId' text (for the loop's diff
+-- + stability gate). Takes the previous tick's raw captures (id-text → last raw)
+-- so the per-flavour observer can apply its stability gate. On a transient sweep
+-- failure the registry's entries are marked '_he_stale' (holding last-known
+-- liveness) and the observation reflects the held state; the tick never throws
+-- on a sweep failure.
 reconcileTick
   :: ReconcileDeps
   -> Reg.HarnessRegistry
   -> LogHandle
-  -> IO (Map Text (Text, Reg.Liveness), [Text])
-  -- ^ @(liveness snapshot keyed by id-text, sessionIds of entries auto-evicted
-  --   this tick)@. Evicted entries are removed from the snapshot map (so the
-  --   next diff does not re-report them) and the loop emits one final
-  --   disappearance event per returned sessionId.
-reconcileTick deps reg logger = do
+  -> Map Text Text                          -- ^ previous captures (id-text → last raw)
+  -> IO (Map Text TickObservation, [Text])
+  -- ^ @(per-id observation, sessionIds of entries auto-evicted this tick)@.
+  --   Evicted entries are removed from the observation map (so the next diff
+  --   does not re-report them) and the loop emits one final disappearance event
+  --   per returned sessionId.
+reconcileTick deps reg logger prevCaps = do
   sessions <- _rd_sessions deps
   -- Sweep every session; a failed sweep yields Nothing (we then hold stale).
   sweepResults <- forM sessions $ \session -> do
@@ -325,15 +363,15 @@ reconcileTick deps reg logger = do
             -- entry's last-known liveness and mark it stale, exactly as a sweep
             -- failure does — never repaint it from a capture error, never let
             -- the exception propagate to the loop's crash handler.
-            r <- try @SomeException (classifyRow deps e row)
+            r <- try @SomeException (classifyRow deps e row (Map.lookup idText prevCaps))
             case r of
               Left err -> do
                 _lh_logWarn logger
                   ("reconcile: capture/liveness probe for @pcl_id " <> idText
                      <> " failed: " <> T.pack (show err) <> " — holding last-known liveness")
                 pure (mkObservedHeld e)
-              Right liveness ->
-                pure (mkObservedLive e row liveness)
+              Right (liveness, mCap) ->
+                pure (mkObservedLive e row liveness mCap)
   let observed = map snd observedPairs
   Reg.mergeReconcile reg observed
   let snapMap = Map.fromList [ (k, v) | (k, v) <- map fst observedPairs ]
@@ -360,16 +398,17 @@ reconcileTick deps reg logger = do
       snapMap'    = foldr Map.delete snapMap evictedKeys
   pure (snapMap', map snd evictedSids)
   where
-    -- Each result is ((keyText, (sessionId, liveness)), ObservedHarness).
-    mkObservedHeld :: Reg.HarnessEntry -> ((Text, (Text, Reg.Liveness)), Reg.ObservedHarness)
+    -- Each result is ((keyText, TickObservation), ObservedHarness). The held and
+    -- orphaned paths take no fresh capture, so '_to_capture' is 'Nothing'.
+    mkObservedHeld :: Reg.HarnessEntry -> ((Text, TickObservation), Reg.ObservedHarness)
     mkObservedHeld e =
       let live = Reg._he_liveness e
-      in ( (Reg.harnessIdToText (Reg._he_id e), (sidOf e, live))
+      in ( (Reg.harnessIdToText (Reg._he_id e), tickObs e live Nothing)
          , (baseObserved e live) { Reg._oh_stale = True } )
 
-    mkObservedOrphaned :: Reg.HarnessEntry -> ((Text, (Text, Reg.Liveness)), Reg.ObservedHarness)
+    mkObservedOrphaned :: Reg.HarnessEntry -> ((Text, TickObservation), Reg.ObservedHarness)
     mkObservedOrphaned e =
-      ( (Reg.harnessIdToText (Reg._he_id e), (sidOf e, Reg.LivenessOrphaned))
+      ( (Reg.harnessIdToText (Reg._he_id e), tickObs e Reg.LivenessOrphaned Nothing)
       , (baseObserved e Reg.LivenessOrphaned)
           { Reg._oh_liveness = Reg.LivenessOrphaned
             -- The corroborated window is absent this tick: advance the
@@ -378,11 +417,11 @@ reconcileTick deps reg logger = do
           } )
 
     mkObservedLive
-      :: Reg.HarnessEntry -> TmuxWindowRow -> Reg.Liveness
-      -> ((Text, (Text, Reg.Liveness)), Reg.ObservedHarness)
-    mkObservedLive e row liveness =
+      :: Reg.HarnessEntry -> TmuxWindowRow -> Reg.Liveness -> Maybe Text
+      -> ((Text, TickObservation), Reg.ObservedHarness)
+    mkObservedLive e row liveness mCap =
       let extMod = _twr_windowName row /= Reg._he_windowName e
-      in ( (Reg.harnessIdToText (Reg._he_id e), (sidOf e, liveness))
+      in ( (Reg.harnessIdToText (Reg._he_id e), tickObs e liveness mCap)
          , Reg.ObservedHarness
              { Reg._oh_id          = Reg._he_id e
              , Reg._oh_session     = Reg._he_session e
@@ -413,15 +452,32 @@ reconcileTick deps reg logger = do
       , Reg._oh_orphanedTicks = Reg._he_orphanedTicks e
       }
 
+    tickObs :: Reg.HarnessEntry -> Reg.Liveness -> Maybe Text -> TickObservation
+    tickObs e live mCap = TickObservation
+      { _to_sessionId = sidOf e
+      , _to_liveness  = live
+      , _to_capture   = mCap
+      }
+
     sidOf :: Reg.HarnessEntry -> Text
     sidOf e = fromMaybe (Reg._he_label e) (Reg._he_sessionId e)
 
 -- | Classify a corroborated window's liveness, capturing the screen only when
 -- the window is alive (not pane_dead and the harness PID is present). A
 -- @pane_dead@ window is NEVER captured (D5.4\/D5.5).
-classifyRow :: ReconcileDeps -> Reg.HarnessEntry -> TmuxWindowRow -> IO Reg.Liveness
-classifyRow deps e row
-  | _twr_paneDead row = pure Reg.LivenessExited
+--
+-- Takes the entry's PREVIOUS raw capture (the stability gate input) and returns
+-- @(liveness, capture-taken-this-tick)@ so the loop can carry the capture
+-- forward as the next tick's @prevCap@. A failed/skipped capture returns
+-- 'Nothing', which disables the stability gate for that tick.
+classifyRow
+  :: ReconcileDeps
+  -> Reg.HarnessEntry
+  -> TmuxWindowRow
+  -> Maybe Text                    -- ^ previous capture for this entry
+  -> IO (Reg.Liveness, Maybe Text)
+classifyRow deps e row prevCap
+  | _twr_paneDead row = pure (Reg.LivenessExited, Nothing)
   | otherwise = do
       -- Liveness of the agent process: re-derive it by descending from the live
       -- shell PID (the row's @#{pane_pid}@). We only bother when we recorded a
@@ -431,10 +487,15 @@ classifyRow deps e row
         (Just _, Just shellPid) -> _rd_harnessAlive deps shellPid
         _                       -> pure True
       if not alive
-        then pure Reg.LivenessExited
+        then pure (Reg.LivenessExited, Nothing)
         else do
-          idle <- _rd_capture deps (Reg._he_session e) (_twr_windowName row)
-          pure (classifyLiveness False True idle)
+          mCap <- _rd_capture deps (Reg._he_session e) (_twr_windowName row)
+          let cap    = fromMaybe "" mCap
+              -- The screen is "stable" only when we got a capture this tick AND
+              -- it is byte-identical to the previous tick's capture.
+              stable = isJust mCap && mCap == prevCap
+              obs    = Obs.observerFor (Reg._he_flavour e)
+          pure (classifyFromObserver obs False True stable cap, mCap)
 
 -- ---------------------------------------------------------------------------
 -- The loop
@@ -481,13 +542,16 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
   threadDelay tickMicros
   -- Baseline tick: emits no transitions. Any eviction on this first tick still
   -- emits its final disappearance event (an eviction is not a diff transition).
-  (initial, evicted0) <- reconcileTick deps reg logger
+  -- The first tick has no previous captures, so the stability gate sees nothing
+  -- stable (a fresh idle frame reads Thinking until a second identical capture).
+  (initial, evicted0) <- reconcileTick deps reg logger Map.empty
   publishEvictions evicted0
-  loop initial
+  loop (livenessSnap initial) (capSnap initial)
   where
-    loop prev = do
+    loop prev prevCaps = do
       threadDelay tickMicros
-      (next, evicted) <- reconcileTick deps reg logger
+      (obs, evicted) <- reconcileTick deps reg logger prevCaps
+      let next = livenessSnap obs
       forM_ (diffLiveness prev next) $ \(sid, liveness) ->
         _streamBroker_publish broker
           (ActivityChanged (SessionId sid) (SaHarnessStatus (livenessToActivity liveness)))
@@ -495,7 +559,15 @@ runReconcileLoopWith tickMicros deps reg broker logger = handle outer $ do
       -- already Orphaned, so the diff above does NOT re-emit it; this guarantees
       -- the frontend sees it leave even though no liveness transition occurred.
       publishEvictions evicted
-      loop next
+      loop next (capSnap obs)
+
+    -- Project the observation map into the (sessionId, liveness) snapshot the
+    -- 'diffLiveness' publish path consumes, and into the carry-forward captures.
+    livenessSnap :: Map Text TickObservation -> Map Text (Text, Reg.Liveness)
+    livenessSnap = Map.map (\o -> (_to_sessionId o, _to_liveness o))
+
+    capSnap :: Map Text TickObservation -> Map Text Text
+    capSnap = Map.mapMaybe _to_capture
 
     publishEvictions = mapM_ $ \sid ->
       _streamBroker_publish broker
@@ -550,6 +622,7 @@ bootReconstruct deps reg logger = do
         , Reg._he_shellPid    = _twr_panePid row
         , Reg._he_harnessPid  = Nothing
         , Reg._he_origin      = Reg.OriginDiscovered
+        , Reg._he_flavour     = Kind.HClaudeCode
         , Reg._he_liveness    = live
         , Reg._he_extModified = False
         , Reg._he_stale       = False

--- a/src/PureClaw/Harness/Registry.hs
+++ b/src/PureClaw/Harness/Registry.hs
@@ -15,8 +15,8 @@
 -- Leaf module: it may import 'PureClaw.Handles.Harness' (for 'HarnessHandle')
 -- and standard libraries only — never @Agent@\/@Frontend@\/@CLI@.
 module PureClaw.Harness.Registry
-  ( -- * Identity
-    HarnessId
+  ( -- * Identity (re-exported from PureClaw.Harness.Id)
+    HarnessId (..)
   , newHarnessId
   , parseHarnessId
   , harnessIdToText
@@ -40,52 +40,21 @@ module PureClaw.Harness.Registry
   ) where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar', newTVarIO, readTVar, readTVarIO)
-import Data.Aeson (FromJSON (..), ToJSON (..))
-import Data.Aeson qualified as Aeson
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import Data.UUID (UUID)
-import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUIDv4
 
 import PureClaw.Handles.Harness (HarnessHandle)
+import PureClaw.Harness.Id (HarnessId (..), harnessIdToText, parseHarnessId)
 
 -- ---------------------------------------------------------------------------
 -- Identity
 -- ---------------------------------------------------------------------------
 
--- | A PureClaw-assigned, UUID-backed harness identity. This is the canonical
--- key for the registry and the durable anchor that survives tmux window
--- rename\/move and PureClaw restart (persisted in @session.json@).
-newtype HarnessId = HarnessId { unHarnessId :: UUID }
-  deriving stock (Eq, Ord, Show)
-
 -- | Generate a fresh random 'HarnessId' (UUID v4).
 newHarnessId :: IO HarnessId
 newHarnessId = HarnessId <$> UUIDv4.nextRandom
-
--- | Parse a 'HarnessId' from its canonical UUID text representation.
--- Returns 'Nothing' for any non-UUID input.
-parseHarnessId :: Text -> Maybe HarnessId
-parseHarnessId = fmap HarnessId . UUID.fromText
-
--- | Render a 'HarnessId' as its canonical UUID text representation.
-harnessIdToText :: HarnessId -> Text
-harnessIdToText = UUID.toText . unHarnessId
-
--- | Round-trippable JSON: a 'HarnessId' is encoded as the canonical UUID
--- string (D2.4). We hand-write the codec rather than @deriving newtype@ so the
--- on-the-wire shape (a plain string) is explicit and decode rejects malformed
--- UUIDs with a clear error.
-instance ToJSON HarnessId where
-  toJSON = Aeson.String . harnessIdToText
-
-instance FromJSON HarnessId where
-  parseJSON = Aeson.withText "HarnessId" $ \t ->
-    case parseHarnessId t of
-      Just hid -> pure hid
-      Nothing  -> fail ("invalid HarnessId (not a UUID): " <> show t)
 
 -- ---------------------------------------------------------------------------
 -- Entry types

--- a/src/PureClaw/Harness/Registry.hs
+++ b/src/PureClaw/Harness/Registry.hs
@@ -108,10 +108,11 @@ data HarnessOrigin
 -- states: the former is the orthogonal '_he_extModified' flag, and the latter
 -- maps to the '_he_stale' flag (hold last-known liveness).
 data Liveness
-  = LivenessIdle      -- ^ Window present, harness running, not actively working.
-  | LivenessThinking  -- ^ Harness actively working (screen-capture heuristic).
-  | LivenessExited    -- ^ Harness PID gone or @pane_dead@, window still present.
-  | LivenessOrphaned  -- ^ No live window+PID for this id.
+  = LivenessIdle           -- ^ Window present, harness running, not actively working.
+  | LivenessThinking       -- ^ Harness actively working (screen-capture heuristic).
+  | LivenessAwaitingInput  -- ^ Window present, harness blocked on an approval/menu prompt.
+  | LivenessExited         -- ^ Harness PID gone or @pane_dead@, window still present.
+  | LivenessOrphaned       -- ^ No live window+PID for this id.
   deriving stock (Eq, Show)
 
 -- | A registry entry: the durable identity plus the reconciled health\/coordinate

--- a/src/PureClaw/Harness/Registry.hs
+++ b/src/PureClaw/Harness/Registry.hs
@@ -47,6 +47,7 @@ import Data.UUID.V4 qualified as UUIDv4
 
 import PureClaw.Handles.Harness (HarnessHandle)
 import PureClaw.Harness.Id (HarnessId (..), harnessIdToText, parseHarnessId)
+import PureClaw.Session.Kind qualified as Kind
 
 -- ---------------------------------------------------------------------------
 -- Identity
@@ -105,6 +106,10 @@ data HarnessEntry = HarnessEntry
     -- ^ Recorded harness-process PID (the agent binary) — trust anchor.
   , _he_origin      :: !HarnessOrigin
     -- ^ How PureClaw came to manage this harness.
+  , _he_flavour     :: !Kind.HarnessFlavour
+    -- ^ The harness tool flavour (Claude Code, Codex, …). Selects the
+    --   per-flavour 'PureClaw.Harness.Observer.HarnessObserver' the reconcile
+    --   loop uses to classify the screen capture.
   , _he_liveness    :: !Liveness
     -- ^ Current reconciled liveness.
   , _he_extModified :: !Bool

--- a/src/PureClaw/Harness/Tmux.hs
+++ b/src/PureClaw/Harness/Tmux.hs
@@ -387,7 +387,7 @@ pasteBufferNamedArgs sessionName windowName =
 captureNamedArgs :: Text -> Text -> Int -> [String]
 captureNamedArgs sessionName windowName lineCount =
   [ "capture-pane", "-t", windowTarget sessionName windowName
-  , "-p", "-S", "-" <> show lineCount
+  , "-p", "-J", "-S", "-" <> show lineCount
   ]
 
 -- | @kill-window@ argv targeting a window by name.

--- a/src/PureClaw/Session/Kind.hs
+++ b/src/PureClaw/Session/Kind.hs
@@ -41,7 +41,7 @@ import Data.Text qualified as T
 
 import PureClaw.Agent.AgentDef (AgentName, unAgentName)
 import PureClaw.Core.Types (ModelId (..), ProviderId (..))
-import PureClaw.Harness.Registry (HarnessId)
+import PureClaw.Harness.Id (HarnessId)
 
 -- ---------------------------------------------------------------------------
 -- Session kind

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -324,6 +324,11 @@ spec = do
     it "strips surrounding whitespace from the /bg prompt" $ do
       parseSlashCommand "/bg   do thing  " `shouldBe` Just (CmdBg "do thing")
 
+    it "parses /harness output with optional name and N" $ do
+      parseSlashCommand "/harness output"          `shouldBe` Just (CmdHarness (HarnessOutput Nothing 0))
+      parseSlashCommand "/harness output coder"    `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 0))
+      parseSlashCommand "/harness output coder 40" `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 40))
+
   describe "executeSlashCommand" $ do
     let mkEnv sentRef = do
           vaultRef    <- newIORef Nothing
@@ -432,6 +437,59 @@ spec = do
       Map.null harnesses `shouldBe` True
       entries <- Reg.snapshot reg
       length entries `shouldBe` 0
+
+    it "HarnessOutput sends the snapshot text for the named harness" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      env0 <- mkEnv sentRef
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "latest harness reply" }
+      writeIORef (_env_harnesses env0) (Map.fromList [("coder", hh)])
+      _ <- executeSlashCommand env0 (CmdHarness (HarnessOutput (Just "coder") 0)) (emptyContext Nothing)
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> t `shouldSatisfy` T.isInfixOf "latest harness reply"
+        Nothing -> expectationFailure "Expected snapshot output"
+
+    it "HarnessOutput reports error for unknown harness name" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      env0 <- mkEnv sentRef
+      _ <- executeSlashCommand env0 (CmdHarness (HarnessOutput (Just "ghost") 0)) (emptyContext Nothing)
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "No running harness named 'ghost'"
+        Nothing -> expectationFailure "Expected error message"
+
+    it "HarnessOutput with no name uses sole running harness" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      env0 <- mkEnv sentRef
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "sole harness output" }
+      writeIORef (_env_harnesses env0) (Map.fromList [("only-one", hh)])
+      _ <- executeSlashCommand env0 (CmdHarness (HarnessOutput Nothing 0)) (emptyContext Nothing)
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> t `shouldSatisfy` T.isInfixOf "sole harness output"
+        Nothing -> expectationFailure "Expected snapshot output"
+
+    it "HarnessOutput with no name and multiple harnesses asks for explicit name" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      env0 <- mkEnv sentRef
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "output" }
+      writeIORef (_env_harnesses env0) (Map.fromList [("a", hh), ("b", hh)])
+      _ <- executeSlashCommand env0 (CmdHarness (HarnessOutput Nothing 0)) (emptyContext Nothing)
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "Specify a harness name"
+        Nothing -> expectationFailure "Expected error message"
+
+    it "HarnessOutput sends '(no recent output)' when snapshot is blank" $ do
+      sentRef <- newIORef (Nothing :: Maybe Text)
+      env0 <- mkEnv sentRef
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "   " }
+      writeIORef (_env_harnesses env0) (Map.fromList [("coder", hh)])
+      _ <- executeSlashCommand env0 (CmdHarness (HarnessOutput (Just "coder") 0)) (emptyContext Nothing)
+      sent <- readIORef sentRef
+      case sent of
+        Just t  -> T.unpack t `shouldContain` "(no recent output)"
+        Nothing -> expectationFailure "Expected fallback message"
 
     it "/status shows session info" $ do
       sentRef <- newIORef (Nothing :: Maybe Text)

--- a/test/Agent/SlashCommandsSpec.hs
+++ b/test/Agent/SlashCommandsSpec.hs
@@ -328,6 +328,8 @@ spec = do
       parseSlashCommand "/harness output"          `shouldBe` Just (CmdHarness (HarnessOutput Nothing 0))
       parseSlashCommand "/harness output coder"    `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 0))
       parseSlashCommand "/harness output coder 40" `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 40))
+      parseSlashCommand "/harness output 40"       `shouldBe` Just (CmdHarness (HarnessOutput Nothing 40))
+      parseSlashCommand "/harness output coder 40abc" `shouldBe` Just (CmdHarness (HarnessOutput (Just "coder") 40))
 
   describe "executeSlashCommand" $ do
     let mkEnv sentRef = do

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -4192,6 +4192,7 @@ baseEntry hid window mHandle = Registry.HarnessEntry
   , Registry._he_shellPid    = Nothing
   , Registry._he_harnessPid  = Nothing
   , Registry._he_origin      = Registry.OriginSpawned
+  , Registry._he_flavour     = HClaudeCode
   , Registry._he_liveness    = Registry.LivenessIdle
   , Registry._he_extModified = False
   , Registry._he_stale       = False

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -1041,6 +1041,9 @@ spec = do
     it "gives Exited and Orphaned distinct status strings (no longer collapsed)" $
       livenessToTabStatus Registry.LivenessExited
         `shouldNotBe` livenessToTabStatus Registry.LivenessOrphaned
+    -- Task 3: LivenessAwaitingInput → "running" (distinct state shown via activity dot)
+    it "maps LivenessAwaitingInput to \"running\"" $
+      livenessToTabStatus Registry.LivenessAwaitingInput `shouldBe` "running"
 
   describe "harnessOriginToText (P2-WU1 — origin pill mapping)" $ do
     it "maps OriginSpawned to \"spawned\"" $

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -4018,12 +4018,13 @@ fakeStartHarnessWith harnessRef key hid mReg reqSpec _ = do
 -- surfaced — without spawning a real tmux process.
 mkFakeHarnessHandle :: IORef [ByteString] -> ByteString -> HarnessHandle
 mkFakeHarnessHandle sentRef canned = HarnessHandle
-  { _hh_send    = \bs -> modifyIORef' sentRef (++ [bs])
-  , _hh_receive = pure canned
-  , _hh_name    = "fake-harness"
-  , _hh_session = "pureclaw"
-  , _hh_status  = pure HarnessRunning
-  , _hh_stop    = pure ()
+  { _hh_send     = \bs -> modifyIORef' sentRef (++ [bs])
+  , _hh_receive  = pure canned
+  , _hh_snapshot = \_ -> pure ""
+  , _hh_name     = "fake-harness"
+  , _hh_session  = "pureclaw"
+  , _hh_status   = pure HarnessRunning
+  , _hh_stop     = pure ()
   }
 
 -- | Read every event currently in a broker 'Subscription' queue, waiting up
@@ -4050,12 +4051,13 @@ drainBrokerQueue budgetMicros sub = do
 -- the throw, then surfaces a 500.
 mkThrowingHarnessHandle :: IORef [ByteString] -> HarnessHandle
 mkThrowingHarnessHandle sentRef = HarnessHandle
-  { _hh_send    = \bs -> modifyIORef' sentRef (++ [bs])
-  , _hh_receive = throwIO (userError "boom")
-  , _hh_name    = "fake-throwing-harness"
-  , _hh_session = "pureclaw"
-  , _hh_status  = pure HarnessRunning
-  , _hh_stop    = pure ()
+  { _hh_send     = \bs -> modifyIORef' sentRef (++ [bs])
+  , _hh_receive  = throwIO (userError "boom")
+  , _hh_snapshot = \_ -> pure ""
+  , _hh_name     = "fake-throwing-harness"
+  , _hh_session  = "pureclaw"
+  , _hh_status   = pure HarnessRunning
+  , _hh_stop     = pure ()
   }
 
 -- | A fake handle that, like a restart-discovered REAL handle, ALSO records
@@ -4065,16 +4067,17 @@ mkThrowingHarnessHandle sentRef = HarnessHandle
 -- entries in the *session* transcript when the handle records elsewhere.
 mkRecordingFakeHarnessHandle :: FilePath -> IORef [ByteString] -> ByteString -> HarnessHandle
 mkRecordingFakeHarnessHandle ownTranscript sentRef canned = HarnessHandle
-  { _hh_send    = \bs -> do
+  { _hh_send     = \bs -> do
       modifyIORef' sentRef (++ [bs])
       LBS.appendFile ownTranscript (LBS.fromStrict bs <> "\n")
-  , _hh_receive = do
+  , _hh_receive  = do
       LBS.appendFile ownTranscript (LBS.fromStrict canned <> "\n")
       pure canned
-  , _hh_name    = "fake-recording-harness"
-  , _hh_session = "pureclaw"
-  , _hh_status  = pure HarnessRunning
-  , _hh_stop    = pure ()
+  , _hh_snapshot = \_ -> pure ""
+  , _hh_name     = "fake-recording-harness"
+  , _hh_session  = "pureclaw"
+  , _hh_status   = pure HarnessRunning
+  , _hh_stop     = pure ()
   }
 
 -- | Write a harness-backed session to disk: @session.json@ whose

--- a/test/Frontend/APISpec.hs
+++ b/test/Frontend/APISpec.hs
@@ -2359,8 +2359,9 @@ spec = do
 
   describe "POST /api/sessions/{sid}/send (harness routing — WU3)" $ do
     -- D3.1: an SkHarness session with a live handle registered under its
-    -- key routes the message to the handle (not the provider) and returns
-    -- the handle's sanitized output as the response.
+    -- key routes the message to the handle (not the provider). The send
+    -- path returns promptly with response="" (the real reply arrives via WS
+    -- from the reconcile watcher — Task 8 decoupling).
     it "routes a harness session to its live tmux handle, not the provider" $ do
       withSystemTempDirectory "pureclaw-hsend-d31" $ \tmpDir -> do
         let sid = "sess-harness-1"
@@ -2377,8 +2378,9 @@ spec = do
         (st, respBody) <- postJSON env ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("ping" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "harness says hi")
+          `shouldBe` Just (Aeson.String "")
         -- The harness handle received the bytes …
         sent <- readIORef sentRef
         sent `shouldBe` ["ping"]
@@ -2433,14 +2435,16 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("after restart" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "reconnected")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["after restart"]
 
-    -- D3.5: a successful harness send records exactly one Request and one
-    -- Response entry to the SESSION transcript (no duplicates).
-    it "records exactly one Request and one Response entry per send" $ do
+    -- D3.5: a successful harness send records exactly one Request entry to the
+    -- SESSION transcript. The Response is recorded by the reconcile watcher
+    -- (Task 8: send path no longer calls _hh_receive / records a Response).
+    it "records exactly one Request entry (no inline Response) per send" $ do
       withSystemTempDirectory "pureclaw-hsend-d35" $ \tmpDir -> do
         let sid = "sess-harness-tx"
             key = "claude-code-1"
@@ -2456,15 +2460,16 @@ spec = do
         let reqs  = [ e | e <- entries, _te_direction e == Request ]
             resps = [ e | e <- entries, _te_direction e == Response ]
         length reqs  `shouldBe` 1
-        length resps `shouldBe` 1
+        resps `shouldBe` []
         _te_payload (head reqs)  `shouldBe` "hi there"
-        _te_payload (head resps) `shouldBe` "the reply"
 
-    -- D3.5b (restart hardening): a restart-discovered handle records to its
-    -- OWN (CLI) transcript — a different file. Prove the SESSION transcript
-    -- still gets exactly one Request + one Response (handleSend is the sole
-    -- writer of the session transcript; no cross-file duplication).
-    it "keeps the session transcript at 1+1 when the handle records elsewhere" $ do
+    -- D3.5b (restart hardening): the send path records exactly one Request
+    -- to the SESSION transcript — no Response (the watcher owns that). The
+    -- mkRecordingFakeHarnessHandle simulates a restart-discovered handle
+    -- whose _hh_send writes to a separate CLI transcript file; since
+    -- _hh_receive is no longer called on the send path, the CLI file receives
+    -- only the send line (1 entry), not 2.
+    it "keeps the session transcript at 1+0 when the handle records elsewhere" $ do
       withSystemTempDirectory "pureclaw-hsend-d35b" $ \tmpDir -> do
         let sid = "sess-harness-restart"
             key = "claude-code-7"
@@ -2477,15 +2482,15 @@ spec = do
         (st, _) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("after restart" :: Text)]))
         st `shouldBe` HTTP.status200
-        -- Session transcript: exactly one Request + one Response.
+        -- Session transcript: exactly one Request, no inline Response.
         entries <- readSessionTranscript tmpDir sid
         length [ e | e <- entries, _te_direction e == Request ]  `shouldBe` 1
-        length [ e | e <- entries, _te_direction e == Response ] `shouldBe` 1
-        -- The handle's own (separate) transcript received its 2 lines —
-        -- proving the second recorder writes to a DIFFERENT file, not the
-        -- session transcript.
+        length [ e | e <- entries, _te_direction e == Response ] `shouldBe` 0
+        -- The handle's own (separate) transcript received its 1 send line;
+        -- _hh_receive is NOT called on the send path (Task 8), so only the
+        -- _hh_send line was appended — the CLI file has exactly 1 entry.
         cliRaw <- LBS.readFile cliTranscript
-        length (filter (not . LBS.null) (LBS.split 0x0a cliRaw)) `shouldBe` 2
+        length (filter (not . LBS.null) (LBS.split 0x0a cliRaw)) `shouldBe` 1
 
     -- D3.6: harness routing must work even when no provider/model are
     -- configured (the provider guard must not pre-empt the kind branch).
@@ -2502,14 +2507,16 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("hello" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "no-provider reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["hello"]
 
-    -- D3.7: a blank/whitespace harness reply yields 200 {"response":""}
-    -- with NO Response entry written (only the Request entry).
-    it "writes no Response entry when the harness reply is blank" $ do
+    -- D3.7: the send path never calls _hh_receive (Task 8 decoupling), so
+    -- the HTTP body is always {"response":""} — only a Request entry is
+    -- recorded inline; the Response is owned by the reconcile watcher.
+    it "responds 200 with empty response and records only a Request entry" $ do
       withSystemTempDirectory "pureclaw-hsend-d37" $ \tmpDir -> do
         let sid = "sess-harness-blank"
             key = "claude-code-4"
@@ -2530,26 +2537,60 @@ spec = do
         resps `shouldBe` []
 
     -- D3.8 (WU4 coverage): when the harness handle throws during
-    -- send/receive (e.g. tmux IO failure), 'sendToHarness' catches it,
+    -- _hh_send (e.g. tmux IO failure), 'routeViaHandle' catches it,
     -- logs, and responds 500 {"error":"Harness send failed"} — never a
     -- crash, never a silent provider fallback.
-    it "responds 500 when the harness handle throws during send/receive" $ do
+    -- (Task 8: _hh_receive is no longer called on the send path, so the
+    -- throw must come from _hh_send itself.)
+    it "responds 500 when the harness handle throws during send" $ do
       withSystemTempDirectory "pureclaw-hsend-d38" $ \tmpDir -> do
         let sid = "sess-harness-throw"
             key = "claude-code-9"
         writeHarnessSession tmpDir sid key
-        sentRef <- newIORef []
         env0 <- mkTestFrontendEnvWithTabsAndDir [] tmpDir
         modifyIORef' (_fe_harnesses env0)
-          (Map.insert key (mkThrowingHarnessHandle sentRef))
+          (Map.insert key mkSendThrowingHarnessHandle)
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("will throw" :: Text)]))
         st `shouldBe` HTTP.status500
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "error"
           `shouldBe` Just (Aeson.String "Harness send failed")
-        -- The send was attempted (bytes reached the handle) before the throw.
+
+  -- -----------------------------------------------------------------------
+  -- Task 8: decouple harness send from receive
+  -- -----------------------------------------------------------------------
+  describe "POST /api/sessions/{sid}/send (decouple send/receive — Task 8)" $ do
+    -- The send path records a Request entry and injects keystrokes via
+    -- _hh_send, then returns promptly with {"kind":"assistant","response":""}.
+    -- _hh_receive must NOT be called (the reconcile watcher owns Response
+    -- recording). A handle whose _hh_receive = error "..." proves this.
+    it "harness /send records a Request and injects keystrokes but records NO Response inline" $ do
+      withSystemTempDirectory "pureclaw-task8-decoupled" $ \tmpDir -> do
+        let sid = "sess-task8-decouple"
+            key = "claude-code-0"
+        writeHarnessSession tmpDir sid key
+        sentRef <- newIORef ([] :: [ByteString])
+        env0 <- mkTestFrontendEnvWithTabsAndDir [] tmpDir
+        -- A handle whose _hh_receive throws — proves it is never called.
+        let hh = (mkNoOpHarnessHandle)
+                   { _hh_send    = \bs -> modifyIORef' sentRef (++ [bs])
+                   , _hh_receive = error "receive must not be called on the send path"
+                   }
+        modifyIORef' (_fe_harnesses env0) (Map.insert key hh)
+        (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
+          (Aeson.encode (object ["message" .= ("hello" :: Text)]))
+        st `shouldBe` HTTP.status200
+        -- Response is empty — reply arrives via WS stream from the watcher.
+        lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
+          `shouldBe` Just (Aeson.String "")
+        lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "kind"
+          `shouldBe` Just (Aeson.String "assistant")
+        -- Keystrokes were injected.
         sent <- readIORef sentRef
-        sent `shouldBe` ["will throw"]
+        sent `shouldBe` [TE.encodeUtf8 "hello"]
+        -- Only a Request entry was recorded; no inline Response.
+        entries <- readSessionTranscript tmpDir sid
+        map _te_direction entries `shouldBe` [Request]
 
   -- -----------------------------------------------------------------------
   -- Task 7: slash-command short-circuit in handleSend
@@ -2789,8 +2830,9 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("ping" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "id-routed reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["ping"]
 
@@ -2800,8 +2842,8 @@ spec = do
     -- handle; and 'routeViaHandle' is the SOLE recorder of the session
     -- transcript (the adopted handle, like the spawned one, was given a no-op
     -- transcript). This proves a send to an adopted harness records exactly one
-    -- Request + one Response to the SESSION transcript — adoption is consistent
-    -- with the spawn-via-frontend path.
+    -- Request entry to the SESSION transcript (Task 8: Response is owned by the
+    -- reconcile watcher, not the send path) — adoption is consistent with spawn.
     it "records a send to an ADOPTED harness to the session transcript (WU8 Part B)" $ do
       withSystemTempDirectory "pureclaw-wu8-partb" $ \tmpDir -> do
         let sid    = "sess-adopted-route"
@@ -2820,21 +2862,20 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("hello adopted" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "adopted reply")
+          `shouldBe` Just (Aeson.String "")
         -- The keystrokes reached the adopted handle.
         sent <- readIORef sentRef
         sent `shouldBe` ["hello adopted"]
-        -- handleSend recorded exactly one Request + one Response to the SESSION
-        -- transcript (sole recorder — no double-write from the adopted handle,
-        -- whose own transcript is a no-op, mirroring the spawn path).
+        -- handleSend recorded exactly one Request entry to the SESSION transcript
+        -- (sole recorder; no inline Response — the watcher owns that).
         entries <- readSessionTranscript tmpDir sid
         let reqs  = [ e | e <- entries, _te_direction e == Request ]
             resps = [ e | e <- entries, _te_direction e == Response ]
         length reqs  `shouldBe` 1
-        length resps `shouldBe` 1
+        resps `shouldBe` []
         _te_payload (head reqs)  `shouldBe` "hello adopted"
-        _te_payload (head resps) `shouldBe` "adopted reply"
 
     -- D6.4: id not in the registry -> falls back to the legacy name-keyed
     -- _fe_harnesses map (the PR #74 path). Proves the name fallback survives.
@@ -2853,8 +2894,9 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("hi" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "name-fallback reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["hi"]
 
@@ -2872,8 +2914,9 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("legacy hi" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "legacy reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["legacy hi"]
 
@@ -2933,8 +2976,9 @@ spec = do
         (st, respBody) <- postJSON env0 ["api", "sessions", sid, "send"]
           (Aeson.encode (object ["message" .= ("fallthrough" :: Text)]))
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "name-path reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["fallthrough"]
 
@@ -3000,8 +3044,9 @@ spec = do
           (Aeson.encode (object ["message" .= ("first" :: Text)]))
         -- The send succeeded despite the throwing back-fill.
         st `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode respBody)) "response"
-          `shouldBe` Just (Aeson.String "matched")
+          `shouldBe` Just (Aeson.String "")
         -- The keystrokes were delivered.
         sent <- readIORef sentRef
         sent `shouldBe` ["first"]
@@ -3137,8 +3182,9 @@ spec = do
         (stSend, sendResp) <- postJSON env ["api", "sessions", newSid, "send"]
           (Aeson.encode (object ["message" .= ("first prompt" :: Text)]))
         stSend `shouldBe` HTTP.status200
+        -- Task 8: send returns "" immediately; reply arrives via WS stream.
         lookupKey (fromMaybe Aeson.Null (Aeson.decode sendResp)) "response"
-          `shouldBe` Just (Aeson.String "id-routed reply")
+          `shouldBe` Just (Aeson.String "")
         sent <- readIORef sentRef
         sent `shouldBe` ["first prompt"]
 
@@ -4044,17 +4090,15 @@ drainBrokerQueue budgetMicros sub = do
         Nothing -> pure []
         Just ev -> (ev :) <$> drainNonBlocking
 
--- | A fake 'HarnessHandle' whose '_hh_receive' throws, exercising the
--- exception path in 'sendToHarness' (the @try \@SomeException@ around the
--- '_hh_send'\/'_hh_receive' interaction). It records the send like
--- 'mkFakeHarnessHandle' so the test can confirm the send happened before
--- the throw, then surfaces a 500.
-mkThrowingHarnessHandle :: IORef [ByteString] -> HarnessHandle
-mkThrowingHarnessHandle sentRef = HarnessHandle
-  { _hh_send     = \bs -> modifyIORef' sentRef (++ [bs])
-  , _hh_receive  = throwIO (userError "boom")
+-- | A fake 'HarnessHandle' whose '_hh_send' throws immediately. Used by
+-- D3.8 (Task 8) to exercise the 500 path: the send path no longer calls
+-- '_hh_receive', so the throw must come from '_hh_send'.
+mkSendThrowingHarnessHandle :: HarnessHandle
+mkSendThrowingHarnessHandle = HarnessHandle
+  { _hh_send     = \_ -> throwIO (userError "send boom")
+  , _hh_receive  = pure ""
   , _hh_snapshot = \_ -> pure ""
-  , _hh_name     = "fake-throwing-harness"
+  , _hh_name     = "fake-send-throwing-harness"
   , _hh_session  = "pureclaw"
   , _hh_status   = pure HarnessRunning
   , _hh_stop     = pure ()

--- a/test/Frontend/ActivityTypesSpec.hs
+++ b/test/Frontend/ActivityTypesSpec.hs
@@ -1,0 +1,25 @@
+-- | Tests for 'PureClaw.Frontend.Activity.Types'.
+--
+-- Covers the 'HarnessActivity' 'ToJSON' instances, including the
+-- 'HarnessNeedsInput' constructor added in Task 3.
+module Frontend.ActivityTypesSpec (spec) where
+
+import Data.Aeson qualified as Aeson
+import Test.Hspec
+
+import PureClaw.Frontend.Activity.Types (HarnessActivity (..))
+
+spec :: Spec
+spec = do
+  describe "HarnessActivity ToJSON" $ do
+    it "encodes HarnessThinking as \"thinking\"" $
+      Aeson.toJSON HarnessThinking `shouldBe` Aeson.String "thinking"
+
+    it "encodes HarnessIdle as \"idle\"" $
+      Aeson.toJSON HarnessIdle `shouldBe` Aeson.String "idle"
+
+    it "encodes HarnessNeedsInput as \"needs-input\"" $
+      Aeson.toJSON HarnessNeedsInput `shouldBe` Aeson.String "needs-input"
+
+    it "encodes HarnessStopped as \"stopped\"" $
+      Aeson.toJSON HarnessStopped `shouldBe` Aeson.String "stopped"

--- a/test/Frontend/TabsViewSpec.hs
+++ b/test/Frontend/TabsViewSpec.hs
@@ -23,6 +23,7 @@ import Test.Hspec
 
 import PureClaw.Core.Types (SessionId (..))
 import PureClaw.Harness.Registry qualified as Registry
+import PureClaw.Session.Kind qualified as Kind
 import PureClaw.Tabs.Types
   ( TabRef (..)
   , appendTab
@@ -66,6 +67,7 @@ mkEntry hid label = Registry.HarnessEntry
   , Registry._he_shellPid      = Nothing
   , Registry._he_harnessPid    = Nothing
   , Registry._he_origin        = Registry.OriginSpawned
+  , Registry._he_flavour       = Kind.HClaudeCode
   , Registry._he_liveness      = Registry.LivenessIdle
   , Registry._he_extModified   = False
   , Registry._he_stale         = False

--- a/test/Frontend/TabsViewSpec.hs
+++ b/test/Frontend/TabsViewSpec.hs
@@ -235,3 +235,8 @@ spec = do
             _ts_index t0 `shouldBe` 0
             _ts_index t1 `shouldBe` 1
           other -> expectationFailure ("expected 2 snapshots, got " <> show (length other))
+
+  -- Task 3: livenessToTabStatus — LivenessAwaitingInput maps to "running"
+  describe "livenessToTabStatus LivenessAwaitingInput" $ do
+    it "maps LivenessAwaitingInput to \"running\" (state shown via activity dot, not tab badge)" $
+      livenessToTabStatus Registry.LivenessAwaitingInput `shouldBe` "running"

--- a/test/Harness/ClaudeCodeSpec.hs
+++ b/test/Harness/ClaudeCodeSpec.hs
@@ -850,6 +850,20 @@ spec = do
             txExists `shouldBe` True
           other -> expectationFailure ("expected exactly one session dir, got " <> show (length other))
 
+    it "_hh_snapshot returns the latest extracted response (no polling)" $
+      withSystemTempDirectory "pcl-snap" $ \tmp -> do
+        reg <- Reg.newRegistry
+        let deps = okDeps
+              { _ccd_newId        = pure fixedId
+              , _ccd_sweep        = \_ -> pure [adoptableRow 0 "win-snap"]
+              , _ccd_panePidOf    = \_ _ -> pure (Just 7)
+              , _ccd_captureNamed = \_ _ _ -> pure (Just (TE.encodeUtf8
+                  "\x23FA Hello from the harness.\n\10095\n"))
+              }
+        Right (_, hh) <- adoptExternalWindow deps reg mkNoOpTranscriptHandle tmp mkToken Nothing "win-snap"
+        out <- _hh_snapshot hh 0
+        out `shouldSatisfy` T.isInfixOf "Hello from the harness."
+
   describe "discovered handle" $ do
     it "mkDiscoveredClaudeCodeHandle threads the real session name" $ do
       let transcript = mkNoOpTranscriptHandle

--- a/test/Harness/ClaudeCodeSpec.hs
+++ b/test/Harness/ClaudeCodeSpec.hs
@@ -453,6 +453,9 @@ spec = do
     it "isIdle is False for an approval/needs-input frame" $
       isIdle "Do you want to proceed?" `shouldBe` False
 
+    it "is NOT idle when a spinner/working line is present even though the ❯ input box is shown (regression)" $
+      isIdle "\x2736 Smooshing\x2026 (4s \xB7 16k tokens)\n\x276F" `shouldBe` False
+
     it "isResponseMarker recognises the ⏺ and ⬤ markers" $ do
       isResponseMarker "\x23FA hello" `shouldBe` True
       isResponseMarker "\x2B24 hello" `shouldBe` True

--- a/test/Harness/ClaudeCodeSpec.hs
+++ b/test/Harness/ClaudeCodeSpec.hs
@@ -441,14 +441,17 @@ spec = do
           hasUnsafeFlag argv `shouldBe` True
 
   describe "response extraction (pure)" $ do
-    it "isIdle is True when the prompt is present and no busy markers" $
-      isIdle "some text \x276F " `shouldBe` True
+    -- isIdle is now defined via the observer (classifyClaude): HasIdle iff
+    -- the screen has no working or approval lines (Task 8 redefinition).
+    it "isIdle is True for a bare-prompt idle frame" $
+      isIdle "\x276F" `shouldBe` True
 
-    it "isIdle is False while Thinking" $
-      isIdle "\x276F Thinking..." `shouldBe` False
+    it "isIdle is False for a spinner/working frame" $
+      -- "✶ …" is a working line: spinner glyph ✶ (U+2736) + "…"
+      isIdle "\x2736 \x2026" `shouldBe` False
 
-    it "isIdle is False without the prompt glyph" $
-      isIdle "no prompt here" `shouldBe` False
+    it "isIdle is False for an approval/needs-input frame" $
+      isIdle "Do you want to proceed?" `shouldBe` False
 
     it "isResponseMarker recognises the ⏺ and ⬤ markers" $ do
       isResponseMarker "\x23FA hello" `shouldBe` True

--- a/test/Harness/ObserverSpec.hs
+++ b/test/Harness/ObserverSpec.hs
@@ -59,3 +59,27 @@ spec = do
         `shouldBe` HasWorking
     it "maps non-Claude flavours to the generic observer" $
       _ho_classify (observerFor HCodex) "✶ anything" `shouldBe` HasIdle
+
+  -- Finding 2: response markers (⏺ ● ⬤) must NOT be classified as HasWorking
+  -- even when the line contains an ellipsis.  They are NOT spinner glyphs —
+  -- they appear as the first character of actual Claude replies (e.g.
+  -- "⏺ Let me check the other call sites…").  Before the fix, such a line
+  -- would be misclassified HasWorking → the turn would never settle → the
+  -- watcher would never record the reply.
+  describe "response-marker lines are NOT HasWorking (Finding 2)" $ do
+    it "⏺ with an ellipsis + idle prompt classifies as HasIdle, not HasWorking" $ do
+      -- Frame: a response line starting with ⏺ that contains an ellipsis,
+      -- followed by the bare idle-input prompt.  The whole frame must read
+      -- HasIdle (the turn settled), not HasWorking.
+      let frame = "\x23FA Let me check the other call sites\x2026\n\x276F"
+      _ho_classify claudeObserver frame `shouldBe` HasIdle
+    it "● (U+25CF) with an ellipsis + idle prompt classifies as HasIdle" $ do
+      let frame = "\x25CF Reviewing the diff\x2026\n\x276F"
+      _ho_classify claudeObserver frame `shouldBe` HasIdle
+    it "⬤ (U+2B24) with an ellipsis + idle prompt classifies as HasIdle" $ do
+      let frame = "\x2B24 Analysing results\x2026\n\x276F"
+      _ho_classify claudeObserver frame `shouldBe` HasIdle
+    -- Positive regression guard: a genuine spinner glyph STILL reads HasWorking.
+    it "✶ (U+2736) with an ellipsis still classifies as HasWorking (spinner glyph)" $ do
+      let frame = "\x2736 Smooshing\x2026 (4s)"
+      _ho_classify claudeObserver frame `shouldBe` HasWorking

--- a/test/Harness/ObserverSpec.hs
+++ b/test/Harness/ObserverSpec.hs
@@ -1,0 +1,61 @@
+module Harness.ObserverSpec (spec) where
+
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import           PureClaw.Harness.Observer
+import           PureClaw.Session.Kind (HarnessFlavour (..))
+import           Test.Hspec
+
+loadFix :: FilePath -> IO BS.ByteString
+loadFix name = BS.readFile ("test/fixtures/harness/" <> name)
+
+spec :: Spec
+spec = do
+  describe "claudeObserver._ho_classify" $ do
+    it "HasWorking when a spinner/status line is present" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-working.txt"
+      _ho_classify claudeObserver t `shouldBe` HasWorking
+    it "HasAwaitingInput on an approval prompt" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-approval.txt"
+      _ho_classify claudeObserver t `shouldBe` HasAwaitingInput
+    it "HasIdle on a bare prompt with no spinner/approval" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-idle.txt"
+      _ho_classify claudeObserver t `shouldBe` HasIdle
+    it "is NOT HasIdle when the prompt is a menu cursor (❯ N.)" $ do
+      t <- TE.decodeUtf8 <$> loadFix "claude-menu-cursor.txt"
+      _ho_classify claudeObserver t `shouldNotBe` HasIdle
+
+  describe "claudeObserver._ho_extractResponse" $ do
+    it "returns the last assistant block, marker + chrome stripped" $ do
+      cap <- loadFix "claude-response.txt"
+      let out = _ho_extractResponse claudeObserver 0 cap
+      out `shouldSatisfy` T.isInfixOf "Applied the change and the tests pass."
+      out `shouldNotSatisfy` T.isInfixOf "\x23FA"        -- no ⏺ marker
+      out `shouldNotSatisfy` T.isInfixOf "ctrl+o"         -- chrome stripped
+      out `shouldNotSatisfy` T.isInfixOf "fix the bug"    -- not the user line
+    it "returns the prompt text when awaiting input" $ do
+      cap <- loadFix "claude-approval.txt"
+      _ho_extractResponse claudeObserver 0 cap
+        `shouldSatisfy` T.isInfixOf "Do you want to proceed?"
+
+  describe "claudeObserver._ho_relevantTail" $
+    it "returns the last N cleaned lines without box-drawing chrome" $ do
+      cap <- loadFix "claude-idle.txt"
+      let out = _ho_relevantTail claudeObserver 3 cap
+      length (T.lines out) `shouldSatisfy` (<= 3)
+      out `shouldNotSatisfy` T.isInfixOf "────"
+
+  describe "genericObserver" $ do
+    it "classify is always HasIdle (no markers; stability decides in the loop)" $
+      _ho_classify genericObserver "anything at all" `shouldBe` HasIdle
+    it "relevantTail returns the last N lines" $
+      _ho_relevantTail genericObserver 2 (TE.encodeUtf8 "a\nb\nc\nd")
+        `shouldBe` "c\nd"
+
+  describe "observerFor" $ do
+    it "maps HClaudeCode to the Claude observer" $
+      _ho_classify (observerFor HClaudeCode) "✶ Working… (3s · 1k tokens)"
+        `shouldBe` HasWorking
+    it "maps non-Claude flavours to the generic observer" $
+      _ho_classify (observerFor HCodex) "✶ anything" `shouldBe` HasIdle

--- a/test/Harness/ReconcileSpec.hs
+++ b/test/Harness/ReconcileSpec.hs
@@ -42,6 +42,7 @@ import PureClaw.Frontend.StreamBroker
   , defaultBrokerConfig
   , mkInProcessBroker
   )
+import PureClaw.Handles.Harness (HarnessHandle (..), mkNoOpHarnessHandle)
 import PureClaw.Handles.Log (LogHandle (..), mkNoOpLogHandle)
 import PureClaw.Harness.Observer (claudeObserver)
 import PureClaw.Harness.Reconcile
@@ -136,6 +137,7 @@ fakeDeps f = ReconcileDeps
       pure (Map.findWithDefault True pid m)
   , _rd_stampLegacy = \_session _windowName -> pure Nothing
   , _rd_evict = \_hid _label -> pure ()
+  , _rd_recordResponse = \_sid _txt -> pure ()
   }
 
 -- | A log handle that records every warn\/error message into an 'IORef' so a
@@ -339,6 +341,129 @@ spec = do
               sid `shouldBe` SessionId "label-fallback"
             other -> expectationFailure $
               "expected a HarnessStopped event under the label, got: " <> show other
+
+  describe "output watcher — record Response on settle (Task 7)" $ do
+    -- These tests drive the real loop (the settle detection lives in the loop,
+    -- not in 'reconcileTick'). A scripted per-tick capture sequence
+    -- spinner→spinner→idle→idle produces a working→idle settle on the tick
+    -- where two identical idle frames pass the stability gate. The fake handle's
+    -- '_hh_snapshot' returns a fixed response the recorder captures.
+    let settleHid = "claude-code-0"
+
+        -- Build deps whose '_rd_capture' replays a per-tick frame script (the
+        -- last frame repeats) and whose '_rd_recordResponse' appends to a ref.
+        settleDeps
+          :: Text                          -- ^ the entry's @pcl_id (harness id text)
+          -> IORef [Text]                  -- ^ per-tick capture script
+          -> (SessionId -> Text -> IO ())  -- ^ recordResponse
+          -> ReconcileDeps
+        settleDeps pclId frames record = ReconcileDeps
+          { _rd_sessions = pure ["pureclaw"]
+          , _rd_sweep    = \_ -> pure
+              [ mkRow 0 settleHid pclId (Just 100) False ]
+          , _rd_capture  = \_session _windowName -> do
+              xs <- readIORef frames
+              case xs of
+                []       -> pure (Just idleFrame)
+                [x]      -> pure (Just x)
+                (x : ys) -> do writeIORef frames ys; pure (Just x)
+          , _rd_harnessAlive   = \_ -> pure True
+          , _rd_stampLegacy     = \_ _ -> pure Nothing
+          , _rd_evict           = \_ _ -> pure ()
+          , _rd_recordResponse  = record
+          }
+
+    it "records exactly one Response on a working→idle settle, then dedups" $ do
+      recorded <- newIORef ([] :: [(SessionId, Text)])
+      reg <- Reg.newRegistry
+      hid <- Reg.newHarnessId
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "the answer" }
+      Reg.insertEntry reg
+        ((mkEntry hid settleHid (Just 100) (Just 200) Reg.LivenessThinking)
+          { Reg._he_sessionId = Just "sess-1"
+          , Reg._he_handle    = Just hh
+          })
+      -- spinner, spinner, idle, idle, idle... → Idle settle once two idle
+      -- frames are stable; subsequent idle ticks must dedup to zero.
+      frames <- newIORef [busyFrame, busyFrame, idleFrame]
+      let deps = settleDeps (Reg.harnessIdToText hid) frames
+                   (\sid txt -> modifyIORef' recorded ((sid, txt) :))
+      broker <- mkInProcessBroker defaultBrokerConfig
+      let tick = 40_000
+      Async.withAsync
+        (runReconcileLoopWith tick deps reg broker mkNoOpLogHandle) $ \_a -> do
+          threadDelay (20 * tick)
+      xs <- readIORef recorded
+      xs `shouldBe` [(SessionId "sess-1", "the answer")]
+
+    it "records the approval prompt on a working→awaiting-input settle" $ do
+      recorded <- newIORef ([] :: [(SessionId, Text)])
+      reg <- Reg.newRegistry
+      hid <- Reg.newHarnessId
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "the prompt" }
+      Reg.insertEntry reg
+        ((mkEntry hid settleHid (Just 100) (Just 200) Reg.LivenessThinking)
+          { Reg._he_sessionId = Just "sess-1"
+          , Reg._he_handle    = Just hh
+          })
+      -- spinner, then an approval frame (AwaitingInput needs no stability gate).
+      let approvalFrame = "Do you want to proceed?"
+      frames <- newIORef [busyFrame, approvalFrame]
+      let deps = settleDeps (Reg.harnessIdToText hid) frames
+                   (\sid txt -> modifyIORef' recorded ((sid, txt) :))
+      broker <- mkInProcessBroker defaultBrokerConfig
+      let tick = 40_000
+      Async.withAsync
+        (runReconcileLoopWith tick deps reg broker mkNoOpLogHandle) $ \_a -> do
+          threadDelay (20 * tick)
+      xs <- readIORef recorded
+      xs `shouldBe` [(SessionId "sess-1", "the prompt")]
+
+    it "skips recording when _he_sessionId is Nothing (label-only entry)" $ do
+      recorded <- newIORef ([] :: [(SessionId, Text)])
+      reg <- Reg.newRegistry
+      hid <- Reg.newHarnessId
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "the answer" }
+      Reg.insertEntry reg
+        ((mkEntry hid settleHid (Just 100) (Just 200) Reg.LivenessThinking)
+          { Reg._he_sessionId = Nothing
+          , Reg._he_label     = settleHid
+          , Reg._he_handle    = Just hh
+          })
+      frames <- newIORef [busyFrame, busyFrame, idleFrame]
+      let deps = settleDeps (Reg.harnessIdToText hid) frames
+                   (\sid txt -> modifyIORef' recorded ((sid, txt) :))
+      broker <- mkInProcessBroker defaultBrokerConfig
+      let tick = 40_000
+      Async.withAsync
+        (runReconcileLoopWith tick deps reg broker mkNoOpLogHandle) $ \_a -> do
+          threadDelay (20 * tick)
+      xs <- readIORef recorded
+      xs `shouldBe` []
+
+    it "records output produced with no preceding send (direct-tmux: spinner→idle)" $ do
+      -- No /send happened; the harness just produced output. The settle on a
+      -- spinner→idle transition still records it (the loop watches liveness, not
+      -- send calls).
+      recorded <- newIORef ([] :: [(SessionId, Text)])
+      reg <- Reg.newRegistry
+      hid <- Reg.newHarnessId
+      let hh = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "spontaneous output" }
+      Reg.insertEntry reg
+        ((mkEntry hid settleHid (Just 100) (Just 200) Reg.LivenessThinking)
+          { Reg._he_sessionId = Just "sess-1"
+          , Reg._he_handle    = Just hh
+          })
+      frames <- newIORef [busyFrame, busyFrame, idleFrame]
+      let deps = settleDeps (Reg.harnessIdToText hid) frames
+                   (\sid txt -> modifyIORef' recorded ((sid, txt) :))
+      broker <- mkInProcessBroker defaultBrokerConfig
+      let tick = 40_000
+      Async.withAsync
+        (runReconcileLoopWith tick deps reg broker mkNoOpLogHandle) $ \_a -> do
+          threadDelay (20 * tick)
+      xs <- readIORef recorded
+      xs `shouldBe` [(SessionId "sess-1", "spontaneous output")]
 
   describe "reconcileTick — D5.5 / D5.7 (non-ours rows are never captured)" $ do
     it "a PID-mismatched marker row is logged + treated as not-ours (never captured, entry → Orphaned)" $ do

--- a/test/Harness/ReconcileSpec.hs
+++ b/test/Harness/ReconcileSpec.hs
@@ -22,7 +22,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async qualified as Async
 import Control.Monad (replicateM_, void)
 import Control.Concurrent.STM (atomically, readTBQueue)
-import Control.Exception (throwIO, ErrorCall (..))
+import Control.Exception (IOException, throwIO, ErrorCall (..))
 import Data.IORef
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -464,6 +464,84 @@ spec = do
           threadDelay (20 * tick)
       xs <- readIORef recorded
       xs `shouldBe` [(SessionId "sess-1", "spontaneous output")]
+
+    -- Finding 1: a non-async exception thrown by '_rd_recordResponse' (or
+    -- '_hh_snapshot') on one settled harness must NOT kill the reconcile loop.
+    -- The loop must:
+    --   * log a warning for the failing entry;
+    --   * keep running;
+    --   * still record the Response for a SECOND, healthy harness that settles
+    --     on a later tick.
+    -- RED on the unfixed code: the exception propagates to the 'outer' handler
+    -- which logs + returns (exits) — the healthy harness's record is never seen.
+    it "Finding 1: settle path survives a non-async IOException from _rd_recordResponse" $ do
+      recorded  <- newIORef ([] :: [(SessionId, Text)])
+      (logRef, capLog) <- mkCapturingLog
+
+      reg <- Reg.newRegistry
+
+      -- Harness A: its _rd_recordResponse throws an IOException on settle.
+      hidA <- Reg.newHarnessId
+      let hhA = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "response-A" }
+      Reg.insertEntry reg
+        ((mkEntry hidA settleHid (Just 100) (Just 200) Reg.LivenessThinking)
+          { Reg._he_sessionId = Just "sess-A"
+          , Reg._he_handle    = Just hhA
+          })
+
+      -- Harness B: healthy; sits at Thinking until a later set of idle frames.
+      hidB <- Reg.newHarnessId
+      let win_B = "claude-code-1"
+          hhB   = mkNoOpHarnessHandle { _hh_snapshot = \_ -> pure "response-B" }
+      Reg.insertEntry reg
+        ((mkEntry hidB win_B (Just 300) (Just 400) Reg.LivenessThinking)
+          { Reg._he_sessionId = Just "sess-B"
+          , Reg._he_handle    = Just hhB
+          })
+
+      -- The injected _rd_recordResponse throws for sess-A, succeeds for sess-B.
+      let record sid txt =
+            if sid == SessionId "sess-A"
+              then throwIO (userError "disk full" :: IOException)
+              else modifyIORef' recorded ((sid, txt) :)
+
+      -- Frame script: both harnesses start busy, then settle (idle×2 for the
+      -- stability gate).  We map by window name so each gets its own sequence.
+      framesA <- newIORef [busyFrame, busyFrame, idleFrame]
+      framesB <- newIORef [busyFrame, busyFrame, busyFrame, idleFrame]
+
+      broker <- mkInProcessBroker defaultBrokerConfig
+      let tick = 40_000
+          deps = ReconcileDeps
+            { _rd_sessions = pure ["pureclaw"]
+            , _rd_sweep    = \_ -> pure
+                [ mkRow 0 settleHid (Reg.harnessIdToText hidA) (Just 100) False
+                , mkRow 1 win_B     (Reg.harnessIdToText hidB) (Just 300) False
+                ]
+            , _rd_capture  = \_session windowName -> do
+                let ref = if windowName == settleHid then framesA else framesB
+                xs <- readIORef ref
+                case xs of
+                  []       -> pure (Just idleFrame)
+                  [x]      -> pure (Just x)
+                  (x : ys) -> do writeIORef ref ys; pure (Just x)
+            , _rd_harnessAlive   = \_ -> pure True
+            , _rd_stampLegacy     = \_ _ -> pure Nothing
+            , _rd_evict           = \_ _ -> pure ()
+            , _rd_recordResponse  = record
+            }
+
+      Async.withAsync
+        (runReconcileLoopWith tick deps reg broker capLog) $ \_a -> do
+          threadDelay (30 * tick)
+
+      -- The healthy harness (B) must have been recorded despite A's failure.
+      xs <- readIORef recorded
+      xs `shouldBe` [(SessionId "sess-B", "response-B")]
+
+      -- The loop must have logged a warning about the failing settle.
+      logs <- readIORef logRef
+      any (\m -> "settle snapshot/record" `T.isInfixOf` m) logs `shouldBe` True
 
   describe "reconcileTick — D5.5 / D5.7 (non-ours rows are never captured)" $ do
     it "a PID-mismatched marker row is logged + treated as not-ours (never captured, entry → Orphaned)" $ do

--- a/test/Harness/ReconcileSpec.hs
+++ b/test/Harness/ReconcileSpec.hs
@@ -43,9 +43,11 @@ import PureClaw.Frontend.StreamBroker
   , mkInProcessBroker
   )
 import PureClaw.Handles.Log (LogHandle (..), mkNoOpLogHandle)
+import PureClaw.Harness.Observer (claudeObserver)
 import PureClaw.Harness.Reconcile
 import PureClaw.Harness.Registry qualified as Reg
 import PureClaw.Harness.Tmux (TmuxWindowRow (..))
+import PureClaw.Session.Kind qualified as Kind
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -61,6 +63,7 @@ mkEntry hid windowName shellPid harnessPid liveness = Reg.HarnessEntry
   , Reg._he_shellPid    = shellPid
   , Reg._he_harnessPid  = harnessPid
   , Reg._he_origin      = Reg.OriginSpawned
+  , Reg._he_flavour     = Kind.HClaudeCode
   , Reg._he_liveness    = liveness
   , Reg._he_extModified = False
   , Reg._he_stale       = False
@@ -83,6 +86,13 @@ mkRow idx name pclId panePid paneDead = TmuxWindowRow
 recvWithin :: Int -> Subscription -> IO (Maybe BrokerEvent)
 recvWithin micros sub =
   timeout micros $ atomically $ readTBQueue (_sub_queue sub)
+
+-- | A raw screen frame the claudeObserver classifies as working (HasWorking ⇒
+-- Thinking), and one it classifies as idle (HasIdle ⇒ Idle once stable). The
+-- fake '_rd_capture' returns these to drive the observer-based classifier.
+busyFrame, idleFrame :: Text
+busyFrame = "\x2736 Smooshing\x2026 (4m 55s)"   -- ✶ working/status line
+idleFrame = "ready when you are"                -- neither working nor approval
 
 -- | Deterministic deps: a queue of sweeps (one per tick; the last repeats),
 -- a captured-windows recorder, and a settable idle/capture map.
@@ -116,7 +126,11 @@ fakeDeps f = ReconcileDeps
   , _rd_capture  = \_session windowName -> do
       modifyIORef' (f_capturedWindows f) (++ [windowName])
       m <- readIORef (f_idleByWindow f)
-      pure (Map.findWithDefault True windowName m)
+      -- Map the test's idle/busy intent onto a raw frame the claudeObserver
+      -- classifies: an idle frame reads HasIdle (⇒ Idle once stable), a busy
+      -- frame reads HasWorking (⇒ Thinking). Default (unmapped) is idle.
+      let idle = Map.findWithDefault True windowName m
+      pure (Just (if idle then idleFrame else busyFrame))
   , _rd_harnessAlive = \pid -> do
       m <- readIORef (f_aliveByPid f)
       pure (Map.findWithDefault True pid m)
@@ -167,16 +181,28 @@ spec = do
       corroborate e good `shouldBe` Corroborated
       corroborate e bad  `shouldBe` PidMismatch
 
-  describe "liveness classification (D5.4)" $ do
-    -- Args are (paneDead, harnessAlive, isIdle).
-    it "pane_dead → Exited" $
-      classifyLiveness True True True `shouldBe` Reg.LivenessExited
+  describe "observer-based classification (3-state + stability gate)" $ do
+    -- The approval frame the claudeObserver recognizes (busyFrame/idleFrame are
+    -- the shared module-level fixtures).
+    let approvalFrame = "Do you want to proceed?"           -- approval prompt
+    -- Args are (observer, paneDead, harnessAlive, stable, screen).
+    it "pane_dead → Exited regardless of the screen" $
+      classifyFromObserver claudeObserver True True True busyFrame
+        `shouldBe` Reg.LivenessExited
     it "harness PID gone → Exited (window present, not pane_dead)" $
-      classifyLiveness False False True `shouldBe` Reg.LivenessExited
-    it "alive + idle screen → Idle" $
-      classifyLiveness False True True `shouldBe` Reg.LivenessIdle
-    it "alive + busy screen → Thinking" $
-      classifyLiveness False True False `shouldBe` Reg.LivenessThinking
+      classifyFromObserver claudeObserver False False True busyFrame
+        `shouldBe` Reg.LivenessExited
+    it "classifies a spinner frame as Thinking regardless of stability" $ do
+      classifyFromObserver claudeObserver False True True  busyFrame
+        `shouldBe` Reg.LivenessThinking
+      classifyFromObserver claudeObserver False True False busyFrame
+        `shouldBe` Reg.LivenessThinking
+    it "classifies an approval frame as AwaitingInput" $
+      classifyFromObserver claudeObserver False True True approvalFrame
+        `shouldBe` Reg.LivenessAwaitingInput
+    it "an idle-marker frame is Thinking until it is stable across ticks" $ do
+      classifyFromObserver claudeObserver False True False idleFrame `shouldBe` Reg.LivenessThinking
+      classifyFromObserver claudeObserver False True True  idleFrame `shouldBe` Reg.LivenessIdle
 
   describe "symmetric diff (D5.2 — disappearance emits an event)" $ do
     it "an entry whose liveness changed emits its new liveness" $ do
@@ -207,6 +233,8 @@ spec = do
       livenessToActivity Reg.LivenessThinking `shouldBe` HarnessThinking
       livenessToActivity Reg.LivenessExited   `shouldBe` HarnessStopped
       livenessToActivity Reg.LivenessOrphaned `shouldBe` HarnessStopped
+    it "maps AwaitingInput to needs-input" $
+      livenessToActivity Reg.LivenessAwaitingInput `shouldBe` HarnessNeedsInput
 
   describe "reconcileTick — D5.1 (update entries by id)" $
     it "updates a registered entry's liveness + coordinate from the sweep" $ do
@@ -219,7 +247,7 @@ spec = do
         [Right [mkRow 0 "renamed-window" (Reg.harnessIdToText hid) (Just 100) False]]
         (Map.singleton "renamed-window" False)  -- busy ⇒ Thinking
         Map.empty
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_liveness e   `shouldBe` Reg.LivenessThinking
       Reg._he_windowName e `shouldBe` "renamed-window"
@@ -233,7 +261,7 @@ spec = do
       f <- mkFakes
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 100) True]]
         Map.empty Map.empty
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_liveness e `shouldBe` Reg.LivenessExited
       -- A pane_dead window is never captured.
@@ -245,7 +273,7 @@ spec = do
       hid <- Reg.newHarnessId
       Reg.insertEntry reg (mkEntry hid "claude-code-0" (Just 100) (Just 200) Reg.LivenessIdle)
       f <- mkFakes [Right []] Map.empty Map.empty  -- empty sweep
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_liveness e `shouldBe` Reg.LivenessOrphaned
 
@@ -257,7 +285,7 @@ spec = do
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 100) False]]
         Map.empty
         (Map.singleton 100 False)  -- descent from shell PID 100 finds no agent
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_liveness e `shouldBe` Reg.LivenessExited
 
@@ -276,7 +304,7 @@ spec = do
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 100) False]]
         (Map.singleton "claude-code-0" False)  -- busy screen ⇒ Thinking
         Map.empty
-      _ <- reconcileTick (f0 f) reg mkNoOpLogHandle
+      _ <- reconcileTick (f0 f) reg mkNoOpLogHandle Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_liveness e `shouldBe` Reg.LivenessThinking
       -- The alive-probe was NOT consulted (no recorded harness PID).
@@ -321,7 +349,7 @@ spec = do
       f <- mkFakes
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 9999) False]]
         Map.empty Map.empty
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       cap <- readIORef (f_capturedWindows f)
       cap `shouldBe` []  -- never captured the spoofed window
       [e] <- Reg.snapshot reg
@@ -333,7 +361,7 @@ spec = do
       f <- mkFakes
         [Right [mkRow 0 "stranger" "00000000-0000-0000-0000-000000000000" (Just 7) False]]
         Map.empty Map.empty
-      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle
+      _ <- reconcileTick (fakeDeps f) reg mkNoOpLogHandle Map.empty
       cap <- readIORef (f_capturedWindows f)
       cap `shouldBe` []
 
@@ -344,7 +372,7 @@ spec = do
       Reg.insertEntry reg (mkEntry hid "claude-code-0" (Just 100) (Just 200) Reg.LivenessThinking)
       (logRef, logger) <- mkCapturingLog
       f <- mkFakes [Left (userError "tmux hiccup")] Map.empty Map.empty
-      _ <- reconcileTick (fakeDeps f) reg logger
+      _ <- reconcileTick (fakeDeps f) reg logger Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_stale e    `shouldBe` True
       Reg._he_liveness e `shouldBe` Reg.LivenessThinking  -- held, not repainted
@@ -366,7 +394,7 @@ spec = do
       f <- mkFakes
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 100) False]]
         Map.empty Map.empty
-      _ <- reconcileTick (f0 f) reg logger
+      _ <- reconcileTick (f0 f) reg logger Map.empty
       [e] <- Reg.snapshot reg
       Reg._he_stale e    `shouldBe` True
       Reg._he_liveness e `shouldBe` Reg.LivenessThinking  -- held, not repainted
@@ -392,7 +420,7 @@ spec = do
           ]]
         (Map.singleton "claude-code-1" False)  -- good entry's screen is busy
         Map.empty
-      _ <- reconcileTick (f0 f) reg mkNoOpLogHandle
+      _ <- reconcileTick (f0 f) reg mkNoOpLogHandle Map.empty
       entries <- Reg.snapshot reg
       let byId i = case [ e | e <- entries, Reg._he_id e == i ] of
             (e : _) -> e
@@ -440,9 +468,14 @@ spec = do
       broker <- mkInProcessBroker defaultBrokerConfig
       eSub   <- _streamBroker_subscribe broker
       sub    <- either (\e -> error ("subscribe: " <> show e)) pure eSub
+      -- A busy (working) window: it reads Thinking on every tick (working frames
+      -- ignore the stability gate), so subsequent identical ticks produce no
+      -- transition. This isolates the "first tick is a silent baseline" invariant
+      -- from the legitimate idle-stability flip (an idle window would read
+      -- Thinking on tick 1, then Idle once the capture is stable on tick 2).
       f <- mkFakes
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 100) False]]
-        (Map.singleton "claude-code-0" True)
+        (Map.singleton "claude-code-0" False)
         Map.empty
       let tick = 40_000
       Async.withAsync
@@ -581,7 +614,7 @@ spec = do
       f <- mkFakes
         [Right [mkRow 0 "claude-code-0" (Reg.harnessIdToText hid) (Just 9999) False]]
         Map.empty Map.empty
-      _ <- reconcileTick (fakeDeps f) reg logger
+      _ <- reconcileTick (fakeDeps f) reg logger Map.empty
       logs <- readIORef logRef
       any (\m -> "no corroborating PID" `T.isInfixOf` m) logs `shouldBe` True
 
@@ -620,7 +653,7 @@ spec = do
             { _rd_evict = \i l -> modifyIORef' evictRef (++ [(i, l)]) }
       -- Run threshold-1 orphaned ticks: the entry must survive every one.
       replicateM_ (defaultOrphanGraceTicks - 1) $ do
-        _ <- reconcileTick deps reg mkNoOpLogHandle
+        _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty
         pure ()
       snap <- Reg.snapshot reg
       map Reg._he_id snap `shouldBe` [hid]            -- still present (retained)
@@ -645,8 +678,8 @@ spec = do
       let deps = (fakeDeps f)
             { _rd_evict = \i l -> modifyIORef' evictRef (++ [(i, l)]) }
       -- Run threshold-1 ticks (retained), then the threshold-th tick evicts.
-      replicateM_ (defaultOrphanGraceTicks - 1) (void (reconcileTick deps reg mkNoOpLogHandle))
-      (_snap, evictedSids) <- reconcileTick deps reg mkNoOpLogHandle
+      replicateM_ (defaultOrphanGraceTicks - 1) (void (reconcileTick deps reg mkNoOpLogHandle Map.empty))
+      (_snap, evictedSids) <- reconcileTick deps reg mkNoOpLogHandle Map.empty
       -- Registry: the entry is gone.
       snap <- Reg.snapshot reg
       map Reg._he_id snap `shouldBe` []
@@ -677,16 +710,20 @@ spec = do
         Map.empty
       let deps = (fakeDeps f)
             { _rd_evict = \i l -> modifyIORef' evictRef (++ [(i, l)]) }
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan 1
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan 2
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan 1
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan 2
       afterTwo <- Reg.snapshot reg
       (Reg._he_orphanedTicks <$> afterTwo) `shouldBe` [2]
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- live again ⇒ reset
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- live again ⇒ reset
       afterLive <- Reg.snapshot reg
       [eLive] <- pure afterLive
-      Reg._he_liveness eLive      `shouldBe` Reg.LivenessIdle
+      -- The window reappeared this tick but its capture is not yet stable across
+      -- ticks (the preceding ticks were empty sweeps, so there is no prior
+      -- capture to match), so the idle frame reads Thinking — the point here is
+      -- the entry is LIVE again (not Orphaned), which resets the grace counter.
+      Reg._he_liveness eLive      `shouldBe` Reg.LivenessThinking
       Reg._he_orphanedTicks eLive `shouldBe` 0       -- counter reset
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan again ⇒ count restarts at 1
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan again ⇒ count restarts at 1
       afterReorphan <- Reg.snapshot reg
       (Reg._he_orphanedTicks <$> afterReorphan) `shouldBe` [1]
       evicted <- readIORef evictRef
@@ -712,7 +749,7 @@ spec = do
       f <- mkFakes [Right []] Map.empty Map.empty
       let deps = (fakeDeps f)
             { _rd_evict = \i l -> modifyIORef' evictArgs (++ [(i, l)]) }
-      replicateM_ defaultOrphanGraceTicks (void (reconcileTick deps reg mkNoOpLogHandle))
+      replicateM_ defaultOrphanGraceTicks (void (reconcileTick deps reg mkNoOpLogHandle Map.empty))
       -- Registry entry evicted...
       snap <- Reg.snapshot reg
       map Reg._he_id snap `shouldBe` []
@@ -749,14 +786,14 @@ spec = do
         Map.empty Map.empty
       let deps = (fakeDeps f)
             { _rd_evict = \i l -> modifyIORef' evictRef (++ [(i, l)]) }
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan 1
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan 2
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan 3
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan 1
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan 2
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan 3
       afterThree <- Reg.snapshot reg
       (Reg._he_orphanedTicks <$> afterThree) `shouldBe` [3]
       -- The failed sweep: counter HELD (not advanced to 4, not reset to 0), the
       -- entry stays Orphaned + marked stale, and it is NOT evicted.
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- transient failure
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- transient failure
       afterFail <- Reg.snapshot reg
       [eHeld] <- pure afterFail
       Reg._he_orphanedTicks eHeld `shouldBe` 3                       -- HELD, not advanced/reset
@@ -764,7 +801,7 @@ spec = do
       Reg._he_stale eHeld         `shouldBe` True                    -- the blip marked it stale
       readIORef evictRef `shouldReturn` []                          -- NOT evicted by the blip
       -- The next real (empty) sweep resumes advancing from the held value.
-      _ <- reconcileTick deps reg mkNoOpLogHandle  -- orphan again
+      _ <- reconcileTick deps reg mkNoOpLogHandle Map.empty  -- orphan again
       afterResume <- Reg.snapshot reg
       (Reg._he_orphanedTicks <$> afterResume) `shouldBe` [4]
       readIORef evictRef `shouldReturn` []

--- a/test/Harness/RegistrySpec.hs
+++ b/test/Harness/RegistrySpec.hs
@@ -11,6 +11,7 @@ import Test.Hspec
 
 import PureClaw.Handles.Harness (mkNoOpHarnessHandle)
 import PureClaw.Harness.Registry
+import PureClaw.Session.Kind qualified as Kind
 
 -- | Deterministic test ids built from fixed UUID strings (no IO randomness),
 -- so assertions are stable.
@@ -34,6 +35,7 @@ mkEntry hid lbl = HarnessEntry
   , _he_shellPid    = Nothing
   , _he_harnessPid  = Nothing
   , _he_origin      = OriginSpawned
+  , _he_flavour     = Kind.HClaudeCode
   , _he_liveness    = LivenessIdle
   , _he_extModified = False
   , _he_stale       = False
@@ -307,6 +309,7 @@ spec = do
           , _he_shellPid    = Just 100
           , _he_harnessPid  = Just 200
           , _he_origin      = OriginDiscovered
+          , _he_flavour     = Kind.HClaudeCode
           , _he_liveness    = LivenessThinking
           , _he_extModified = True
           , _he_stale       = True

--- a/test/Harness/TmuxSpec.hs
+++ b/test/Harness/TmuxSpec.hs
@@ -59,7 +59,12 @@ spec = do
 
     it "captureNamedArgs targets the window name with -p and scrollback" $ do
       let argv = captureNamedArgs "pureclaw" "claude-code-0" 300
-      argv `shouldBe` ["capture-pane", "-t", "pureclaw:claude-code-0", "-p", "-S", "-300"]
+      argv `shouldBe` ["capture-pane", "-t", "pureclaw:claude-code-0", "-p", "-J", "-S", "-300"]
+
+    it "joins wrapped lines with -J so long lines are not split" $
+      captureNamedArgs "sess" "win" 50
+        `shouldBe`
+        [ "capture-pane", "-t", "sess:win", "-p", "-J", "-S", "-50" ]
 
     it "killWindowNamedArgs targets the window name" $ do
       let argv = killWindowNamedArgs "pureclaw" "claude-code-0"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -102,6 +102,7 @@ import qualified Harness.JsonlTailSpec
 import qualified Harness.ReconcileSpec
 import qualified Harness.RegistrySpec
 import qualified Harness.TmuxSpec
+import qualified Harness.ObserverSpec
 import qualified Transcript.CombinatorSpec
 import qualified Transcript.ProviderSpec
 import qualified Session.TypesSpec
@@ -270,6 +271,7 @@ main = hspec $ do
   describe "Harness.Reconcile" Harness.ReconcileSpec.spec
   describe "Harness.Registry" Harness.RegistrySpec.spec
   describe "Harness.Tmux" Harness.TmuxSpec.spec
+  describe "Harness.Observer" Harness.ObserverSpec.spec
   describe "Transcript.Combinator" Transcript.CombinatorSpec.spec
   describe "Transcript.Provider" Transcript.ProviderSpec.spec
   describe "Session.Types" Session.TypesSpec.spec

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -159,6 +159,8 @@ import qualified Frontend.StreamGoldensSpec
 import qualified Frontend.StreamIntegrationSpec
 -- WU4 (activity probe loop)
 import qualified Frontend.ActivityProbeSpec
+-- Task 3: HarnessActivity ToJSON unit tests
+import qualified Frontend.ActivityTypesSpec
 -- Frontend.APISpec is already imported at the top of this block (from main)
 -- Tabs-as-View (GitHub #79) WU3-FE (pure tabSnapshotsFromRegistry)
 import qualified Frontend.TabsViewSpec
@@ -323,6 +325,8 @@ main = hspec $ do
   describe "Frontend.StreamIntegration" Frontend.StreamIntegrationSpec.spec
   -- WU4 (activity probe loop)
   describe "Frontend.ActivityProbe" Frontend.ActivityProbeSpec.spec
+  -- Task 3: HarnessActivity ToJSON
+  describe "Frontend.ActivityTypes" Frontend.ActivityTypesSpec.spec
   -- Frontend.APISpec is registered earlier (from main's WU-7 unified endpoint)
   -- Tabs-as-View (GitHub #79) WU3-FE (pure tabSnapshotsFromRegistry)
   describe "Frontend.TabsView" Frontend.TabsViewSpec.spec

--- a/test/Tabs/RuntimesSpec.hs
+++ b/test/Tabs/RuntimesSpec.hs
@@ -186,10 +186,10 @@ mkFakeHarness scriptRef statusRef recvDone signalled = do
         []       -> ([], "")        -- drained: keep returning empty
         (b : bs) -> (bs, b)
       handle = HarnessHandle
-        { _hh_send    = \bs -> do
+        { _hh_send     = \bs -> do
             modifyIORef' sent (++ [bs])
             putMVar sendDone bs
-        , _hh_receive = do
+        , _hh_receive  = do
             out <- recv
             remaining <- readIORef scriptRef
             -- Signal exactly once when the script first drains.
@@ -199,10 +199,11 @@ mkFakeHarness scriptRef statusRef recvDone signalled = do
                 if fired then pure () else putMVar recvDone ()
               _  -> pure ()
             pure out
-        , _hh_name    = "fake"
-        , _hh_session = "fake-sess"
-        , _hh_status  = readIORef statusRef
-        , _hh_stop    = modifyIORef' stops (+ 1)
+        , _hh_snapshot = \_ -> pure ""
+        , _hh_name     = "fake"
+        , _hh_session  = "fake-sess"
+        , _hh_status   = readIORef statusRef
+        , _hh_stop     = modifyIORef' stops (+ 1)
         }
   pure (FakeHarness handle sent stops sendDone)
 
@@ -426,12 +427,13 @@ spec = do
       -- whose '_hh_receive' always returns "" (the drainer just polls). The
       -- bounded send queue then fills and '_rt_send' surfaces back-pressure.
       let handle = HarnessHandle
-            { _hh_send    = \_ -> takeMVar sendGate
-            , _hh_receive = pure ""
-            , _hh_name    = "fake"
-            , _hh_session = "fake-sess"
-            , _hh_status  = pure HarnessRunning
-            , _hh_stop    = modifyIORef' stops (+ 1)
+            { _hh_send     = \_ -> takeMVar sendGate
+            , _hh_receive  = pure ""
+            , _hh_snapshot = \_ -> pure ""
+            , _hh_name     = "fake"
+            , _hh_session  = "fake-sess"
+            , _hh_status   = pure HarnessRunning
+            , _hh_stop     = modifyIORef' stops (+ 1)
             }
       emits <- newIORef []
       let deps = (mkHarnDeps handle (recordingEmit emits)) { _hrd_sendBound = 1 }
@@ -496,14 +498,15 @@ spec = do
       -- test waits for the drainer to actually observe the exit (and take the
       -- HarnessExited branch) before stopping — making the stop deterministic.
       let handle = HarnessHandle
-            { _hh_send    = \_ -> pure ()
-            , _hh_receive = pure ""
-            , _hh_name    = "fake"
-            , _hh_session = "fake-sess"
-            , _hh_status  = do
+            { _hh_send     = \_ -> pure ()
+            , _hh_receive  = pure ""
+            , _hh_snapshot = \_ -> pure ""
+            , _hh_name     = "fake"
+            , _hh_session  = "fake-sess"
+            , _hh_status   = do
                 _ <- tryPutMVar statusSeen ()
                 pure (HarnessExited ExitSuccess)
-            , _hh_stop    = modifyIORef' stops (+ 1)
+            , _hh_stop     = modifyIORef' stops (+ 1)
             }
       emits <- newIORef []
       let deps = mkHarnDeps handle (recordingEmit emits)

--- a/test/fixtures/harness/claude-approval.txt
+++ b/test/fixtures/harness/claude-approval.txt
@@ -1,0 +1,7 @@
+⏺ I'll run the test suite.
+
+  Bash(npm test)
+  Do you want to proceed?
+❯ 1. Yes
+  2. Yes, and don't ask again
+  3. No

--- a/test/fixtures/harness/claude-idle.txt
+++ b/test/fixtures/harness/claude-idle.txt
@@ -1,0 +1,6 @@
+⏺ Done. Applied the fix to foo.ts and ran the tests.
+
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+  arrakis /path [Opus 4.8 | ctx: 77% left]

--- a/test/fixtures/harness/claude-menu-cursor.txt
+++ b/test/fixtures/harness/claude-menu-cursor.txt
@@ -1,0 +1,3 @@
+⏺ Which layout?
+❯ 1. Mobile only
+  2. All sizes

--- a/test/fixtures/harness/claude-response.txt
+++ b/test/fixtures/harness/claude-response.txt
@@ -1,0 +1,9 @@
+❯ fix the bug in foo.ts
+
+⏺ I found the bug in foo.ts:42 — an off-by-one. Here is the fix.
+
+  Read 1 file (ctrl+o to expand)
+⏺ Applied the change and the tests pass.
+────────────────────────────────────────
+❯
+────────────────────────────────────────

--- a/test/fixtures/harness/claude-working.txt
+++ b/test/fixtures/harness/claude-working.txt
@@ -1,0 +1,9 @@
+⏺ Reading the file to understand the layout.
+
+  Read 1 file (ctrl+o to expand)
+
+✶ Smooshing… (4m 55s · ↓ 16.6k tokens)
+────────────────────────────────────────
+❯
+────────────────────────────────────────
+  arrakis /path [Opus 4.8 | ctx: 77% left]


### PR DESCRIPTION
## What & why

Fixes the reported bug: input reached a tmux-backed harness (Claude Code) from the web UI, but **no output came back** — not even the direct reply. Root cause: `isIdle` treated the always-present `❯` input box as "idle" and looked for a spinner glyph/words the live TUI never shows, so the poll captured before the reply rendered and the empty result was dropped.

Phase 1 of a two-phase effort (Phase 2 = live in-place message editing, deferred to its own spec).

## What it does

- **`PureClaw.Harness.Observer`** — per-flavour pure detection/extraction seam (`classify` / `extractResponse` / `relevantTail`); real Claude Code impl (spinner/status-line + approval detection, `❯ N.` menu disambiguation), generic stability-only fallback. Replaces the broken `isIdle`.
- **Reconcile loop is now the sole recorder of harness output** — observer-based 3-state classification (working / idle / **awaiting-input**) with a cross-tick stability gate, and records one `Response` transcript entry on a working→settle transition, deduped, via `_hh_snapshot` → broker → WS. Captures async work and direct-in-tmux typing.
- **Decoupled send from receive** — harness `POST /send` records the Request + injects keystrokes and returns promptly; the reply arrives over the stream.
- **`/harness output [name] [N]`** — on-demand ephemeral view of recent harness output.
- **`needs-input` state** surfaced end to end (Haskell enums, JSON, TS, `StatusDot`).
- tmux `capture-pane -J` (join wrapped lines); `HarnessId` extracted to a leaf module `PureClaw.Harness.Id` to break a `Registry`↔`Session.Kind` cycle.

Heuristics validated against live captures; informed by [faryo](https://github.com/Snailflyer/faryo) (MIT).

## Verification

- `cabal build` clean under `-Wall -Werror`; full suite **2802** examples, 0 failures (includes #93's isolation tests after merging main).
- frontend `tsc --noEmit` clean; vitest **362** passing.
- `cabal test --enable-coverage` ran green.

## Process notes

Built subagent-driven (implementer + independent reviewer per task, fix loops, final whole-branch review). The final review caught two real cross-cutting bugs that per-task reviews missed: a settle-path IO throw could kill the reconcile loop, and the response markers `⏺●⬤` were in the spinner set (a reply with an ellipsis would wedge at "Thinking" and be lost) — both fixed with proving tests.

Spec: `docs/superpowers/specs/2026-06-18-harness-output-streaming-design.md`
Plan: `docs/superpowers/plans/2026-06-19-harness-output-streaming-phase1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)